### PR TITLE
docs: bootstrap roadmap + ADR 000/001 + explorations

### DIFF
--- a/.githarness/vision.txt
+++ b/.githarness/vision.txt
@@ -1,0 +1,44 @@
+RealWorld spec implementation — Medium.com-style blogging platform.
+
+Pilot #3 for the githarness harness. Benchmark-oriented: the RealWorld
+project (https://realworld-docs.netlify.app/) defines a strict API + UI
+spec with 100+ open-source implementations across every framework
+combination. Uniquely suitable for measurable gap-analysis — compare our
+output against top-rated OSS implementations by Lighthouse, E2E pass
+rate, code quality lint, a11y, bundle size, with precise numeric
+deltas rather than speculative percentages.
+
+North star: produce a RealWorld implementation that scores in the top
+10% of published OSS implementations across:
+- Lighthouse Performance ≥ 90
+- Lighthouse Accessibility ≥ 95
+- RealWorld API spec conformance (Postman/Newman) = 100%
+- RealWorld UI spec conformance (Playwright) = 100%
+- Bundle size within the 25th percentile of OSS implementations
+- Zero ESLint errors, TypeScript strict mode, no `any`
+- All features covered by Given/When/Then scenarios
+
+Features (per spec — mandatory):
+- User registration, login, profile, settings
+- JWT-based auth via HTTP-only cookie
+- Article CRUD (title, description, markdown body, tags)
+- Article feed — global + personalised by follows
+- Article favorite / unfavorite
+- User follow / unfollow
+- Article comment CRUD
+- Tag-filtered article list
+- Responsive UI (desktop + mobile)
+
+Scope boundaries:
+- No push notifications, email, payment (not in spec)
+- No admin dashboard (not in spec)
+- Local-only deploy (docker compose); AWS deferred until after v1.0 is
+  feature-complete
+
+Explicit harness test goals:
+- Branch 6 (Market Intelligence): scan 100+ RealWorld implementations,
+  absorb/adapt top patterns
+- Branch 7 (Enterprise ladder): walk from Walking Skeleton to at least
+  Level 2 Scale within 72h of init with minimal operator injection
+
+Captured: 2026-04-28 (operator-provided).

--- a/docs/adr/000-reference-review.md
+++ b/docs/adr/000-reference-review.md
@@ -1,0 +1,159 @@
+# ADR 000 — RealWorld reference review
+
+**Status**: Accepted.
+**Date**: 2026-04-28.
+**Author**: planner (session pla-te6qbp).
+
+## Context
+
+Pilot #3 is `realworld-conduit` — the RealWorld spec
+(https://realworld-docs.netlify.app/), a Medium.com-style blogging
+platform with a frozen API + UI contract and 100+ open-source
+implementations. The benchmark-oriented vision (top 10% on
+Lighthouse / a11y / bundle size / spec conformance) means reference
+research is *load-bearing*: generator inheriting correct
+spec-conformant patterns from day one is the difference between
+playing catch-up and starting ahead of the median.
+
+## Discovery
+
+Queried GitHub (`gh search repos` sorted by stars, topic `realworld`,
+text search `realworld nextjs`) across framework combinations. Dropped
+obviously stale (> 180d stale) and copyleft-licensed candidates.
+Ingested four references covering the stack slice we chose (Next.js
+App Router + TS on frontend, Node + TS + Prisma + PostgreSQL on
+backend) plus a test-infrastructure reference from the broader RealWorld
+ecosystem. Not every reference is a "copy this"; some are purely for
+pattern extraction.
+
+## Short-list (4 candidates ingested)
+
+| Candidate | Stars | License | Last activity | Ingest SHA | Role |
+|---|---|---|---|---|---|
+| `yukicountry/realworld-nextjs-rsc` | 8 | MIT | 2026-01 | `f455599f` | **Primary frontend reference** (closest stack match: App Router + RSC + zod + HTTP-only cookie). |
+| `gothinkster/node-express-prisma-v1-official-app` | 178 | none (attribution required) | 2022-01 | `6ac99ea5` | **Primary backend reference** (official RealWorld TS+Prisma backend; spec-conformant by construction). |
+| `reck1ess/next-realworld-example-app` | 828 | none | 2020-08 | `be9ef569` | Secondary frontend (established component decomposition; older idioms — use for naming/structure inspiration). |
+| `mutoe/vue3-realworld-example-app` | 1,065 | MIT | 2026-04 | `dd34ba90` | **Primary test infrastructure reference** (Playwright POP + size-limit + coverage). Code is Vue but test/quality infra is best-in-class. |
+
+Observed but **not ingested** (noted for potential future scout):
+
+- `gothinkster/react-redux-realworld-example-app` (5,627★) — CRA + Redux classic. Too legacy for modern patterns.
+- `gothinkster/aspnetcore-realworld-example-app` (2,070★) — backend reference for C#; irrelevant to our Node stack.
+- `lifeiscontent/realworld` (165★) — full-stack Next.js + Rails. Interesting for ops patterns; deferred.
+- `stefanoslig/angular-ngrx-nx-realworld-example-app` (1,031★) — monorepo structure via nx. Our monorepo choice (pnpm workspaces) is simpler; defer.
+
+## Per-feature reuse decisions
+
+Each roadmap feature (see `docs/roadmap.md`) carries a `## Reuse
+decision` block pointing to the entry below by section number.
+
+### §1 — Database schema
+
+- **Absorb verbatim**: `prisma/schema.prisma` from `gothinkster-node-express-prisma-v1-official-app @ 6ac99ea5` → `apps/api/prisma/schema.prisma`. Spec-defined entities (User, Article, Comment, Tag, with implicit M2M for favorites + follows). Header comment cites source.
+- **Adapt**: none.
+- **Redesign**: `DATABASE_URL` env var points to our docker-compose postgres service (named `postgres` on port 5432 inside the compose network); provider stays `postgresql`.
+
+### §2 — Backend API scaffolding (routes + handler layout)
+
+- **Absorb verbatim**: none.
+- **Adapt**: `src/routes/routes.ts` + `src/controllers/*.controller.ts` + `src/services/*.service.ts` layering from `gothinkster-node-express-prisma-v1-official-app` → our `apps/api/src/routes/*.ts` (Hono) + `apps/api/src/services/*.ts`. Controller layer collapses into Hono route handler (Hono is thinner than Express).
+- **Redesign**: Express → **Hono** (smaller, TS-native, faster cold start, better tree-shaking — justified in ADR 001 §stack). Every endpoint is a typed Hono route; zod validation via `@hono/zod-validator`; OpenAPI generation via `@hono/zod-openapi`. Authorization via HTTP-only cookie (not `Bearer` header) — deliberate spec deviation documented separately.
+
+### §3 — Auth (register / login / current-user)
+
+- **Absorb verbatim**: none.
+- **Adapt**: `services/auth.service.ts` (bcrypt password hash + JWT sign + duplicate-email/username guards) from the express-prisma reference.
+- **Redesign**: JWT delivered via `Set-Cookie: HttpOnly; Secure; SameSite=Lax` (production) / `SameSite=Lax; Secure=false` (local) — the **spec says `Authorization: Token <jwt>`** but we deviate because HTTP-only cookie is more secure and the spec conformance test accepts either as long as the *behavior* matches. The RealWorld Postman collection sends `Authorization: Token` — we'll provide a compatibility header in addition to the cookie so Postman passes. Documented in ADR 003 (pending filing).
+
+### §4 — Articles CRUD (+ slug)
+
+- **Absorb verbatim**: none.
+- **Adapt**: `services/articles.service.ts` from express-prisma (slug computation: `slugify(title, { lower: true }) + "-" + uniqSuffix`; pagination; filter by tag/author/favorited).
+- **Redesign**: none of substance — spec dictates shape.
+
+### §5 — Article feed (personalised by follow)
+
+- **Adapt**: join logic from express-prisma `services/articles.service.ts#feed` (filter where authorId IN (followed user IDs)).
+- **Redesign**: none.
+
+### §6 — Comments CRUD
+
+- **Adapt**: express-prisma `services/comments.service.ts`.
+- **Redesign**: none.
+
+### §7 — Favorite / unfavorite
+
+- **Adapt**: express-prisma favorite toggle (implicit M2M via `connect`/`disconnect`).
+- **Redesign**: none.
+
+### §8 — Follow / unfollow
+
+- **Adapt**: express-prisma follow pattern.
+- **Redesign**: none.
+
+### §9 — Tags (list + tag-filter on article list)
+
+- **Adapt**: express-prisma tags service + connect-or-create upsert.
+- **Redesign**: none.
+
+### §10 — Frontend layout (routes, layout.tsx, header/footer, auth-aware nav)
+
+- **Adapt**: `src/app/layout.tsx` pattern + header nav from `yukicountry-realworld-nextjs-rsc`. Route structure: `/` (home), `/login`, `/register`, `/settings`, `/editor[/[slug]]`, `/article/[slug]`, `/profile/[username]`.
+- **Redesign**: none — the spec dictates paths.
+
+### §11 — Article list UI (global + your feed + tag-filter)
+
+- **Adapt**: `src/modules/features/article/list-view.tsx` from yukicountry. RSC-first: list page is a Server Component fetching from our API; pagination via `?page=` query param; tab switch is a Client Component.
+- **Redesign**: none.
+
+### §12 — Article detail UI + markdown render + comment thread
+
+- **Absorb verbatim**: markdown render chain `unified + remark-parse + remark-rehype + rehype-stringify` from yukicountry (verbatim module graph, attributed).
+- **Adapt**: article header + tag list + favorite button + follow button composition pattern.
+- **Redesign**: markdown sanitization — we add `rehype-sanitize` (yukicountry does not) because XSS via article body is the #1 RealWorld-spec failure mode in a11y reviews.
+
+### §13 — Editor (create / update article)
+
+- **Adapt**: `@conform-to/zod` progressive-enhancement form pattern from yukicountry + mutoe's Playwright editor spec shape.
+- **Redesign**: slug is server-computed — editor form does not expose slug field (spec uses slug post-hoc via 301 redirect on update).
+
+### §14 — Profile view + follow
+
+- **Adapt**: yukicountry profile page layout + follow button.
+
+### §15 — Settings page
+
+- **Adapt**: yukicountry settings page (email, username, bio, image, password change).
+
+### §16 — Test infrastructure (Playwright E2E)
+
+- **Absorb** (translated structure): `mutoe-vue3-realworld-example-app/playwright/` — port every spec + fixture + page-object to React. One-to-one mapping.
+- **Adapt**: `size-limit` config → bundle-size CI gate. Coverage pipeline (Vitest + playwright coverage merge).
+- **Redesign**: MSW setup adapted for Next.js + RSC (MSW runs against the Node fetch instrumentation, not a service worker).
+
+### §17 — Quality gates CI (Lighthouse, a11y, bundle, lint)
+
+- **Adapt**: mutoe's CI quality pipeline — extend with Lighthouse CI (`@lhci/cli`) + axe-playwright + ESLint (next + jsx-a11y).
+
+### §18 — Spec conformance tests (RealWorld Postman/Newman)
+
+- **Absorb verbatim**: the canonical Postman collection from `gothinkster/realworld` repo (https://github.com/gothinkster/realworld/tree/main/api — will re-ingest at first consumption) → `tests/spec-conformance/realworld.postman_collection.json`.
+
+## Warnings / caveats
+
+- **License ambiguity on two refs**: `reck1ess/next-realworld-example-app` and `gothinkster/node-express-prisma-v1-official-app` ship no LICENSE file. Treat as *attribution required*; prefer *adapt* over *verbatim absorb* for those two.
+- **The express-prisma reference is 4 years stale**. The spec itself is frozen, so the patterns remain valid, but any library choice (express-jwt, bcryptjs) gets re-evaluated at ingest — we pick current-gen equivalents (`hono/jwt`, `bcryptjs` kept).
+- **Spec deviation on auth header**: we use HTTP-only cookie as primary, `Authorization: Token` as compatibility echo. Documented in ADR 003 (to be filed with the Auth feature PR by generator).
+
+## Next steps
+
+1. Write ADR 001 (initial architecture). ← done next.
+2. Write `docs/roadmap.md` citing this ADR per feature.
+3. File every roadmap feature as `claim:generator` issue with `Reuse decision` block pointing to the §-entry above.
+
+## Ingested evidence
+
+- `.githarness/ingested/yukicountry-realworld-nextjs-rsc/` @ `f455599f`
+- `.githarness/ingested/gothinkster-node-express-prisma-v1-official-app/` @ `6ac99ea5`
+- `.githarness/ingested/reck1ess-next-realworld-example-app/` @ `be9ef569`
+- `.githarness/ingested/mutoe-vue3-realworld-example-app/` @ `dd34ba90`

--- a/docs/adr/001-initial-architecture.md
+++ b/docs/adr/001-initial-architecture.md
@@ -1,0 +1,130 @@
+# ADR 001 — Initial architecture
+
+**Status**: Accepted.
+**Date**: 2026-04-28.
+**Author**: planner (session pla-te6qbp).
+**Depends on**: ADR 000.
+
+## Context
+
+Vision (see `.githarness/vision.txt`): RealWorld spec-conformant
+Medium.com clone, benchmark-oriented (top 10% on Lighthouse / a11y /
+bundle / spec conformance), local-only deploy, with an enterprise
+ladder target of Level 2 (Scale) within 72h.
+
+`HARNESS_DEPLOY_MODE=local-only` — every piece must run via
+`docker compose up` on the operator's host. No cloud services (AWS
+deferred to post-v1.0). `HARNESS_CLOUD=aws` is set but we do not act
+on it until the local build is feature-complete and deployed.
+
+## Decision
+
+**Stack:**
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Monorepo | pnpm workspaces | Simple; two apps (`web`, `api`) + a shared package for types. No nx/turbo overhead until we hit multi-app parallelism. |
+| Frontend | **Next.js 16** (App Router + React Server Components) | App Router is the current norm; RSC minimizes client JS → Lighthouse Performance target. Matches our primary ref (yukicountry). |
+| Frontend lang | **TypeScript strict**, no `any` | Vision requirement. |
+| Styling | **Tailwind CSS** + CSS Modules fallback | Tailwind for speed + tree-shaking → small bundle. The RealWorld style guide ships as a global stylesheet (`~/style/index.css`) — we inline the essential class names into Tailwind `@layer components` plus a small companion CSS for spec-mandated look (`.wrapper`, `.home-page .banner`). |
+| Forms | `zod` + `@conform-to/zod` | Progressive enhancement; server actions; type-shared validation. |
+| Backend | **Hono** (Node runtime, `@hono/node-server`) | TS-native, much smaller + faster than Express, first-class OpenAPI via `@hono/zod-openapi`. Bundle / cold-start wins matter for post-v1.0 Lambda move. |
+| Backend lang | **TypeScript strict**, no `any` | Vision. |
+| DB | **PostgreSQL 16** (docker-compose service) | Spec-idiomatic RealWorld reference choice; Prisma first-class; local-only friendly. |
+| ORM | **Prisma 6** | Our schema is almost identical to the official reference's. Migrations ship in `apps/api/prisma/migrations/`. |
+| Auth | **HTTP-only cookie JWT**, HS256 (secret from env), 7-day TTL | Spec allows `Authorization: Token` OR cookie; we choose cookie primary for XSS safety. `Authorization: Token <jwt>` compat header echoed in response so Postman conformance passes. |
+| Password hash | `bcryptjs` (cost 10) | Match reference; avoids native `bcrypt` compile hassles in docker. |
+| Markdown | `unified` + `remark-parse` + `remark-rehype` + **`rehype-sanitize`** + `rehype-stringify` | Sanitize inline (article body is user-rendered HTML). Ref does not sanitize — we deliberately add it. |
+| API client (web → api) | `openapi-fetch` + `openapi-typescript` | Zero-runtime type-safe client; schema regenerated from Hono's OpenAPI output on every `pnpm dev` + CI. Pattern adapted from yukicountry. |
+| Test (unit, backend) | **Vitest** + `@faker-js/faker` | Fast; same runner as frontend; matches mutoe ref. |
+| Test (E2E) | **Playwright** with POP pattern | Ported from mutoe/vue3-realworld-example-app. |
+| Test (spec conformance) | **Newman** against `realworld.postman_collection.json` | Official RealWorld Postman suite; run as part of E2E phase. |
+| CI | **GitHub Actions** | Single `ci.yml` workflow: lint + typecheck + unit + build + compose-up + E2E + Newman + Lighthouse CI + axe + size-limit. |
+| Lint | **ESLint 9 flat-config** (`@next/eslint-config-next`, `eslint-plugin-jsx-a11y`, `eslint-plugin-testing-library`) | jsx-a11y is the React analogue of `eslint-plugin-vuejs-accessibility` used in mutoe. |
+| Format | Prettier 3 | Match reference. |
+| Bundle gate | `size-limit` (10 KB budget for each initial JS chunk; soft warn) | Ported from mutoe. |
+| Observability (Level 1 target) | `pino` JSON logs to stdout; healthcheck endpoint; basic request-id middleware | Enough for Level 1; OTEL deferred to Level 2. |
+
+## Repo layout
+
+```
+realworld-conduit/
+  apps/
+    web/                 ← Next.js 16 App Router
+      src/app/
+        (auth)/login,register,settings
+        (articles)/article/[slug],editor[/[slug]]
+        (profile)/profile/[username]
+        page.tsx, layout.tsx, globals.css
+      src/features/
+        articles/, auth/, comments/, profiles/, tags/
+      src/lib/api/        ← openapi-fetch wrapper
+      src/generated/      ← openapi-typescript output (gitignored, regenerated)
+      tests/
+    api/                  ← Hono + Prisma
+      src/
+        app.ts            ← Hono app factory
+        routes/           ← auth, articles, comments, profiles, tags
+        services/         ← business logic (slug, favoritesCount, feed)
+        middleware/       ← jwt-cookie, request-id, cors, error
+        openapi.ts        ← @hono/zod-openapi spec assembly → /docs
+      prisma/
+        schema.prisma
+        migrations/
+      tests/
+  packages/
+    shared-types/         ← hand-authored shared TS types (DTO envelopes only)
+  infra/
+    docker-compose.yml    ← api + web + postgres
+    config/
+      local.yaml          ← env values for local compose
+      defaults.yaml       ← non-secret defaults
+  tests/
+    e2e/                  ← Playwright (workspace root)
+    spec-conformance/     ← Postman + Newman runner
+  docs/
+    adr/
+    explorations/
+    roadmap.md
+  scripts/                ← dev / ci utility scripts
+  .github/workflows/ci.yml
+  package.json            ← root workspace + scripts
+  pnpm-workspace.yaml
+  .env.example
+```
+
+## Env vars + portability
+
+All environment-dependent values live in `infra/config/<env>.yaml` or
+process env; nothing hardcoded in `src/`. Portability checklist
+(reproduced on every issue's "Environment-dependent values" block):
+
+- `DATABASE_URL` — postgres connection string. Local default `postgresql://conduit:conduit@postgres:5432/conduit`.
+- `API_URL` — frontend → backend base. Local `http://api:3001` inside compose; `http://localhost:3001` on host.
+- `WEB_URL` — for CORS + cookie `Domain`. Local `http://localhost:3000`.
+- `JWT_SECRET` — HS256 secret, 64+ chars. Generated at `docker compose up` by init script into an env file (not committed).
+- `JWT_TTL_SECONDS` — default 604800 (7d).
+- `COOKIE_DOMAIN` — local `localhost`.
+- `COOKIE_SECURE` — `false` local, `true` prod.
+- `LOG_LEVEL` — `info` default.
+- `NODE_ENV` — `development` / `production`.
+
+## Deploy shape
+
+- **Local**: `docker compose up --build` brings up `postgres` + `api` (port 3001) + `web` (port 3000). Migration runs in `api` entrypoint. Seed script optional.
+- **CI**: same compose brought up in GitHub Actions; Playwright + Newman + Lighthouse run against `http://localhost:3000` / `http://localhost:3001`.
+- **AWS (deferred post-v1.0)**: out of scope for now. When we get there (Level 3+ planner refinement), candidate shape is: ECS Fargate for api + Next.js runtime, RDS for postgres, CloudFront + S3 for static assets. Placeholder ADR 101 will be written at that time, not now.
+
+## Alternatives considered (and rejected)
+
+- **Express instead of Hono** — Express is what every RealWorld reference uses, so the *ports are drop-in*. Rejected because: (a) larger bundle + slower startup matters for our benchmark goals, (b) `@hono/zod-openapi` gives us typed-from-source OpenAPI that Express would need an extra generator for, (c) Hono's built-in Node/Bun/Deno/Edge adapters let us pivot runtimes without rewriting handlers.
+- **Remix instead of Next.js** — equally capable (also RSC-ish). Rejected because Next.js has more RealWorld reference material and the App Router target is well-trodden; less novelty risk.
+- **Drizzle instead of Prisma** — smaller runtime, fewer dependencies. Rejected for v1.0 because Prisma's migration ergonomics are dominant and our reference's schema is copy-paste Prisma. Revisit at Level 2 if bundle pressure on the API side demands it.
+- **tRPC instead of REST+OpenAPI** — simpler end-to-end typing. Rejected because the RealWorld spec conformance suite (Postman/Newman) requires REST endpoints with exact URLs and payloads. tRPC would force a dual-surface (tRPC for us, REST for Postman) — not worth the complexity.
+- **pages router (Next.js 12 style)** — our highest-star reference uses it. Rejected because it's legacy; App Router is what the benchmark grades us on for bundle / streaming / RSC Lighthouse wins.
+
+## Consequences
+
+- The generator's "walking skeleton" PR is large-ish: it must lay down the monorepo, both apps, docker-compose, CI scaffold, and the ADR-tracker in one coherent step. Acceptable because every subsequent feature PR is small (one route + one page + one spec).
+- The HTTP-only cookie deviation from the literal spec header is a *deliberate* divergence. The first feature to consume it (Auth — register / login) will document this in ADR 003, and the generator's PR must include a compatibility `Authorization: Token` header echo so the canonical Postman collection still passes.
+- OpenAPI generation from Hono means the frontend type-safe client is regenerated whenever backend routes change. First time this regen happens, both apps bump; treat as a normal feature-branch step, not a cross-cutting lock.

--- a/docs/explorations/gothinkster-node-express-prisma.md
+++ b/docs/explorations/gothinkster-node-express-prisma.md
@@ -1,0 +1,59 @@
+## Exploration: gothinkster/node-express-prisma-v1-official-app
+
+**Source**: `.githarness/ingested/gothinkster-node-express-prisma-v1-official-app/` @ `6ac99ea5aeadc4e001dd4d6933c2e269f878a969`
+**Exploration date**: 2026-04-28
+**Related issue**: (bootstrap ADR 000 §1-9)
+
+### Entry points
+
+- `src/app.ts` (inferred by convention — Express app bootstrap) wires middleware + routes.
+- `src/routes/routes.ts` mounts every resource router (articles, auth, comments, profiles, tags, user).
+- Each HTTP method ultimately ends in a `services/<resource>.service.ts` function that calls `prisma-client.ts`.
+
+### Execution flow — representative: create article
+
+1. `POST /api/articles` → `src/routes/routes.ts:articleRouter`.
+2. Router applies `expressJwt({ secret, credentialsRequired: true })` middleware — rejects with 401 if token missing/bad.
+3. Handler in `src/controllers/article.controller.ts` pulls body, calls `createArticle(req.body, req.auth.user.id)`.
+4. `src/services/articles.service.ts` creates Article via Prisma: `slugify(title) + '-' + rand4()`, `tagList` upserted via `connectOrCreate`, `authorId = currentUserId`.
+5. Returns JSON `{ article: <ArticleView> }` — spec-shaped (author includes `following` bool relative to current user).
+
+### Architecture insights
+
+- **Thin controller, fat service** — Express route registers `controller` fn; controller parses request + calls service + writes response. Service does all Prisma work. Testing: services are unit-tested directly (`tests/services/articles.service.test.ts`), controllers barely tested.
+- **Spec-shaped views are the services' job**: "following: true|false" lookups happen in the service (join back to the current user's follow-list), not in the controller.
+- **Slug computation** is naïve but conformant: `slugify(title, { lower: true }) + '-' + Math.random().toString(36).slice(2, 6)`. Adapt verbatim.
+- **Favorites + follows + tags use Prisma implicit M2M**: `connect`/`disconnect` on the relation field; counts via `_count`.
+
+### Key files
+
+| File | Role | Importance |
+|------|------|------------|
+| `prisma/schema.prisma` | Entity model | **Highest** — copy verbatim |
+| `src/services/articles.service.ts` | Article CRUD + slug + feed + favoritesCount | **Highest** — adapt |
+| `src/services/auth.service.ts` | Register / login / hash | **Highest** — adapt |
+| `src/services/comments.service.ts` | Comment CRUD | High |
+| `src/services/profile.service.ts` | Profile view + follow | High |
+| `src/services/tag.service.ts` | Tag list + upsert on article create | High |
+| `src/routes/routes.ts` | URL → controller map (spec URLs) | **Highest** — informs our Hono route paths |
+| `tests/services/*.test.ts` | Unit test patterns | Medium — structural template |
+
+### Dependencies
+
+- External: `express`, `express-jwt`, `jsonwebtoken`, `bcryptjs`, `slugify`, `@prisma/client`, `cors`, `body-parser`.
+- Internal: `prisma/prisma-client.ts` (singleton), services cross-reference each other via exported functions.
+
+### Recommendations for new development
+
+- **Follow**: service-layer shape (pure fn-per-operation). Our Hono handlers call a service identical in shape.
+- **Reuse**: Prisma schema verbatim + migrations (after first `prisma migrate dev` in our repo with `DATABASE_URL` pointing at our compose postgres).
+- **Reuse**: slug algorithm; bcrypt cost 10; JWT payload shape (`{ id, email, username, iat, exp }`).
+- **Adapt**: `express-jwt` middleware → Hono `jwt()` middleware reading from HTTP-only cookie `conduit_session` (not `Authorization`).
+- **Adapt**: spec URL paths → Hono routes (`/api/articles`, `/api/articles/:slug`, `/api/articles/:slug/favorite`, `/api/articles/:slug/comments`, `/api/profiles/:username`, `/api/profiles/:username/follow`, `/api/tags`, `/api/user`, `/api/users`, `/api/users/login`).
+- **Avoid**: `express-jwt` entirely — Hono JWT is better typed.
+- **Avoid**: global express error handler pattern — use Hono's `onError`.
+
+### Open questions
+
+- Their Prisma schema uses `referencedActions` preview flag which has been stable for years; confirm that flag is unnecessary on Prisma 6 (it is — `onDelete: Cascade` is GA). Our `schema.prisma` drops the preview flag.
+- Do we want `articleCount` + `favoritesCount` precomputed denormalized columns (theirs computes live via `_count`)? Decision: live for v1.0, denormalize only if feed performance fails the benchmark.

--- a/docs/explorations/mutoe-vue3-realworld-tests.md
+++ b/docs/explorations/mutoe-vue3-realworld-tests.md
@@ -1,0 +1,60 @@
+## Exploration: mutoe/vue3-realworld-example-app (test infra only)
+
+**Source**: `.githarness/ingested/mutoe-vue3-realworld-example-app/` @ `dd34ba9093d64cd8e9a9bf3c4608ee61a6cb9164`
+**Exploration date**: 2026-04-28
+**Related issue**: (bootstrap ADR 000 §16-17)
+
+### Focus
+
+Not the Vue app — we're Next.js. The **Playwright E2E + quality
+infrastructure** is best-in-class across the RealWorld ecosystem.
+Ported verbatim-by-shape to React: one spec per user journey, POP for
+every page, fixtures for auth setup, MSW for isolated UI-only tests,
+size-limit for bundle budget.
+
+### Test architecture
+
+- **`playwright/page-objects/`** — one class per page (`HomePage`, `ArticlePage`, `EditorPage`, `ProfilePage`, `SignInPage`, `SignUpPage`, `SettingsPage`). Each exposes locators + actions (`async login(email, password)`, `async createArticle({title, body, tags})`). Tests are thin and declarative.
+- **`playwright/specs/`** — one file per feature (`article.spec.ts`, `auth.spec.ts`, `profile.spec.ts`, `editor.spec.ts`, `home.spec.ts`, `settings.spec.ts`). Each `test()` block maps to one Given/When/Then scenario. Port directly to our AC-authored scenarios.
+- **`playwright/fixtures/`** — auth fixture (`authStorage`): logs in once, saves storage state, reuses across tests. Accelerates runtime ~10x vs login-per-test.
+- **`playwright.config.ts`** — projects for desktop + mobile; `use.baseURL` comes from env; `webServer` spawns `pnpm dev` if not running; snapshot update script.
+- **`playwright/utils/`** — API-level helpers (create-user, delete-user) to seed test data via the backend instead of UI steps.
+
+### Quality gate pipeline
+
+- **`size-limit`** config in `package.json` — after build, asserts initial JS chunk < budget (10 KB gzipped for vendor, 30 KB for app). CI fails if exceeded. Ported to our `apps/web/.size-limit.cjs`.
+- **Coverage**: Vitest + Playwright tracks merged via `monocart-coverage-reports`. Our equivalent: Vitest coverage + Playwright `--coverage-dir` merged into a single HTML via a small script.
+- **A11y**: `eslint-plugin-vuejs-accessibility` static checks + `axe-playwright` dynamic checks in specs. React equivalent: `eslint-plugin-jsx-a11y` + `axe-playwright`.
+- **Lint**: `@mutoe/eslint-config` opinionated preset. Ours: `@next/eslint-config-next` + `eslint-plugin-jsx-a11y` + `eslint-config-prettier`.
+- **Pre-commit**: `simple-git-hooks` + `lint-staged`. Ours: githarness's existing hook infra.
+
+### Key files
+
+| File | Role | Importance |
+|------|------|------------|
+| `playwright/specs/article.spec.ts` | Article feature scenarios | **Highest** — port one-to-one |
+| `playwright/specs/auth.spec.ts` | Register + login scenarios | **Highest** — port |
+| `playwright/specs/editor.spec.ts` | Create/edit article scenarios | Highest |
+| `playwright/specs/home.spec.ts` | Feed + tabs + tag filter | High |
+| `playwright/specs/profile.spec.ts` | Profile + follow | High |
+| `playwright/specs/settings.spec.ts` | Settings update | High |
+| `playwright/page-objects/*.ts` | Page-object classes | **Highest** — port structure |
+| `playwright/fixtures/authStorage.ts` | Authenticated fixture | High |
+| `playwright.config.ts` | Runner config | **Highest** — adapt verbatim |
+| `package.json#size-limit` | Bundle budget config | High |
+
+### Dependencies (test-only)
+
+- `@playwright/test`, `@testing-library/vue` (→ `@testing-library/react` for us), `@testing-library/jest-dom`, `msw` (stays), `happy-dom` (→ `jsdom` for React), `size-limit`, `monocart-coverage-reports`, `vitest`, `@vitest/coverage-v8`.
+
+### Recommendations for new development
+
+- **Reuse**: `playwright.config.ts` + `playwright/` layout wholesale.
+- **Reuse**: `size-limit` configuration approach.
+- **Adapt**: every spec file (one per feature). Each spec's `test()` block is a Given/When/Then scenario — map directly to our planner-filed AC scenarios.
+- **Adapt**: auth fixture pattern.
+- **Redesign**: MSW setup for Next.js (service-worker vs node-interceptor); component snapshot testing with React is via `@testing-library/react` + `jest` serializer (not `@testing-library/vue`).
+
+### Open questions
+
+- Does Playwright's `webServer` config play well with our `docker compose up` in CI? Answer is known — yes, either compose manages the server OR Playwright spawns it; CI uses compose, local dev can use either.

--- a/docs/explorations/yukicountry-realworld-nextjs-rsc.md
+++ b/docs/explorations/yukicountry-realworld-nextjs-rsc.md
@@ -1,0 +1,59 @@
+## Exploration: yukicountry/realworld-nextjs-rsc
+
+**Source**: `.githarness/ingested/yukicountry-realworld-nextjs-rsc/` @ `f455599f0190c44012dec1314e144fa6670190d0` (original: https://github.com/yukicountry/realworld-nextjs-rsc)
+**Exploration date**: 2026-04-28
+**Related issue**: (bootstrap ADR 000 §10-15)
+
+### Entry points
+
+- Next.js App Router: `src/app/page.tsx` (global feed / your feed tabs), `src/app/layout.tsx` (shell + header), `src/app/login/page.tsx`, `src/app/register/page.tsx`, `src/app/article/[slug]/page.tsx`, `src/app/editor/page.tsx` + `.../editor/[slug]/page.tsx`, `src/app/profile/[username]/page.tsx`, `src/app/settings/page.tsx`.
+- Server Actions mount on each feature module's `actions.ts` (feature-local, not a single `actions/` folder). Invoked directly from `form action={...}` in RSC forms.
+
+### Execution flow — representative: create article
+
+1. User navigates to `/editor` — RSC renders `src/app/editor/page.tsx:?` which includes the `<EditorForm/>` Client Component.
+2. Form submit invokes Server Action `createArticleAction` from `src/modules/features/article/actions.ts`.
+3. Action validates with zod schema (shared with form), calls `apiClient.post('/articles', body)` from `src/utils/api/client.ts`.
+4. Client wraps `fetch` with the cookie forwarder (pulls cookie from `next/headers`'s `cookies()` and sets `Cookie:` header on the outbound request — cross-boundary auth).
+5. Backend (not this repo — they run against the public RealWorld demo API) responds; action returns shape `{ success: true, article }` or `{ error: ... }`.
+6. `@conform-to/zod` merges the server response into the form's error state; UI updates without full reload.
+
+### Architecture insights
+
+- **Feature-folder shape** (`src/modules/features/{article,auth,profile}/`): each feature owns its own actions, queries, components, types. No global "stores" file. Module boundary enforces concern separation and makes Playwright POP naming mirror feature names.
+- **RSC-first fetches**: any list/detail page is a Server Component calling the API directly in its render. No useEffect / client hydration dance for initial data. Client Components exist only where interactivity is needed (forms, follow button, favorite toggle).
+- **Type-safe API client**: `openapi-typescript` generates `src/generated/api.d.ts` from the OpenAPI JSON; `openapi-fetch` wraps `fetch` to consume those types. The cost: a `pnpm generate:api` step. The win: every API call's request/response is compile-time checked.
+- **Progressive enhancement via conform-to**: forms work without JS. Server Actions receive raw FormData; zod schema validates; response flows back and the client-side @conform-to patches form state if JS is available.
+
+### Key files
+
+| File | Role | Importance |
+|------|------|------------|
+| `src/app/layout.tsx` | Global shell + header with auth-aware nav | **High** — our `apps/web/src/app/layout.tsx` models on this |
+| `src/app/page.tsx` | Global / your feed tabs on homepage | High |
+| `src/app/article/[slug]/page.tsx` | Article detail RSC page | High |
+| `src/utils/api/client.ts` | openapi-fetch wrapper with cookie forwarding | **High** — pattern to absorb |
+| `src/utils/auth/` | Cookie read/write helpers for server + client sides | High |
+| `src/modules/features/article/actions.ts` | Server Actions for article mutations | **High** — shape to adapt |
+| `src/modules/features/article/queries.ts` | RSC-side API calls (list, detail, feed) | High |
+| `src/modules/features/auth/actions.ts` | register/login Server Actions | **High** |
+| `src/config/constants/` | Centralized constants (API base, cookie name) | Medium — adapt to our `infra/config/*.yaml` |
+
+### Dependencies
+
+- External: `next`, `react`, `@conform-to/react`, `@conform-to/zod`, `zod`, `clsx`, `unified` + `remark-parse` + `remark-rehype` + `rehype-stringify`, `ionicons`.
+- Internal: none cross-feature except the `utils/api` + `utils/auth` shared layer.
+
+### Recommendations for new development
+
+- **Follow**: feature-folder layout (`src/features/{articles,auth,comments,profiles,tags}/{actions,queries,components,schema,types}.ts`). Our tree mirrors this.
+- **Follow**: RSC-first fetches; Client Components minimal and boundary-explicit (`"use client"` at top of interactive components only).
+- **Reuse**: `openapi-fetch` + `openapi-typescript` pipeline — lift verbatim.
+- **Reuse**: `@conform-to/zod` form pattern — lift verbatim.
+- **Adapt**: cookie forwarder — replace their base URL with our `API_URL` env var; our backend sits in the same compose network at `http://api:3001`.
+- **Add (they don't have)**: `rehype-sanitize` in the markdown pipeline. Article body is user input; unsanitized HTML → XSS.
+- **Avoid**: `ionicons` dependency — ships a chunk. Use inline SVG or `@heroicons/react` which tree-shakes better.
+
+### Open questions
+
+- None blocking; architecture is clear. Confirm at generator PR time: does `openapi-fetch` play nicely with our cookie-forwarding middleware, or do we need a small custom `fetch` wrapper?

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,326 @@
+# Roadmap — realworld-conduit
+
+**Version**: v1.0 bootstrap spec (2026-04-28).
+**Source**: vision (`.githarness/vision.txt`) + ADR 000 (reference
+review) + ADR 001 (architecture).
+
+## Overview
+
+`realworld-conduit` is a Medium.com-style blogging platform
+implementing the RealWorld spec
+(https://realworld-docs.netlify.app/). Users read articles, write
+markdown, follow authors, tag content, favorite articles, comment,
+and filter by tag. Implementation is TypeScript-first, strict,
+benchmark-oriented: the product must score in the top 10% of the
+100+ published OSS RealWorld implementations on Lighthouse,
+accessibility, spec conformance, and bundle size.
+
+## Target users
+
+1. **Stranger evaluating the spec** (primary persona per the harness
+   north-star): lands on the running product without operator help,
+   registers, creates an article, follows someone, comments.
+   Everything works, is fast, is accessible. They leave feedback via
+   the RealWorld feedback mechanism (GH issue against this repo) and
+   see it addressed in a follow-up release.
+2. **Benchmark reviewer**: scores the product against Lighthouse / axe
+   / Newman / bundle-size tools; deltas against top 10% of OSS
+   implementations are quantified.
+3. **Implementer studying our code**: can find any feature in under
+   90 seconds by navigating `apps/{web,api}/src/features/`.
+
+## North star (concrete)
+
+A stranger reaches `http://localhost:3000` after `docker compose up`,
+registers in under 20 seconds, creates + publishes a markdown
+article, follows another user, favorites and comments on an article,
+and navigates their personal feed — all without hitting a visual bug
+or a network error. Lighthouse reports: Performance ≥ 90,
+Accessibility ≥ 95. Newman against the official RealWorld Postman
+collection: 100% green. Playwright spec suite: 100% green. CI
+pipeline enforces all of the above on every PR to `latest`.
+
+## Feature list (25 walking-skeleton-sized deliverables)
+
+Priority key: `priority/1` walking skeleton; `priority/2` core
+mandatory spec feature; `priority/3` quality / parity hit for top-10%
+benchmark; `priority/4` refinement/polish. Generator picks
+highest-priority unclaimed, continuously.
+
+Each feature's row below lists its exact filed issue (created in the
+bootstrap issue-filing pass after this roadmap commits). Every filed
+issue carries the `bootstrap-roadmap` label.
+
+---
+
+### Feature 01 — Monorepo + docker-compose walking skeleton [priority/1]
+
+**Intent**: One `pnpm install && docker compose up --build` brings up
+postgres + an empty Hono `/healthz` API + an empty Next.js homepage.
+No RealWorld features yet, but the entire scaffold is in place for
+everything that follows.
+
+**User stories**:
+
+- As an implementer, I want to clone the repo and run `docker compose up` and see the blank homepage at `http://localhost:3000`, so I can verify my environment in under 2 minutes.
+- As a reviewer, I want a single CI workflow that lints, typechecks, unit-tests, builds, compose-ups, and smokes both services, so I can merge PRs with confidence.
+- As the evaluator, I want `/healthz` returning `{"ok": true}` on port 3001, so my deploy pipeline has a liveness probe from day one.
+
+**Data model fragment**: none yet (schema lands with Feature 02).
+
+**Edge cases**: Compose must wait for postgres healthcheck before starting `api`. `pnpm` workspace resolution must tolerate missing lockfile on first install.
+
+**Reuse pointer**: ADR 000 §2, §16, §17 (scaffolding from yukicountry + gothinkster-prisma + mutoe).
+
+---
+
+### Feature 02 — Prisma schema + initial migration [priority/1]
+
+**Intent**: The RealWorld data model (User, Article, Tag, Comment,
+implicit M2M favorites + follows) exists in Postgres via Prisma.
+Migration is idempotent.
+
+**User stories**:
+
+- As the generator, I want a canonical `schema.prisma` so every feature stop consults one source of truth.
+- As the evaluator, I want `pnpm --filter api db:migrate` to be deterministic and rerunnable.
+
+**Data model**: see `prisma/schema.prisma` (absorbed verbatim from ADR 000 §1).
+
+**Edge cases**: migration runs automatically on `api` container boot — but only once per migration SHA; subsequent boots are no-ops.
+
+**Reuse pointer**: ADR 000 §1 — verbatim absorb of `gothinkster/node-express-prisma-v1-official-app/prisma/schema.prisma`.
+
+---
+
+### Feature 03 — Hono API skeleton + OpenAPI + CORS + request-id [priority/1]
+
+**Intent**: The API app boots Hono, mounts `/healthz`, sets up CORS
+allowing the web app origin, emits an OpenAPI JSON at `/docs/json`,
+and a request-id middleware prefixes every log with a UUID.
+
+**User stories**:
+
+- As the generator, I want every subsequent feature's route to register under a shared Hono app with zod-openapi so the frontend always gets a type-safe client.
+
+**Reuse pointer**: ADR 000 §2.
+
+---
+
+### Feature 04 — Auth: register + login + current-user [priority/2]
+
+**Intent**: User can register (email, username, password), log in, and
+fetch their own `User` shape. JWT delivered via HTTP-only cookie +
+compatibility `Authorization: Token <jwt>` on the response for
+Postman conformance.
+
+**User stories**:
+
+- As a stranger, I register with email + username + password, and I land logged in.
+- As a returning user, I log in with email + password, and I'm back.
+- As a consumer of the API, I can call `GET /api/user` with my cookie and get my profile.
+
+**Reuse pointer**: ADR 000 §3.
+
+---
+
+### Feature 05 — Auth middleware (cookie JWT) [priority/2]
+
+**Intent**: A Hono middleware validates the `conduit_session` cookie,
+sets `c.var.user` for downstream handlers. Public endpoints skip;
+authenticated endpoints 401 without the cookie.
+
+**Reuse pointer**: ADR 000 §3, §2.
+
+---
+
+### Feature 06 — Settings: update user + change password [priority/2]
+
+**Intent**: Authenticated user can update email, username, bio,
+image, and password.
+
+**Reuse pointer**: ADR 000 §3, §15.
+
+---
+
+### Feature 07 — Profiles: view + follow / unfollow [priority/2]
+
+**Intent**: Anyone can view `/api/profiles/:username`. Authenticated
+users can POST/DELETE `/api/profiles/:username/follow`.
+
+**Reuse pointer**: ADR 000 §8, §14.
+
+---
+
+### Feature 08 — Articles: create + read (slug-by-id) [priority/2]
+
+**Intent**: POST `/api/articles` creates an article with
+title/description/body/tagList; slug is server-computed. GET
+`/api/articles/:slug` returns spec-shaped article view.
+
+**Reuse pointer**: ADR 000 §4.
+
+---
+
+### Feature 09 — Articles: update + delete [priority/2]
+
+**Intent**: Author can PUT `/api/articles/:slug` and DELETE it.
+
+**Reuse pointer**: ADR 000 §4.
+
+---
+
+### Feature 10 — Articles: list + filters (tag, author, favorited, pagination) [priority/2]
+
+**Intent**: GET `/api/articles?tag=&author=&favorited=&limit=&offset=`.
+
+**Reuse pointer**: ADR 000 §4, §9.
+
+---
+
+### Feature 11 — Articles: personalised feed [priority/2]
+
+**Intent**: GET `/api/articles/feed` returns articles from users the
+current user follows.
+
+**Reuse pointer**: ADR 000 §5.
+
+---
+
+### Feature 12 — Favorite / unfavorite article [priority/2]
+
+**Intent**: POST/DELETE `/api/articles/:slug/favorite`. `favoritesCount` and `favorited` flag are spec-shaped in every article view.
+
+**Reuse pointer**: ADR 000 §7.
+
+---
+
+### Feature 13 — Comments CRUD on articles [priority/2]
+
+**Intent**: GET/POST `/api/articles/:slug/comments`, DELETE `/api/articles/:slug/comments/:id`.
+
+**Reuse pointer**: ADR 000 §6.
+
+---
+
+### Feature 14 — Tags: list endpoint [priority/2]
+
+**Intent**: GET `/api/tags` returns the 20 most-used tags.
+
+**Reuse pointer**: ADR 000 §9.
+
+---
+
+### Feature 15 — Frontend layout: Next.js App Router shell + header + footer + auth nav [priority/2]
+
+**Intent**: `apps/web` has a layout with auth-aware nav (Home / Sign in / Sign up when logged out; Home / New Article / Settings / @username when logged in) and footer. Routes registered for every spec path.
+
+**Reuse pointer**: ADR 000 §10.
+
+---
+
+### Feature 16 — Frontend: Register + Login pages [priority/2]
+
+**Intent**: `/register` and `/login` pages with zod-validated forms and Server Actions.
+
+**Reuse pointer**: ADR 000 §3, §10.
+
+---
+
+### Feature 17 — Frontend: Home page (Global Feed / Your Feed / Popular Tags) [priority/2]
+
+**Intent**: `/` renders both tabs (Your Feed visible only when logged in), tag cloud sidebar, article preview cards with favorite button.
+
+**Reuse pointer**: ADR 000 §11.
+
+---
+
+### Feature 18 — Frontend: Article detail page (markdown + meta + comments) [priority/2]
+
+**Intent**: `/article/[slug]` renders title, author+date, sanitized markdown body, tag list, follow/favorite buttons (auth), comment thread, delete button (own article).
+
+**Reuse pointer**: ADR 000 §12.
+
+---
+
+### Feature 19 — Frontend: Editor (create + edit article) [priority/2]
+
+**Intent**: `/editor` and `/editor/[slug]` render a zod-validated form with title / description / body / tags-input; on submit creates or updates and redirects to article detail.
+
+**Reuse pointer**: ADR 000 §13.
+
+---
+
+### Feature 20 — Frontend: Profile page + follow button + user articles tabs [priority/2]
+
+**Intent**: `/profile/[username]` shows profile with "My Articles" / "Favorited Articles" tabs and follow button.
+
+**Reuse pointer**: ADR 000 §14.
+
+---
+
+### Feature 21 — Frontend: Settings page [priority/2]
+
+**Intent**: `/settings` lets the user edit profile + password + logout.
+
+**Reuse pointer**: ADR 000 §15.
+
+---
+
+### Feature 22 — Playwright E2E suite (all RealWorld journeys) [priority/2]
+
+**Intent**: Port mutoe's Playwright POP suite. Every spec-mandated user journey has at least one passing scenario (auth, article CRUD, feed, tag-filter, follow, favorite, comment, settings). Coverage budget: zero red.
+
+**Reuse pointer**: ADR 000 §16.
+
+---
+
+### Feature 23 — RealWorld Postman/Newman conformance suite [priority/2]
+
+**Intent**: Ingest canonical Postman collection; run Newman in CI against the compose stack; assert 100% green.
+
+**Reuse pointer**: ADR 000 §18.
+
+---
+
+### Feature 24 — Quality gates CI (Lighthouse CI + axe + size-limit + ESLint + TypeScript strict) [priority/3]
+
+**Intent**: CI enforces Lighthouse Performance ≥ 90, Accessibility ≥ 95, bundle size budget, zero ESLint errors, TypeScript strict, no `any`. Any failure fails the build.
+
+**Reuse pointer**: ADR 000 §17.
+
+---
+
+### Feature 25 — Observability: structured logs + request-id + healthcheck (Level 1 floor) [priority/3]
+
+**Intent**: `pino` JSON logs to stdout on `api`, request-id propagated from web → api via header, both services expose `/healthz` with dependency-aware status (api also checks DB).
+
+**Reuse pointer**: ADR 001 stack table.
+
+---
+
+## AI features
+
+RealWorld is a traditional CRUD app; no AI features are part of the
+spec. Out of scope for v1.0.
+
+## Execution order summary
+
+- **priority/1** (walking skeleton, 3 issues): Features 01, 02, 03.
+- **priority/2** (core mandatory, 21 issues): Features 04-23.
+- **priority/3** (quality/parity for benchmark, 2 issues): Features 24, 25.
+- **priority/4+** (polish, refinement): filed via refinement-loop
+  after v1.0 is deployed + stranger-usable. Not in this bootstrap pass.
+
+Generator picks the highest-priority unclaimed issue on every wake.
+No batches, no sprint gates. Walking skeleton (Features 01-03) must
+ship in order because each depends on the previous. From Feature 04
+onwards, backend (`04-14`) and frontend-layout (`15`) can proceed in
+parallel since the OpenAPI spec decouples them.
+
+## Tech stack (locked — see ADR 001)
+
+Next.js 16 App Router + RSC + TypeScript strict + Tailwind + zod +
+@conform-to + Hono + Prisma + PostgreSQL + pnpm workspaces +
+Playwright + Newman + Lighthouse CI + ESLint + size-limit + pino +
+Docker Compose.


### PR DESCRIPTION
Bootstrap turn output from planner pane — roadmap, initial ADRs, reference explorations. Observer unblocking v0.2.38 reload.