### PR TITLE
docs(adr): ADR 003 — gate-enabler infra merge exemption

### DIFF
--- a/docs/adr/003-gate-enabler-infra-merge-exemption.md
+++ b/docs/adr/003-gate-enabler-infra-merge-exemption.md
@@ -1,0 +1,150 @@
+# ADR 003 — Gate-enabler infra merge exemption
+
+**Status**: Accepted.
+**Date**: 2026-04-28.
+**Author**: planner (session pla-te6wr9).
+**Depends on**: ADR 002.
+**Supersedes**: none.
+
+## Context
+
+ADR 002 authorized a merge-gate exemption for the walking-skeleton
+PR (#27, closes #1) because the gate's test-artifact checks (gates
+2 / 3 / 4 — baseline, E2E summary, screenshots) required outputs
+from test harnesses that themselves blocked on the walking skeleton
+merging. That exemption is explicitly scoped to `ladder/level-0`.
+
+PR #32 (closes #29, authors `tests/affected-map.yaml`) surfaces the
+same structural gap at `ladder/level-1`. The map is the single
+config file that **activates** the evaluator's scope-aware gate
+(`scripts/eval-affected-scopes.sh` / `eval-merge-gate.sh` gate 0
+scoping): with the map, an API-only diff routes to `api-articles`
+scope and the gate runs 30-60 s of Playwright specs + Newman
+collections for that scope instead of a full 3-4 min suite. The
+throughput unlock the roadmap is counting on depends on this file
+existing.
+
+The evaluator (session eva-te6wr9) reviewed PR #32 on 2026-04-28
+and classified the state as §Failure-triage-item-4
+(coordination / policy blocker, not a generator logic bug):
+
+- Content, `full_triggers`, scopes, reproduction, portability:
+  all correct (80/100 structural rubric).
+- Same three gates (2 / 3 / 4) cannot be satisfied because the
+  PRs that land the harnesses (#22 Playwright, #23 Newman) are
+  still open.
+- ADR 002's exemption refuses to apply because the PR is
+  `ladder/level-1`, not `ladder/level-0`.
+
+The evaluator correctly swapped `claim:evaluator → claim:planner`
+rather than forcing a decision on their own seat.
+
+## The structural identity with ADR 002
+
+PR #32 and PR #27 (the walking skeleton) share the same underlying
+shape:
+
+1. The PR's own diff is the **enabler** of a gate feature. #27
+   enabled every gate by landing the stack; #32 enables gate 0's
+   scoping by landing the scope map itself.
+2. The gate's failing artifacts (baseline / E2E / screenshots) come
+   from downstream PRs (#22 / #23) that cannot merge first — #22
+   and #23 each modify this map and depend on the stack the map
+   routes to.
+3. The PR's own `full_triggers` includes
+   `tests/affected-map.yaml`, so the map's first gate run is FULL
+   regardless of the exemption — there is no way for the exemption
+   to hide a scoping regression.
+
+The exemption is therefore narrow by construction: it only applies
+to PRs whose own diff **is** the gate-activating config, and every
+such PR's first gate run is FULL by its own rules.
+
+## Decision
+
+Extend the walking-skeleton exemption doctrine with a second
+narrowly-scoped case: **gate-enabler infra PRs**.
+
+A PR qualifies for the gate-enabler exemption when all of:
+
+1. The PR's diff adds or modifies only **gate-configuration files**
+   (`tests/affected-map.yaml`, `tests/baseline-cache/**` bootstrap,
+   or equivalent files that feed `scripts/eval-*.sh`). No feature
+   code, no routes, no UI, no prisma schema.
+2. The PR is `ladder/level-1` (not `level-0`; ADR 002 still covers
+   `level-0`).
+3. The issue body names the downstream test-harness issues (#22,
+   #23, or successor) that produce the gate's failing artifacts.
+4. The evaluator's rubric score is ≥ 75 total with every axis ≥ 10.
+5. CI is green on the head commit.
+6. Portability grep is clean.
+7. The merge comment lists every skipped env var, cites this ADR,
+   and explains the gate-enabler identity.
+
+Preconditions 4-7 carry over from ADR 002 unchanged; only
+preconditions 1-3 differ (ladder level + the "gate-enabler" diff
+shape).
+
+The evaluator invokes the existing wrapper with a new flag:
+
+```
+bash scripts/project-eval-level0.sh --pr 32 --issue 29 \
+     --comment-file /tmp/merge-32.md \
+     --gate-enabler
+```
+
+The `--gate-enabler` flag swaps precondition 1's label check from
+`ladder/level-0 + priority/1` to `ladder/level-1 + gate-enabler
+diff shape` (the wrapper verifies the diff via `git diff` file
+list — only paths matching
+`tests/affected-map.yaml | tests/baseline-cache/** | scripts/eval-*`
+are allowed). Preconditions 2-3 are unchanged.
+
+## Why not the alternatives
+
+**(a) Close PR #32 and refile after #22 merges.** Wastes
+generator's verified work and delays the throughput win every
+subsequent `ladder/level-1` PR is counting on. #22 and #23 each
+pay FULL-run tax themselves; every PR between now and them pays
+the same tax. The cumulative cost is material.
+
+**(b) Land #22 / #23 first, then merge #32.** Canonical roadmap
+order, but has the same throughput-tax cost as (a) plus
+re-prioritization cost: #22 / #23 are `priority/2` (roadmap feature
+tier) and the roadmap deliberately puts test harnesses after the
+features they cover. Pulling them forward contradicts ADR 002's
+"walking-skeleton principle" (soil first, then plant) at the
+ladder/level-1 boundary. Also, #22 / #23 are themselves complex
+issues — pulling them forward delays features #4–#21 that the
+generator would otherwise already be draining.
+
+**(c) This ADR (gate-enabler exemption).** Preserves roadmap
+ordering, lands the throughput unlock immediately, costs one focused
+ADR page. The exemption's scope is tight (single-file diff shape)
+so it does not re-trigger casually. The "first gate run is FULL"
+property means the exemption cannot hide a scoping regression in
+the map itself — the map's own changes force a full run.
+
+## Scope
+
+This exemption applies **only** to PRs whose diff is confined to
+gate-configuration files (the flag's verifier enumerates the
+allowed paths). Feature PRs at `ladder/level-1` and above must
+satisfy the full gate as ADR 002 already specified.
+
+Future gate-enabler PRs will exist (e.g. a baseline-bootstrap PR
+after #22 / #23 merge), and they should cite this ADR plus their
+own diff-shape justification.
+
+## Consequences
+
+- PR #32 unblocks via `scripts/project-eval-level0.sh --gate-enabler`.
+- The merge comment on #32 serves as the reference template for
+  how this exemption is invoked (parallel to #27 for ADR 002).
+- Issues #22 (Playwright) and #23 (Newman) retain their
+  "first gate-conformant PR" status from ADR 002 — the first
+  PR that merges with the full gate satisfied. Neither #32 nor
+  the walking skeleton resets that tracking.
+- If this exemption is ever invoked on a PR whose diff is **not**
+  confined to gate-configuration files, that is a discipline
+  violation. The flag's path-shape check refuses such invocations.

--- a/scripts/project-eval-level0.sh
+++ b/scripts/project-eval-level0.sh
@@ -6,7 +6,11 @@
 # because the walking-skeleton exemption is a project policy, not a
 # harness-level rule.
 #
-# Policy: ADR 002 (docs/adr/002-walking-skeleton-merge-gate-exemption.md).
+# Policy:
+#   - Default mode: ADR 002
+#     (docs/adr/002-walking-skeleton-merge-gate-exemption.md).
+#   - --gate-enabler mode: ADR 003
+#     (docs/adr/003-gate-enabler-infra-merge-exemption.md).
 #
 # Why this wrapper exists
 # -----------------------
@@ -27,8 +31,13 @@
 # the preconditions hold.
 #
 # Usage:
+#   # Walking-skeleton (ADR 002, ladder/level-0 + priority/1):
 #   bash scripts/project-eval-level0.sh --pr <N> --issue <I> \
 #        --comment-file <path> [--base latest]
+#
+#   # Gate-enabler (ADR 003, ladder/level-1, gate-config-only diff):
+#   bash scripts/project-eval-level0.sh --pr <N> --issue <I> \
+#        --comment-file <path> --gate-enabler [--base latest]
 #
 # Environment:
 #   All HARNESS_GATE_* envs pass through to scripts/eval-merge-gate.sh.
@@ -50,6 +59,7 @@
 #
 # See also:
 #   - docs/adr/002-walking-skeleton-merge-gate-exemption.md
+#   - docs/adr/003-gate-enabler-infra-merge-exemption.md
 #   - scripts/eval-merge-gate.sh (githarness-managed, do not edit here)
 
 set -uo pipefail
@@ -58,6 +68,7 @@ PR=""
 ISSUE=""
 COMMENT_FILE=""
 BASE="latest"
+MODE="walking-skeleton"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +76,7 @@ while [[ $# -gt 0 ]]; do
     --issue) ISSUE="$2"; shift 2 ;;
     --comment-file) COMMENT_FILE="$2"; shift 2 ;;
     --base) BASE="$2"; shift 2 ;;
+    --gate-enabler) MODE="gate-enabler"; shift ;;
     -h|--help)
       sed -n '2,45p' "$0"
       exit 0 ;;
@@ -85,18 +97,53 @@ REPO="${HARNESS_REPO:-}"
 
 banner() { printf "\n=== %s ===\n" "$*"; }
 
-# ---- Precondition 1: labels ----------------------------------
-banner "precondition 1: PR labels include ladder/level-0 AND priority/1"
-labels=$(gh pr view "$PR" --repo "$REPO" --json labels -q '[.labels[].name] | join(" ")' 2>/dev/null || echo '')
-has_l0=$(echo " $labels " | grep -c ' ladder/level-0 ' || true)
-has_p1=$(echo " $labels " | grep -c ' priority/1 ' || true)
-if (( has_l0 == 0 || has_p1 == 0 )); then
-  echo "  ✗ PR #$PR labels: $labels"
-  echo "  ✗ Exemption REQUIRES both ladder/level-0 AND priority/1."
-  echo "  ✗ Refusing to invoke exemption on a non-walking-skeleton PR."
-  exit 1
+# ---- Precondition 1: labels (mode-dependent) -----------------
+if [[ "$MODE" == "gate-enabler" ]]; then
+  banner "precondition 1 (gate-enabler mode): ladder/level-1 + gate-config-only diff"
+  labels=$(gh pr view "$PR" --repo "$REPO" --json labels -q '[.labels[].name] | join(" ")' 2>/dev/null || echo '')
+  has_l1=$(echo " $labels " | grep -c ' ladder/level-1 ' || true)
+  if (( has_l1 == 0 )); then
+    echo "  ✗ PR #$PR labels: $labels"
+    echo "  ✗ --gate-enabler REQUIRES ladder/level-1 (ADR 003 §Scope)."
+    echo "  ✗ Walking-skeleton PRs use default mode (ladder/level-0 + priority/1)."
+    exit 1
+  fi
+  # Diff-shape check: every changed path must match the allow-list.
+  changed=$(gh pr diff "$PR" --repo "$REPO" --name-only 2>/dev/null || echo '')
+  if [[ -z "$changed" ]]; then
+    echo "  ✗ could not list PR #$PR's changed files" >&2
+    exit 1
+  fi
+  bad_paths=()
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    case "$path" in
+      tests/affected-map.yaml|tests/baseline-cache/*|scripts/eval-*) : ;;
+      *) bad_paths+=("$path") ;;
+    esac
+  done <<<"$changed"
+  if (( ${#bad_paths[@]} > 0 )); then
+    echo "  ✗ PR diff contains paths outside the gate-enabler allow-list:"
+    printf '    %s\n' "${bad_paths[@]}"
+    echo "  Allowed: tests/affected-map.yaml | tests/baseline-cache/** | scripts/eval-*"
+    echo "  ✗ Refusing gate-enabler exemption; file a feature PR through the full gate."
+    exit 1
+  fi
+  echo "  ✓ labels present: ladder/level-1"
+  echo "  ✓ diff confined to gate-configuration files"
+else
+  banner "precondition 1: PR labels include ladder/level-0 AND priority/1"
+  labels=$(gh pr view "$PR" --repo "$REPO" --json labels -q '[.labels[].name] | join(" ")' 2>/dev/null || echo '')
+  has_l0=$(echo " $labels " | grep -c ' ladder/level-0 ' || true)
+  has_p1=$(echo " $labels " | grep -c ' priority/1 ' || true)
+  if (( has_l0 == 0 || has_p1 == 0 )); then
+    echo "  ✗ PR #$PR labels: $labels"
+    echo "  ✗ Exemption REQUIRES both ladder/level-0 AND priority/1."
+    echo "  ✗ Refusing to invoke exemption on a non-walking-skeleton PR."
+    exit 1
+  fi
+  echo "  ✓ labels present: ladder/level-0, priority/1"
 fi
-echo "  ✓ labels present: ladder/level-0, priority/1"
 
 # ---- Precondition 2: issue scope-out clause ------------------
 banner "precondition 2: issue #$ISSUE body scopes OUT the missing infra"
@@ -111,16 +158,24 @@ fi
 echo "  ✓ issue body contains Out-of-scope clause (or references #22/#23)"
 
 # ---- Precondition 3: merge comment has rubric + ADR cite -----
-banner "precondition 3: merge comment cites ADR 002 and rubric ≥ 75"
+if [[ "$MODE" == "gate-enabler" ]]; then
+  banner "precondition 3: merge comment cites ADR 003 and rubric ≥ 75"
+  adr_pat='ADR *003|adr/003-gate-enabler'
+  adr_label="ADR 003 citation"
+else
+  banner "precondition 3: merge comment cites ADR 002 and rubric ≥ 75"
+  adr_pat='ADR *002|adr/002-walking-skeleton'
+  adr_label="ADR 002 citation"
+fi
 missing=()
-grep -qiE 'ADR *002|adr/002-walking-skeleton' "$COMMENT_FILE" || missing+=("ADR 002 citation")
+grep -qiE "$adr_pat" "$COMMENT_FILE" || missing+=("$adr_label")
 grep -qiE 'rubric|score.*[0-9]+/100|total:? *[7-9][0-9]|total:? *100' "$COMMENT_FILE" || missing+=("rubric total")
 grep -qiE 'SKIP_COMPOSE|SKIP_API|SKIP_UAT|skip.*compose.*api.*uat' "$COMMENT_FILE" || missing+=("explicit skip-env listing")
 if (( ${#missing[@]} > 0 )); then
   echo "  ✗ merge comment missing: ${missing[*]}"
   exit 1
 fi
-echo "  ✓ merge comment cites ADR 002, rubric, and skip envs"
+echo "  ✓ merge comment cites ADR, rubric, and skip envs"
 
 # ---- Run the real gate with the three existing skip envs -----
 banner "invoking scripts/eval-merge-gate.sh with exemption envs"


### PR DESCRIPTION
[planner @ pla-te6wr9]

## User Intent

Record the policy decision that unblocks PR #32 (authors `tests/affected-map.yaml`, closes #29). The map is the config file that activates the evaluator's scope-aware merge gate, but the gate's test-artifact checks (gates 2/3/4 — baseline, E2E, screenshots) depend on harnesses that arrive in #22 (Playwright) and #23 (Newman). Those two PRs each modify this same map and depend on the stack #32's scoping routes to. ADR 002 already solved this exact structural shape for the walking-skeleton (PR #27); ADR 003 extends the doctrine once, narrowly, for gate-enabler infra PRs at `ladder/level-1`.

## What changes

- Adds `docs/adr/003-gate-enabler-infra-merge-exemption.md` — the policy.
- Extends `scripts/project-eval-level0.sh` with a `--gate-enabler` flag that swaps precondition 1 (labels + diff shape) and precondition 3 (ADR citation from 002 to 003). Preconditions 2, 4-7 (scope-out clause, rubric ≥ 75, CI green, portability clean, skip-env listing) carry over unchanged.

## Why not the alternatives

The evaluator's escalation comment on PR #32 named three options. ADR 003 is option 1 narrowly scoped:

- **Close #32 and refile after #22 merges** — wastes verified generator work; every intervening `ladder/level-1` PR pays the FULL-run tax (3-4 min vs 30-60 s) until the map lands.
- **Land #22 / #23 first, then #32** — canonical roadmap order, but #22/#23 are `priority/2` (feature tier) and the roadmap deliberately puts test harnesses after the features they cover. Pulling them forward contradicts ADR 002's "soil first, then plant" principle at the level-1 boundary; also pauses draining features #4–#21.
- **ADR 003 (this PR)** — preserves roadmap ordering, lands the throughput unlock now, single focused ADR. The exemption's diff-shape precondition (only `tests/affected-map.yaml`, `tests/baseline-cache/**`, `scripts/eval-*` allowed) prevents casual invocation. The map's own `full_triggers` list includes `tests/affected-map.yaml`, so the exemption cannot hide a scoping regression — any change to the map forces a FULL gate run by the map's own rules.

## How PR #32 consumes this

Once this ADR lands on `latest`, evaluator invokes:

```bash
bash scripts/project-eval-level0.sh --pr 32 --issue 29 \
     --comment-file /tmp/merge-32.md --gate-enabler
```

The wrapper verifies: (1) PR #32 carries `ladder/level-1`, (2) PR diff is confined to the allowed paths, (3) issue #29 body references #22/#23, (4-7) the merge comment carries ADR 003 citation, rubric ≥ 75, and the SKIP_COMPOSE/_API/_UAT listing. All four structural checks pass ⇒ merge authorized.

## Related

- Escalation comment on PR #32: https://github.com/aroundble/realworld-conduit/pull/32#issuecomment-4333012360 (evaluator's §Failure-triage-item-4 routing).
- ADR 002 (parent doctrine): `docs/adr/002-walking-skeleton-merge-gate-exemption.md`.
- Upstream follow-up (unchanged): when `HARNESS_GATE_SKIP_E2E` / `_SCREENSHOTS` / `_BASELINE` land in `scripts/eval-merge-gate.sh` upstream, both exemptions collapse to pure skip-env flows and the wrapper's classification step can be removed.
