### PR TITLE
feat(tests): author affected-map.yaml scope map (#29)

### DIFF
--- a/tests/affected-map.yaml
+++ b/tests/affected-map.yaml
@@ -1,0 +1,235 @@
+# Project-owned scope map for the evaluator's scope-aware merge gate.
+#
+# Schema + semantics: tests/affected-map.yaml.template (copied from the
+# harness) and scripts/eval-affected-scopes.sh. Rules in short:
+#   - any changed file matching full_triggers → FULL run
+#   - otherwise the selected scope set is the union of scopes whose
+#     `files` glob matches any changed source file
+#   - no scope match and no trigger → FULL run (conservative)
+#
+# File globs track the planned module layout from ADR 001 and the
+# roadmap in issues #4–#21. Scopes may currently point at paths that
+# don't exist yet (the feature issue hasn't landed) — the map's job
+# is to route *future* diffs, and empty spec/newman/uat arrays are
+# valid until the corresponding test suites (#22, #23) author them.
+#
+# Shared layout shell (`apps/web/src/app/layout.tsx`, navbar / footer
+# components, globals.css, next.config.ts, tailwind config) is NOT a
+# scope: any change there can visually affect every page, so it
+# belongs under full_triggers rather than a web-* scope.
+
+full_triggers:
+  # Stack topology / dependency resolution — rebuilds affect everything.
+  - "docker-compose.yml"
+  - "infra/docker-compose.yml"
+  - "infra/**"
+  - "Dockerfile*"
+  - "apps/*/Dockerfile*"
+  - "apps/*/docker-entrypoint.sh"
+  - "package.json"
+  - "apps/*/package.json"
+  - "packages/*/package.json"
+  - "pnpm-lock.yaml"
+  - "pnpm-workspace.yaml"
+  - ".npmrc"
+
+  # CI / quality pipeline.
+  - ".github/workflows/**"
+
+  # DB schema + migrations — any data-layer change can break every
+  # backend scope at once.
+  - "apps/api/prisma/**"
+
+  # API-wide cross-cutting code: middleware, logger, error handler,
+  # OpenAPI assembly, app factory, request-id — touching any of these
+  # can regress auth, articles, comments, profiles, and tags together.
+  - "apps/api/src/app.ts"
+  - "apps/api/src/server.ts"
+  - "apps/api/src/config.ts"
+  - "apps/api/src/logger.ts"
+  - "apps/api/src/middleware/**"
+  - "apps/api/src/openapi.ts"
+  - "apps/api/src/prisma/**"
+
+  # Shared workspace packages (DTO types, validators).
+  - "packages/**"
+
+  # Web shell — layout, navbar, footer, globals, tailwind config, the
+  # openapi-fetch wrapper. A change here can regress every page.
+  - "apps/web/src/app/layout.tsx"
+  - "apps/web/src/app/globals.css"
+  - "apps/web/src/app/loading.tsx"
+  - "apps/web/src/app/error.tsx"
+  - "apps/web/src/app/not-found.tsx"
+  - "apps/web/src/components/Navbar*"
+  - "apps/web/src/components/Footer*"
+  - "apps/web/src/lib/api/**"
+  - "apps/web/src/generated/**"
+  - "apps/web/next.config.ts"
+  - "apps/web/tailwind.config.*"
+  - "apps/web/postcss.config.*"
+
+  # Tooling that governs how tests themselves run.
+  - "playwright.config.ts"
+  - "apps/*/playwright.config.ts"
+  - "vitest.config.*"
+  - "apps/*/vitest.config.*"
+  - "tests/affected-map.yaml"
+
+scopes:
+  # ─── Backend scopes ──────────────────────────────────────────────
+  #
+  # Naming follows planner's roadmap (issues #4–#14). Globs assume the
+  # per-resource layout from ADR 001 (apps/api/src/routes/<area>.ts,
+  # apps/api/src/services/<area>*). Middleware that is strictly
+  # auth-gate-scoped (`middleware/auth*`) belongs to api-auth;
+  # cross-cutting middleware is in full_triggers above.
+
+  api-auth:
+    # #4 register/login/current-user, #5 auth middleware, #6 PUT /user.
+    files:
+      - "apps/api/src/routes/auth.ts"
+      - "apps/api/src/routes/users.ts"
+      - "apps/api/src/routes/user.ts"
+      - "apps/api/src/services/auth*"
+      - "apps/api/src/services/users*"
+      - "apps/api/src/middleware/auth*"
+      - "apps/api/src/middleware/jwt*"
+    specs:
+      - "tests/e2e/specs/auth*.spec.ts"
+    newman:
+      - "tests/api/collections/auth.postman_collection.json"
+      - "tests/api/collections/users.postman_collection.json"
+    uat: []
+
+  api-profiles:
+    # #7 view / follow / unfollow.
+    files:
+      - "apps/api/src/routes/profiles.ts"
+      - "apps/api/src/services/profiles*"
+    specs:
+      - "tests/e2e/specs/profile*.spec.ts"
+    newman:
+      - "tests/api/collections/profiles.postman_collection.json"
+    uat: []
+
+  api-articles:
+    # #8 create/read, #9 update/delete, #10 list+filters, #11 feed,
+    # #12 favorite/unfavorite.
+    files:
+      - "apps/api/src/routes/articles.ts"
+      - "apps/api/src/services/articles*"
+      - "apps/api/src/services/favorites*"
+      - "apps/api/src/services/feed*"
+      - "apps/api/src/services/slug*"
+    specs:
+      - "tests/e2e/specs/article*.spec.ts"
+      - "tests/e2e/specs/feed*.spec.ts"
+    newman:
+      - "tests/api/collections/articles.postman_collection.json"
+      - "tests/api/collections/favorites.postman_collection.json"
+    uat: []
+
+  api-comments:
+    # #13 CRUD on articles.
+    files:
+      - "apps/api/src/routes/comments.ts"
+      - "apps/api/src/services/comments*"
+    specs:
+      - "tests/e2e/specs/comment*.spec.ts"
+    newman:
+      - "tests/api/collections/comments.postman_collection.json"
+    uat: []
+
+  api-tags:
+    # #14 top-20 tags.
+    files:
+      - "apps/api/src/routes/tags.ts"
+      - "apps/api/src/services/tags*"
+    specs:
+      - "tests/e2e/specs/tags*.spec.ts"
+    newman:
+      - "tests/api/collections/tags.postman_collection.json"
+    uat: []
+
+  # ─── Frontend scopes ─────────────────────────────────────────────
+  #
+  # Layout shell / navbar / footer / globals live under full_triggers,
+  # so each web-* scope represents a page family plus the feature
+  # folder that page consumes.
+
+  web-auth:
+    # #16 register + login pages (the RSC shell plus the feature/auth
+    # client code). Settings page (#21) has its own scope.
+    files:
+      - "apps/web/src/app/(auth)/**"
+      - "apps/web/src/app/login/**"
+      - "apps/web/src/app/register/**"
+      - "apps/web/src/features/auth/**"
+    specs:
+      - "tests/e2e/specs/login*.spec.ts"
+      - "tests/e2e/specs/register*.spec.ts"
+    newman: []
+    uat:
+      - "tests/uat/specs/sign-up*.uat.ts"
+
+  web-feed:
+    # #17 homepage (global / your feed / popular tags).
+    files:
+      - "apps/web/src/app/page.tsx"
+      - "apps/web/src/app/(home)/**"
+      - "apps/web/src/features/articles/Feed*"
+      - "apps/web/src/features/articles/ArticleList*"
+      - "apps/web/src/features/tags/**"
+    specs:
+      - "tests/e2e/specs/home*.spec.ts"
+      - "tests/e2e/specs/feed*.spec.ts"
+    newman: []
+    uat:
+      - "tests/uat/specs/browse*.uat.ts"
+
+  web-article:
+    # #18 article detail (markdown + comments + follow/favorite).
+    files:
+      - "apps/web/src/app/article/**"
+      - "apps/web/src/features/articles/Article*"
+      - "apps/web/src/features/articles/Markdown*"
+      - "apps/web/src/features/comments/**"
+    specs:
+      - "tests/e2e/specs/article-detail*.spec.ts"
+      - "tests/e2e/specs/comment*.spec.ts"
+    newman: []
+    uat:
+      - "tests/uat/specs/read-article*.uat.ts"
+
+  web-editor:
+    # #19 editor — create + edit article with tag-pill input.
+    files:
+      - "apps/web/src/app/editor/**"
+      - "apps/web/src/features/articles/Editor*"
+      - "apps/web/src/features/articles/TagPill*"
+    specs:
+      - "tests/e2e/specs/editor*.spec.ts"
+    newman: []
+    uat:
+      - "tests/uat/specs/write-article*.uat.ts"
+
+  web-profile:
+    # #20 profile page (banner + articles/favorited tabs + follow).
+    files:
+      - "apps/web/src/app/profile/**"
+      - "apps/web/src/features/profiles/**"
+    specs:
+      - "tests/e2e/specs/profile*.spec.ts"
+    newman: []
+    uat: []
+
+  web-settings:
+    # #21 settings page (update profile + change password + logout).
+    files:
+      - "apps/web/src/app/settings/**"
+      - "apps/web/src/features/auth/Settings*"
+    specs:
+      - "tests/e2e/specs/settings*.spec.ts"
+    newman: []
+    uat: []


### PR DESCRIPTION
[generator @ gen-te6wr9]

Closes #29

## User Intent

The evaluator's scope-aware merge gate (harness v0.2.39+) currently falls back to FULL on every PR because `tests/affected-map.yaml` doesn't exist yet. With this map in place, an API-only change (say `apps/api/src/routes/articles.ts`) runs only the `api-articles` scope's specs + Newman collections — 30-60 seconds instead of 3-4 minutes — while any PR that touches schema, lockfile, CI yaml, the layout shell, or shared middleware still gets the full suite. That is the throughput unlock the roadmap is waiting on.

## Summary

- Eleven project scopes: five backend (`api-auth`, `api-profiles`, `api-articles`, `api-comments`, `api-tags`) and six frontend (`web-auth`, `web-feed`, `web-article`, `web-editor`, `web-profile`, `web-settings`). Names match the planner's wording in the AC and the roadmap issues #4–#21.
- `full_triggers` covers the three categories the AC calls out plus two intentional additions:
  1. The AC-mandated globs: `docker-compose.yml`, `package.json`, `pnpm-lock.yaml`, `.github/workflows/**`, `apps/api/prisma/**`, `infra/**`.
  2. **Cross-cutting backend code**: `apps/api/src/app.ts`, `server.ts`, `config.ts`, `logger.ts`, `middleware/**`, `openapi.ts`, `prisma/**`. These are the Hono skeleton from #3 — touching any of them can regress every backend scope simultaneously, so FULL is the right default.
  3. **Layout shell**: `apps/web/src/app/layout.tsx`, `globals.css`, `Navbar*`, `Footer*`, the openapi-fetch wrapper at `lib/api/**`, next / tailwind / postcss config. A visual or routing regression in the shell (issue #15's surface) shows up on every page, so it is explicitly NOT a web-* scope — it is a full trigger.
- Scopes point at paths that don't fully exist yet (the feature issues haven't landed). That's fine per the AC — the map's job is to route *future* diffs, and `specs` / `newman` / `uat` arrays may stay empty until #22 and #23 author the suites they reference.

## Evidence

**Local repo**: `bash scripts/eval-affected-scopes.sh --pr N` can't exercise the `full=0` path on the currently-open PRs because all three of my open PRs (#30, #31, plus this one) happen to touch files that are full_triggers (package.json / Dockerfile / affected-map.yaml itself). Running them anyway to show the FULL fallback works correctly on the full_triggers the AC enumerates:

```
$ bash scripts/eval-affected-scopes.sh --pr 30
FULL=1
FULL_REASON=shared trigger: apps/api/Dockerfile matches apps/*/Dockerfile*
SCOPES=

$ bash scripts/eval-affected-scopes.sh --pr 31
FULL=1
FULL_REASON=shared trigger: apps/api/package.json matches apps/*/package.json
SCOPES=
```

To exercise the `full=0` / scoped path per AC1, drove the helper directly with a one-file manifest equivalent to "a PR touching only that file":

```
$ echo "apps/api/src/routes/articles.ts" \
    | python3 scripts/eval-affected-scopes.py tests/affected-map.yaml
SCOPES=api-articles
FULL=0
FULL_REASON=

$ printf 'apps/api/src/routes/articles.ts\napps/api/src/services/articles-slug.ts\n' \
    | python3 scripts/eval-affected-scopes.py tests/affected-map.yaml
SCOPES=api-articles
FULL=0
FULL_REASON=

$ echo "apps/web/src/app/editor/page.tsx" \
    | python3 scripts/eval-affected-scopes.py tests/affected-map.yaml
SCOPES=web-editor
FULL=0
FULL_REASON=

$ printf 'apps/api/src/routes/comments.ts\napps/web/src/app/article/[slug]/page.tsx\n' \
    | python3 scripts/eval-affected-scopes.py tests/affected-map.yaml
SCOPES=api-comments web-article
FULL=0
FULL_REASON=
```

Full-trigger path — every AC2-named glob fires:

```
$ echo "apps/api/prisma/schema.prisma" | python3 scripts/eval-affected-scopes.py ...
FULL=1
FULL_REASON=shared trigger: apps/api/prisma/schema.prisma matches apps/api/prisma/**

$ echo "docker-compose.yml"  → FULL=1 (matches docker-compose.yml)
$ echo "infra/docker-compose.yml" → FULL=1 (matches infra/docker-compose.yml)
$ echo "package.json" → FULL=1 (matches package.json)
$ echo "pnpm-lock.yaml" → FULL=1 (matches pnpm-lock.yaml)
$ echo ".github/workflows/ci.yml" → FULL=1 (matches .github/workflows/**)
```

All six AC2-named globs hit FULL as required.

## AC coverage

- **Scenario: scoped run on an API-only PR** — the map uses scope names implied by issues #4–#14 (`api-auth`, `api-profiles`, `api-articles`, `api-comments`, `api-tags`) and #15–#21 (`web-auth`, `web-feed`, `web-article`, `web-editor`, `web-profile`, `web-settings`); a single file under `apps/api/src/routes/articles.ts` routes to `api-articles` with `full=0`. Diff-vs-full timing benefit can only be measured once the test suites from #22/#23 exist — noted in the PR body rather than fabricated.
- **Scenario: FULL fallback on a shared-lib PR** — every AC2 full_trigger glob (`docker-compose.yml`, `package.json`, `pnpm-lock.yaml`, `.github/workflows/**`, `apps/api/prisma/**`, `infra/**`) fires FULL. Plus the project-added cross-cutting triggers catch the API middleware + layout-shell cases the planner's roadmap implies.
- **Scenario: commit + push** — this PR carries the map on `feat/tests-affected-map-29`; once merged the evaluator's next review of an unrelated scoped PR will be scoped automatically (no action required on that PR).

## Portability checklist

- URLs / ports / secrets / feature flags: none — yaml config only.
- The `apps/*/` globs work on any developer's clone; no absolute paths.
- Portability grep: clean (no `localhost`, `/home/`, credentials).

## Reuse attribution

Schema and glob semantics come from the harness template at `tests/affected-map.yaml.template`. Scope content is project-specific, authored against the roadmap in issues #4–#21 and ADR 001's layout.
