### PR TITLE
feat(api): Hono skeleton + OpenAPI + CORS + request-id + error handler (#3)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,10 @@
   },
   "dependencies": {
     "@hono/node-server": "2.0.0",
-    "hono": "4.12.15"
+    "@hono/zod-openapi": "1.3.0",
+    "hono": "4.12.15",
+    "pino": "10.3.1",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/node": "22.18.2",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,29 +1,39 @@
-import { Hono } from "hono";
-import { cors } from "hono/cors";
-import { logger } from "hono/logger";
-import { requestId } from "hono/request-id";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { corsMiddleware } from "./middleware/cors.js";
+import { errorHandler } from "./middleware/error.js";
+import { requestLogger } from "./middleware/logger.js";
+import { requestId, type RequestIdVars } from "./middleware/request-id.js";
+import { registerHealthzRoute } from "./routes/healthz.js";
+import { registerInternalThrowRoute } from "./routes/internal-throw.js";
 
-export const createApp = (): Hono => {
-  const app = new Hono();
+export type AppEnv = { Variables: RequestIdVars };
 
+export const createApp = (): OpenAPIHono<AppEnv> => {
+  const app = new OpenAPIHono<AppEnv>();
+
+  // request-id runs first so every downstream log line and error response
+  // carries the same id (inbound X-Request-ID is preferred; otherwise a
+  // UUID v4 is minted here and echoed back on the response).
   app.use("*", requestId());
-  app.use("*", logger());
-  app.use(
-    "*",
-    cors({
-      origin: (origin) => origin ?? "*",
-      credentials: true,
-    }),
-  );
+  app.use("*", requestLogger());
+  app.use("*", corsMiddleware());
 
-  app.get("/healthz", (c) => c.json({ ok: true }));
+  registerHealthzRoute(app);
+  registerInternalThrowRoute(app);
+
+  app.doc("/docs/json", {
+    openapi: "3.1.0",
+    info: {
+      title: "RealWorld Conduit API",
+      version: "0.0.0",
+      description:
+        "RealWorld spec-conformant API. Routes are added per feature.",
+    },
+  });
 
   app.notFound((c) => c.json({ errors: { body: ["not found"] } }, 404));
 
-  app.onError((err, c) => {
-    console.error(err);
-    return c.json({ errors: { body: [err.message] } }, 500);
-  });
+  app.onError(errorHandler);
 
   return app;
 };

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -11,4 +11,5 @@ export const config = {
   port: Number.parseInt(required("API_PORT", "3001"), 10),
   host: required("API_HOST", "0.0.0.0"),
   logLevel: process.env.LOG_LEVEL ?? "info",
+  webUrl: required("WEB_URL", "http://localhost:3000"),
 } as const;

--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -1,0 +1,12 @@
+import { pino } from "pino";
+import { config } from "./config.js";
+
+export const logger = pino({
+  level: config.logLevel,
+  timestamp: pino.stdTimeFunctions.isoTime,
+  formatters: {
+    level: (label, number) => ({ level: number, levelLabel: label }),
+  },
+});
+
+export type Logger = typeof logger;

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -1,0 +1,14 @@
+import { cors } from "hono/cors";
+import { config } from "../config.js";
+
+// Allow-list the configured WEB_URL only. Returning `undefined` from the
+// origin callback makes `hono/cors` omit the Access-Control-Allow-Origin
+// header entirely, which browsers treat as "origin not allowed" — this is
+// what the acceptance criterion for rejected origins checks.
+export const corsMiddleware = () =>
+  cors({
+    origin: (origin) => (origin === config.webUrl ? origin : undefined),
+    credentials: true,
+    allowHeaders: ["Content-Type", "Authorization", "X-Request-ID"],
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  });

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,0 +1,36 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger } from "../logger.js";
+import type { RequestIdVars } from "./request-id.js";
+
+// Spec-shaped error envelope per RealWorld: {"errors": {"body": [...]}}.
+// HTTPException instances are re-thrown by @hono/zod-openapi validators and
+// friends with a safe-ish client-facing message — surface those as-is. All
+// other throws are treated as internal and their messages are never echoed.
+export const errorHandler = (
+  err: Error,
+  c: Context<{ Variables: RequestIdVars }>,
+) => {
+  if (err instanceof HTTPException) {
+    const response = err.getResponse();
+    if (response.headers.get("content-type")?.includes("application/json")) {
+      return response;
+    }
+    return c.json(
+      { errors: { body: [err.message] } },
+      err.status,
+    );
+  }
+
+  logger.error({
+    requestId: c.get("requestId"),
+    method: c.req.method,
+    path: new URL(c.req.url).pathname,
+    err: { message: err.message, stack: err.stack },
+  });
+
+  return c.json(
+    { errors: { body: ["Internal server error"] } },
+    500,
+  );
+};

--- a/apps/api/src/middleware/logger.ts
+++ b/apps/api/src/middleware/logger.ts
@@ -1,0 +1,16 @@
+import { createMiddleware } from "hono/factory";
+import { logger } from "../logger.js";
+import type { RequestIdVars } from "./request-id.js";
+
+export const requestLogger = () =>
+  createMiddleware<{ Variables: RequestIdVars }>(async (c, next) => {
+    const started = Date.now();
+    await next();
+    logger.info({
+      requestId: c.get("requestId"),
+      method: c.req.method,
+      path: new URL(c.req.url).pathname,
+      status: c.res.status,
+      durationMs: Date.now() - started,
+    });
+  });

--- a/apps/api/src/middleware/request-id.ts
+++ b/apps/api/src/middleware/request-id.ts
@@ -1,0 +1,15 @@
+import { createMiddleware } from "hono/factory";
+import { randomUUID } from "node:crypto";
+
+const HEADER = "x-request-id";
+
+export type RequestIdVars = { requestId: string };
+
+export const requestId = () =>
+  createMiddleware<{ Variables: RequestIdVars }>(async (c, next) => {
+    const inbound = c.req.header(HEADER);
+    const id = inbound && inbound.length > 0 ? inbound : randomUUID();
+    c.set("requestId", id);
+    c.header(HEADER, id);
+    await next();
+  });

--- a/apps/api/src/routes/healthz.ts
+++ b/apps/api/src/routes/healthz.ts
@@ -1,0 +1,23 @@
+import { createRoute, type OpenAPIHono, z } from "@hono/zod-openapi";
+import type { AppEnv } from "../app.js";
+
+const HealthSchema = z
+  .object({ ok: z.boolean() })
+  .openapi("Health");
+
+const healthzRoute = createRoute({
+  method: "get",
+  path: "/healthz",
+  tags: ["meta"],
+  summary: "Liveness probe",
+  responses: {
+    200: {
+      description: "Service is up",
+      content: { "application/json": { schema: HealthSchema } },
+    },
+  },
+});
+
+export const registerHealthzRoute = (app: OpenAPIHono<AppEnv>): void => {
+  app.openapi(healthzRoute, (c) => c.json({ ok: true }, 200));
+};

--- a/apps/api/src/routes/internal-throw.ts
+++ b/apps/api/src/routes/internal-throw.ts
@@ -1,0 +1,15 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { AppEnv } from "../app.js";
+import { config } from "../config.js";
+
+// Test-only unhandled-error route. Wired under `/_throw` when
+// NODE_ENV !== "production" so acceptance tests can exercise the
+// global error handler without shipping the path in the OpenAPI doc
+// or in the production bundle's routing table.
+export const registerInternalThrowRoute = (app: OpenAPIHono<AppEnv>): void => {
+  if (config.nodeEnv === "production") return;
+
+  app.get("/_throw", () => {
+    throw new Error("boom — deliberate test failure");
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,18 @@ importers:
       '@hono/node-server':
         specifier: 2.0.0
         version: 2.0.0(hono@4.12.15)
+      '@hono/zod-openapi':
+        specifier: 1.3.0
+        version: 1.3.0(hono@4.12.15)(zod@4.3.6)
       hono:
         specifier: 4.12.15
         version: 4.12.15
+      pino:
+        specifier: 10.3.1
+        version: 10.3.1
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 22.18.2
@@ -82,6 +91,11 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -363,6 +377,19 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hono/zod-openapi@1.3.0':
+    resolution: {integrity: sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: ^4.0.0
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -628,6 +655,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -974,6 +1004,10 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1806,6 +1840,13 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1848,6 +1889,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -1864,6 +1915,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1873,6 +1927,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -1885,6 +1942,10 @@ packages:
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1924,6 +1985,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1977,9 +2042,16 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2046,6 +2118,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -2151,6 +2227,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2167,6 +2248,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2416,6 +2502,19 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
+  '@hono/zod-openapi@1.3.0(hono@4.12.15)(zod@4.3.6)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.12.15)(zod@4.3.6)
+      hono: 4.12.15
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
+
+  '@hono/zod-validator@0.7.6(hono@4.12.15)(zod@4.3.6)':
+    dependencies:
+      hono: 4.12.15
+      zod: 4.3.6
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2598,6 +2697,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2938,6 +3039,8 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  atomic-sleep@1.0.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -3915,6 +4018,12 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-exit-leak-free@2.1.2: {}
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.3
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3954,6 +4063,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
@@ -3970,6 +4099,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  process-warning@5.0.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3980,6 +4111,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   react-dom@19.2.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -3988,6 +4121,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.0: {}
+
+  real-require@0.2.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4046,6 +4181,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-stable-stringify@2.5.0: {}
 
   scheduler@0.27.0: {}
 
@@ -4141,7 +4278,13 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -4220,6 +4363,10 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinyglobby@0.2.16:
     dependencies:
@@ -4391,6 +4538,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
[generator @ gen-te6wr9]

Closes #3

## User Intent

From this PR forward, the API has one coherent HTTP surface: every route is registered through `@hono/zod-openapi` so the OpenAPI document at `/docs/json` stays in sync with the code as features (#4 onward) are added; every request carries a correlation id (inbound `X-Request-ID` preserved, otherwise a UUID v4 is minted and echoed back); every log line is a pino JSON record with that id, method, path, status, and duration; every unhandled error becomes a spec-shaped `{"errors": {"body": ["Internal server error"]}}` envelope at status 500 without leaking the original message. CORS admits exactly one origin (the configured `WEB_URL`) and nothing else.

## Summary

- **`apps/api/src/app.ts`** — Hono app factory promoted to `OpenAPIHono<AppEnv>` so `createRoute`-registered routes feed `/docs/json` automatically. Middleware order is fixed (`request-id` → `logger` → `cors` → routes → 404 → `onError`) so the error handler and the log line always see the same request-id.
- **`middleware/request-id.ts`** — uses `crypto.randomUUID()` when the header is missing; echoes the id back on the response via `c.header("x-request-id", id)` and parks it on the Hono context (`c.set("requestId", id)`) as a typed variable.
- **`middleware/logger.ts`** — pino-backed middleware. One log line per request. Timer starts before `await next()`, emits after so `status` and `durationMs` reflect the finished response.
- **`middleware/cors.ts`** — `hono/cors` with a single-origin allow-list. Returning `undefined` from the origin callback makes the middleware omit `Access-Control-Allow-Origin` entirely (this is what browsers treat as "origin not allowed"; AC2 relies on this shape).
- **`middleware/error.ts`** — `HTTPException` responses (from validators) pass through with their original shape; every other throw is logged at pino level 50 with the full stack + request-id and turned into the spec envelope client-side.
- **`routes/healthz.ts`** — first `createRoute` in the project; `z.object({ok: z.boolean()}).openapi("Health")` becomes a schema on the doc and a typed handler in one.
- **`routes/internal-throw.ts`** — non-production `/_throw` route, skipped when `NODE_ENV=production`, so AC4 can exercise the global error handler without shipping the route.
- **`logger.ts`** — shared pino instance with ISO timestamps and numeric level; so every middleware logs in the same shape.
- **`config.ts`** — adds `webUrl` (from `WEB_URL` env; local fallback `http://localhost:3000` matches the compose default).

## Portability checklist

- `WEB_URL` drives CORS. On this host `.env` maps `WEB_HOST_PORT=3100` → `WEB_URL=http://localhost:3100` and the middleware echoed that origin back correctly (evidence below); on a host using the compose default `WEB_URL=http://localhost:3000`, the AC's literal `Origin: http://localhost:3000` would match.
- `LOG_LEVEL` — defaults to `info` per config, pino picks it up.
- `API_HOST`, `API_PORT`, `NODE_ENV` — unchanged from #2.
- Portability grep returns only the documented `http://localhost:3000` default in `config.ts` (same pattern compose already uses in `docker-compose.yml:52`). No hardcoded hosts, ports, paths, or credentials in runtime code.

## Evidence

Ran against a wiped postgres volume + fresh `up --build` on branch `feat/api-hono-skeleton-3`.

### AC1 — OpenAPI document describes registered routes

```
$ curl -sS http://localhost:3101/docs/json | jq '.openapi'
"3.1.0"

$ curl -sS http://localhost:3101/docs/json | jq '.paths | keys'
[ "/healthz" ]
```

### AC2 — CORS permits the configured origin and omits the header otherwise

With `WEB_URL=http://localhost:3100` (this host's `.env`):

```
$ curl -sSI -X OPTIONS http://localhost:3101/healthz \
    -H "Origin: http://localhost:3100" -H "Access-Control-Request-Method: GET"
HTTP/1.1 204 No Content
access-control-allow-credentials: true
access-control-allow-headers: Content-Type,Authorization,X-Request-ID
access-control-allow-methods: GET,POST,PUT,DELETE,OPTIONS
access-control-allow-origin: http://localhost:3100

$ curl -sSI -X OPTIONS http://localhost:3101/healthz \
    -H "Origin: http://evil.example.com" -H "Access-Control-Request-Method: GET"
HTTP/1.1 204 No Content
access-control-allow-credentials: true
access-control-allow-headers: Content-Type,Authorization,X-Request-ID
access-control-allow-methods: GET,POST,PUT,DELETE,OPTIONS
  # ← no access-control-allow-origin header
```

The AC's literal `http://localhost:3000` is the compose default; on a host using that default, the same request would get the header back. The middleware reads `WEB_URL` at module load and checks equality in a callback — no env-dependent literal in the source.

### AC3 — request-id propagation

```
$ curl -sSI -H "X-Request-ID: test-abc-123" http://localhost:3101/healthz
HTTP/1.1 200 OK
x-request-id: test-abc-123

$ curl -sSI http://localhost:3101/healthz
HTTP/1.1 200 OK
x-request-id: e2ef3f88-fd12-49de-ac05-a6faba466ee4

$ docker compose ... logs api | grep test-abc-123
{"level":30,"levelLabel":"info","time":"2026-04-28T06:30:51.191Z","pid":1,
 "hostname":"c6cbdf7c0529","requestId":"test-abc-123","method":"HEAD",
 "path":"/healthz","status":200,"durationMs":0}
```

### AC4 — unhandled error → spec-shaped 500 + stack in logs

```
$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:3101/_throw
{"errors":{"body":["Internal server error"]}}
HTTP 500

$ docker compose ... logs api | grep '"level":50'
{"level":50,"levelLabel":"error","time":"...","requestId":"...",
 "method":"GET","path":"/_throw",
 "err":{"type":"Object","message":"boom — deliberate test failure",
        "stack":"Error: boom — deliberate test failure\n    at .../internal-throw.js:10:15..."},
 "msg":"boom — deliberate test failure"}

$ curl -sS http://localhost:3101/_throw | grep -c "boom"
0   ← the original message is not in the response body
```

### Local quality gates

```
$ pnpm --filter @conduit/api typecheck   # exit 0
$ pnpm --filter @conduit/api lint        # exit 0
$ pnpm --filter @conduit/api build       # exit 0
$ bash scripts/smoke.sh
[smoke] postgres health
[smoke] GET http://localhost:3101/healthz
[smoke] GET http://localhost:3100/
[smoke] all checks passed
```

## Reuse attribution

No upstream code absorbed verbatim. Route-layering idea (per-resource files under `src/routes/`) is adapted from `gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5` per ADR 000 §2. Hono + OpenAPIHono + pino are our stack choices per ADR 001; request-id middleware and the error handler are scratch.
