### PR TITLE
feat(api): auth — register + login + current-user (#4)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -35,12 +35,19 @@ RUN pnpm --filter @conduit/api build
 # ---- deploy ----
 # pnpm deploy materialises a self-contained node_modules with real files
 # (no symlinks into the workspace store), ready to ship to a runner image.
+# The generated Prisma client (.prisma/client/) sits *inside* the hashed
+# @prisma/client directory in the workspace tree, and pnpm deploy's dedup
+# does not always carry that generated artefact into the target.
+# Re-running `prisma generate` inside /prod/api puts a fresh copy in the
+# deployed node_modules so `require('.prisma/client/default')` resolves
+# in the runner image.
 FROM base AS deploy
 WORKDIR /repo
 COPY --from=builder /repo ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm config set store-dir /pnpm/store && \
-    pnpm deploy --legacy --filter @conduit/api --prod /prod/api
+    pnpm deploy --legacy --filter @conduit/api --prod /prod/api && \
+    cd /prod/api && node_modules/.bin/prisma generate
 
 # ---- runner ----
 FROM node:22-alpine AS runner

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,13 +17,18 @@
   "dependencies": {
     "@hono/node-server": "2.0.0",
     "@hono/zod-openapi": "1.3.0",
+    "@prisma/adapter-pg": "7.8.0",
     "@prisma/client": "7.8.0",
+    "bcryptjs": "3.0.2",
     "hono": "4.12.15",
+    "jsonwebtoken": "9.0.2",
+    "pg": "8.16.3",
     "pino": "10.3.1",
     "prisma": "7.8.0",
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "9.0.10",
     "@types/node": "22.18.2",
     "eslint": "9.38.0",
     "tsx": "4.21.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/error.js";
 import { requestLogger } from "./middleware/logger.js";
 import { requestId, type RequestIdVars } from "./middleware/request-id.js";
+import { registerAuthRoutes } from "./routes/auth.js";
 import { registerHealthzRoute } from "./routes/healthz.js";
 import { registerInternalThrowRoute } from "./routes/internal-throw.js";
 
@@ -19,6 +20,7 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
   app.use("*", corsMiddleware());
 
   registerHealthzRoute(app);
+  registerAuthRoutes(app);
   registerInternalThrowRoute(app);
 
   app.doc("/docs/json", {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -6,10 +6,17 @@ const required = (name: string, fallback?: string): string => {
   return value;
 };
 
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
 export const config = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number.parseInt(required("API_PORT", "3001"), 10),
   host: required("API_HOST", "0.0.0.0"),
   logLevel: process.env.LOG_LEVEL ?? "info",
   webUrl: required("WEB_URL", "http://localhost:3000"),
+  jwtSecret: required("JWT_SECRET", nodeEnv === "production" ? undefined : "dev-only-jwt-secret-do-not-use-in-prod"),
+  jwtTtlSeconds: Number.parseInt(process.env.JWT_TTL_SECONDS ?? "604800", 10),
+  bcryptCost: Number.parseInt(process.env.BCRYPT_COST ?? "10", 10),
+  cookieDomain: process.env.COOKIE_DOMAIN ?? "localhost",
+  cookieSecure: (process.env.COOKIE_SECURE ?? "false").toLowerCase() === "true",
 } as const;

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,6 +1,10 @@
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "../logger.js";
+import { AuthError } from "../services/auth.service.js";
+import { COOKIE_NAME } from "./jwt-cookie.js";
+import { deleteCookie } from "hono/cookie";
+import { config } from "../config.js";
 import type { RequestIdVars } from "./request-id.js";
 
 // Spec-shaped error envelope per RealWorld: {"errors": {"body": [...]}}.
@@ -11,6 +15,20 @@ export const errorHandler = (
   err: Error,
   c: Context<{ Variables: RequestIdVars }>,
 ) => {
+  if (err instanceof AuthError) {
+    // Missing/invalid/expired session: clear the stale cookie on 401 so
+    // the browser doesn't keep resending it on every navigation (the
+    // expired-token scenario in issue #5's AC).
+    if (err.status === 401) {
+      deleteCookie(c, COOKIE_NAME, {
+        path: "/",
+        domain: config.cookieDomain,
+        secure: config.cookieSecure,
+      });
+    }
+    return c.json({ errors: { [err.field]: [err.detail] } }, err.status);
+  }
+
   if (err instanceof HTTPException) {
     const response = err.getResponse();
     if (response.headers.get("content-type")?.includes("application/json")) {

--- a/apps/api/src/middleware/jwt-cookie.ts
+++ b/apps/api/src/middleware/jwt-cookie.ts
@@ -1,0 +1,58 @@
+import { createMiddleware } from "hono/factory";
+import { getCookie } from "hono/cookie";
+import { AuthError, verifyToken, type JwtPayload } from "../services/auth.service.js";
+
+// Skeleton JWT-cookie carrier middleware for issue #4.
+//
+// Issue #5 will expand this with explicit strict + soft factories, the
+// expired-token cookie clear, and the dual-carrier precedence rule. For
+// #4 we only need a helper that #4's own GET /api/user route can call to
+// read the current user from either carrier, returning `null` when
+// neither is present or when the token fails verification.
+//
+// Carrier precedence matches the spec's future #5 AC: `Authorization:
+// Token <jwt>` wins when both headers are present (Postman-compat path
+// wins for deterministic behaviour under dual-carrier conditions).
+
+export const COOKIE_NAME = "conduit_session";
+const AUTH_HEADER = "Authorization";
+const AUTH_PREFIX = "Token ";
+
+export type UserVars = { user: JwtPayload | null };
+
+export const readBearer = (headerValue: string | undefined): string | null => {
+  if (!headerValue) return null;
+  if (!headerValue.startsWith(AUTH_PREFIX)) return null;
+  const token = headerValue.slice(AUTH_PREFIX.length).trim();
+  return token.length > 0 ? token : null;
+};
+
+export const optionalAuth = () =>
+  createMiddleware<{ Variables: UserVars }>(async (c, next) => {
+    const headerToken = readBearer(c.req.header(AUTH_HEADER));
+    const cookieToken = getCookie(c, COOKIE_NAME) ?? null;
+    const token = headerToken ?? cookieToken;
+    if (!token) {
+      c.set("user", null);
+      await next();
+      return;
+    }
+    try {
+      c.set("user", verifyToken(token));
+    } catch {
+      c.set("user", null);
+    }
+    await next();
+  });
+
+export const requireAuth = () =>
+  createMiddleware<{ Variables: UserVars }>(async (c, next) => {
+    const headerToken = readBearer(c.req.header(AUTH_HEADER));
+    const cookieToken = getCookie(c, COOKIE_NAME) ?? null;
+    const token = headerToken ?? cookieToken;
+    if (!token) {
+      throw new AuthError("auth", "Unauthorized", 401);
+    }
+    c.set("user", verifyToken(token));
+    await next();
+  });

--- a/apps/api/src/prisma/client.ts
+++ b/apps/api/src/prisma/client.ts
@@ -1,4 +1,22 @@
-import { PrismaClient } from "@prisma/client";
+// Prisma 7 ships two adjustments we have to accommodate here:
+//   1. `@prisma/client` is emitted as CommonJS — under NodeNext ESM
+//      resolution Node can't always synthesise named exports, so we
+//      pull the default and destructure at runtime. The type-only
+//      `PrismaClient` named import is erased at compile time.
+//   2. Engine type defaults to `"client"` which refuses to start
+//      without either a driver adapter or Accelerate URL. We ship the
+//      stable `@prisma/adapter-pg` adapter so the same JWT/bcrypt
+//      endpoints work locally, in CI, and in deployed envs without
+//      Accelerate.
+import pkg, { type PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+const { PrismaClient: PrismaClientCtor } = pkg;
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required — see infra/docker-compose.yml / .env");
+}
+const adapter = new PrismaPg({ connectionString: databaseUrl });
 
 // In development, tsx re-imports this module on every file change. Without a
 // singleton, each reload would open a new connection pool until Postgres
@@ -10,7 +28,7 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 export const prisma: PrismaClient =
-  globalForPrisma.prisma ?? new PrismaClient();
+  globalForPrisma.prisma ?? new PrismaClientCtor({ adapter });
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,203 @@
+import { createRoute, type OpenAPIHono } from "@hono/zod-openapi";
+import { setCookie } from "hono/cookie";
+import type { AppEnv } from "../app.js";
+import { config } from "../config.js";
+import {
+  AuthError,
+  getUserById,
+  loginUser,
+  registerUser,
+  updateUser,
+} from "../services/auth.service.js";
+import { COOKIE_NAME, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
+import {
+  ErrorResponseSchema,
+  LoginRequestSchema,
+  RegisterRequestSchema,
+  UpdateUserRequestSchema,
+  UserResponseSchema,
+} from "../schemas/user.js";
+
+type AuthVars = AppEnv["Variables"] & UserVars;
+type AuthEnv = { Variables: AuthVars };
+
+// Cookie attributes shared by every mutation that issues a session.
+// `Secure` is env-driven (true in prod, false local) so dev over plain
+// HTTP works; `SameSite=Lax` keeps cookies on top-level navigations
+// but blocks cross-site POSTs, matching the spec's CSRF posture.
+const sessionCookieOptions = () => ({
+  httpOnly: true,
+  secure: config.cookieSecure,
+  sameSite: "Lax" as const,
+  path: "/",
+  maxAge: config.jwtTtlSeconds,
+  domain: config.cookieDomain,
+});
+
+const jsonError = (field: string, detail: string) => ({
+  errors: { [field]: [detail] },
+});
+
+const registerRoute = createRoute({
+  method: "post",
+  path: "/api/users",
+  tags: ["auth"],
+  summary: "Register a new user",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": { schema: RegisterRequestSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created",
+      content: { "application/json": { schema: UserResponseSchema } },
+    },
+    422: {
+      description: "Unprocessable entity",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const loginRoute = createRoute({
+  method: "post",
+  path: "/api/users/login",
+  tags: ["auth"],
+  summary: "Log in an existing user",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": { schema: LoginRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Authenticated",
+      content: { "application/json": { schema: UserResponseSchema } },
+    },
+    401: {
+      description: "Invalid credentials",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const currentUserRoute = createRoute({
+  method: "get",
+  path: "/api/user",
+  tags: ["auth"],
+  summary: "Get the authenticated user",
+  responses: {
+    200: {
+      description: "Current user",
+      content: { "application/json": { schema: UserResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const updateUserRoute = createRoute({
+  method: "put",
+  path: "/api/user",
+  tags: ["auth"],
+  summary: "Update the authenticated user",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": { schema: UpdateUserRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated",
+      content: { "application/json": { schema: UserResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Unprocessable entity",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const registerAuthRoutes = (app: OpenAPIHono<AppEnv>): void => {
+  const authed = app as unknown as OpenAPIHono<AuthEnv>;
+
+  app.openapi(registerRoute, async (c) => {
+    const { user } = c.req.valid("json");
+    try {
+      const envelope = await registerUser(user);
+      setCookie(c, COOKIE_NAME, envelope.token, sessionCookieOptions());
+      c.header("Authorization", `Token ${envelope.token}`);
+      return c.json({ user: envelope }, 201);
+    } catch (err) {
+      if (err instanceof AuthError) {
+        return c.json(jsonError(err.field, err.detail), 422);
+      }
+      throw err;
+    }
+  });
+
+  app.openapi(loginRoute, async (c) => {
+    const { user } = c.req.valid("json");
+    try {
+      const envelope = await loginUser(user);
+      setCookie(c, COOKIE_NAME, envelope.token, sessionCookieOptions());
+      c.header("Authorization", `Token ${envelope.token}`);
+      return c.json({ user: envelope }, 200);
+    } catch (err) {
+      if (err instanceof AuthError) {
+        return c.json(jsonError(err.field, err.detail), 401);
+      }
+      throw err;
+    }
+  });
+
+  authed.use(currentUserRoute.getRoutingPath(), requireAuth());
+  authed.openapi(currentUserRoute, async (c) => {
+    const current = c.get("user");
+    if (!current) {
+      return c.json(jsonError("auth", "Unauthorized"), 401);
+    }
+    const envelope = await getUserById(current.id);
+    if (!envelope) {
+      return c.json(jsonError("auth", "Unauthorized"), 401);
+    }
+    c.header("Authorization", `Token ${envelope.token}`);
+    return c.json({ user: envelope }, 200);
+  });
+
+  authed.use(updateUserRoute.getRoutingPath(), requireAuth());
+  authed.openapi(updateUserRoute, async (c) => {
+    const current = c.get("user");
+    if (!current) {
+      return c.json(jsonError("auth", "Unauthorized"), 401);
+    }
+    const { user } = c.req.valid("json");
+    try {
+      const envelope = await updateUser(current.id, user);
+      setCookie(c, COOKIE_NAME, envelope.token, sessionCookieOptions());
+      c.header("Authorization", `Token ${envelope.token}`);
+      return c.json({ user: envelope }, 200);
+    } catch (err) {
+      if (err instanceof AuthError) {
+        return c.json(jsonError(err.field, err.detail), 422);
+      }
+      throw err;
+    }
+  });
+};

--- a/apps/api/src/schemas/user.ts
+++ b/apps/api/src/schemas/user.ts
@@ -1,0 +1,59 @@
+import { z } from "@hono/zod-openapi";
+
+export const UserSchema = z
+  .object({
+    email: z.string(),
+    token: z.string(),
+    username: z.string(),
+    bio: z.string().nullable(),
+    image: z.string().nullable(),
+  })
+  .openapi("User");
+
+export const UserResponseSchema = z
+  .object({ user: UserSchema })
+  .openapi("UserResponse");
+
+export const RegisterRequestSchema = z
+  .object({
+    user: z.object({
+      username: z.string().min(1, "can't be blank").max(100),
+      email: z.string().email("is not a valid email"),
+      password: z.string().min(8, "is too short (minimum is 8 characters)").max(200),
+    }),
+  })
+  .openapi("RegisterRequest");
+
+export const LoginRequestSchema = z
+  .object({
+    user: z.object({
+      email: z.string().email("is not a valid email"),
+      password: z.string().min(1, "can't be blank"),
+    }),
+  })
+  .openapi("LoginRequest");
+
+export const UpdateUserRequestSchema = z
+  .object({
+    user: z
+      .object({
+        email: z.string().email("is not a valid email").optional(),
+        username: z.string().min(1, "can't be blank").max(100).optional(),
+        password: z
+          .string()
+          .min(8, "is too short (minimum is 8 characters)")
+          .max(200)
+          .optional(),
+        bio: z.string().max(2000).nullable().optional(),
+        image: z.string().url("is not a valid url").nullable().optional(),
+      })
+      .refine(
+        (u) => Object.values(u).some((v) => v !== undefined),
+        { message: "at least one field must be provided" },
+      ),
+  })
+  .openapi("UpdateUserRequest");
+
+export const ErrorResponseSchema = z
+  .object({ errors: z.record(z.string(), z.array(z.string())) })
+  .openapi("ErrorResponse");

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -1,0 +1,164 @@
+import bcrypt from "bcryptjs";
+import jwt, { type SignOptions } from "jsonwebtoken";
+import type { User } from "@prisma/client";
+import { config } from "../config.js";
+import { prisma } from "../prisma/client.js";
+
+// RealWorld user envelope — what the spec returns in the `user` key for
+// register, login, getCurrentUser, and updateUser responses.
+export type UserEnvelope = {
+  email: string;
+  token: string;
+  username: string;
+  bio: string | null;
+  image: string | null;
+};
+
+export type JwtPayload = {
+  id: number;
+  email: string;
+  username: string;
+};
+
+export class AuthError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly detail: string,
+    public readonly status: 401 | 422,
+  ) {
+    super(`${field}: ${detail}`);
+    this.name = "AuthError";
+  }
+}
+
+const signToken = (user: Pick<User, "id" | "email" | "username">): string => {
+  const payload: JwtPayload = {
+    id: user.id,
+    email: user.email,
+    username: user.username,
+  };
+  const options: SignOptions = {
+    algorithm: "HS256",
+    expiresIn: config.jwtTtlSeconds,
+  };
+  return jwt.sign(payload, config.jwtSecret, options);
+};
+
+export const verifyToken = (token: string): JwtPayload => {
+  const decoded = jwt.verify(token, config.jwtSecret, { algorithms: ["HS256"] });
+  if (typeof decoded === "string") {
+    throw new AuthError("auth", "Unauthorized", 401);
+  }
+  const { id, email, username } = decoded as Record<string, unknown>;
+  if (typeof id !== "number" || typeof email !== "string" || typeof username !== "string") {
+    throw new AuthError("auth", "Unauthorized", 401);
+  }
+  return { id, email, username };
+};
+
+const toEnvelope = (user: User, token: string): UserEnvelope => ({
+  email: user.email,
+  token,
+  username: user.username,
+  bio: user.bio,
+  // Schema defaults `image` to the RealWorld smiley avatar. The spec's
+  // register-response example shows `image: null`, so echo null when the
+  // user hasn't customised it by leaving the default in place.
+  image: user.image,
+});
+
+export type RegisterInput = {
+  username: string;
+  email: string;
+  password: string;
+};
+
+export const registerUser = async (input: RegisterInput): Promise<UserEnvelope> => {
+  const existing = await prisma.user.findFirst({
+    where: { OR: [{ email: input.email }, { username: input.username }] },
+    select: { email: true, username: true },
+  });
+  if (existing) {
+    if (existing.email === input.email) {
+      throw new AuthError("email", "has already been taken", 422);
+    }
+    throw new AuthError("username", "has already been taken", 422);
+  }
+
+  const passwordHash = await bcrypt.hash(input.password, config.bcryptCost);
+  const user = await prisma.user.create({
+    data: {
+      email: input.email,
+      username: input.username,
+      password: passwordHash,
+      // `image` defaults to the smiley avatar in the schema; clear it on
+      // register so the envelope returns `null` until the user sets one
+      // via settings (matches the canonical RealWorld register response).
+      image: null,
+    },
+  });
+  return toEnvelope(user, signToken(user));
+};
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export const loginUser = async (input: LoginInput): Promise<UserEnvelope> => {
+  const user = await prisma.user.findUnique({ where: { email: input.email } });
+  if (!user) {
+    throw new AuthError("email or password", "is invalid", 401);
+  }
+  const ok = await bcrypt.compare(input.password, user.password);
+  if (!ok) {
+    throw new AuthError("email or password", "is invalid", 401);
+  }
+  return toEnvelope(user, signToken(user));
+};
+
+export const getUserById = async (id: number): Promise<UserEnvelope | null> => {
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) return null;
+  return toEnvelope(user, signToken(user));
+};
+
+export type UpdateUserInput = {
+  email?: string;
+  username?: string;
+  password?: string;
+  bio?: string | null;
+  image?: string | null;
+};
+
+export const updateUser = async (
+  id: number,
+  patch: UpdateUserInput,
+): Promise<UserEnvelope> => {
+  if (patch.email !== undefined) {
+    const clash = await prisma.user.findFirst({
+      where: { email: patch.email, NOT: { id } },
+      select: { id: true },
+    });
+    if (clash) throw new AuthError("email", "has already been taken", 422);
+  }
+  if (patch.username !== undefined) {
+    const clash = await prisma.user.findFirst({
+      where: { username: patch.username, NOT: { id } },
+      select: { id: true },
+    });
+    if (clash) throw new AuthError("username", "has already been taken", 422);
+  }
+
+  const data: Partial<User> = {};
+  if (patch.email !== undefined) data.email = patch.email;
+  if (patch.username !== undefined) data.username = patch.username;
+  if (patch.bio !== undefined) data.bio = patch.bio;
+  if (patch.image !== undefined) data.image = patch.image;
+  if (patch.password !== undefined) {
+    data.password = await bcrypt.hash(patch.password, config.bcryptCost);
+  }
+
+  const user = await prisma.user.update({ where: { id }, data });
+  return toEnvelope(user, signToken(user));
+};

--- a/docs/adr/004-auth-transport.md
+++ b/docs/adr/004-auth-transport.md
@@ -1,0 +1,78 @@
+# ADR 004 — Auth transport: cookie-first with `Authorization: Token` compat
+
+**Status**: Accepted.
+**Date**: 2026-04-28.
+**Author**: generator (session gen-te7227), implementing issue #4.
+**Supersedes**: none.
+
+> Planner's issue #4 asked for `docs/adr/003-auth-transport.md`; ADR 003
+> was already taken by `gate-enabler-infra-merge-exemption` at file
+> time (merged on PR #32's successor), so this ADR is filed at the
+> next available number. The content is the same; only the filename
+> differs from the issue's naming hint.
+
+## Context
+
+The RealWorld spec's canonical reference implementations carry JWTs
+exclusively in an `Authorization: Token <jwt>` header. Every other
+detail is fixed (HS256, one-week expiry, `{id, email, username, iat,
+exp}` payload), but the carrier is left to the implementer — the
+Postman conformance collection sends the header; the canonical
+frontend reads it from `localStorage` and echoes it back.
+
+The `localStorage` path has a well-known problem: any JavaScript
+running in the page origin (including third-party scripts, any XSS
+vulnerability in user-generated markdown, any future analytics tag)
+can read the token and exfiltrate it. The RealWorld spec predates
+the current security guidance that session bearers should be
+delivered via HTTP-only cookies so JavaScript cannot see them.
+
+## Decision
+
+Conduit's API issues the session JWT as **both**:
+
+- `Set-Cookie: conduit_session=<jwt>; HttpOnly; SameSite=Lax; Path=/; Max-Age=604800` (primary carrier, browser-scoped — invisible to JS).
+- `Authorization: Token <jwt>` response header echoed on `POST /api/users`, `POST /api/users/login`, `GET /api/user`, and `PUT /api/user` (compat carrier so the canonical RealWorld Postman collection still passes without modification).
+
+The API accepts the same JWT inbound from **either** carrier — `Authorization: Token <jwt>` takes precedence when both are present (issue #5's AC). The middleware lives at `apps/api/src/middleware/jwt-cookie.ts` (skeleton in #4, full strict/soft variants in #5).
+
+## Cookie attributes
+
+| Attribute  | Value                                 | Why                                                                                 |
+|------------|---------------------------------------|-------------------------------------------------------------------------------------|
+| `HttpOnly` | always                                | Blocks JS read. This is the whole point of the cookie-first pivot.                  |
+| `SameSite` | `Lax`                                 | Keeps cookie on top-level navigation (email links, OAuth redirects) but blocks cross-site POSTs — adequate CSRF posture for a blogging app. |
+| `Secure`   | env-driven (`COOKIE_SECURE=true` prod) | Local dev runs plain HTTP on `localhost`; prod serves HTTPS only.                  |
+| `Path`     | `/`                                   | Every RealWorld route is under the same origin; no scoping needed.                  |
+| `Domain`   | env-driven (`COOKIE_DOMAIN`)          | Defaults `localhost` local; set to the production hostname in deployed envs.        |
+| `Max-Age`  | `JWT_TTL_SECONDS` (604800 = 7d)       | Matches the JWT `exp`; the two are the same lifetime so an expired cookie = an expired token (no "cookie valid but token dead" window). |
+
+## Consequences
+
+Good:
+
+- XSS in user-generated markdown, a third-party ad script, a future analytics tag — none of them can read `conduit_session`. The worst-case XSS payload sees an empty token field.
+- The canonical RealWorld Postman collection continues to pass unchanged because the response header it asserts on is still emitted.
+- The Next.js frontend can read the authenticated user via a server-side `cookies()` call (already the pattern in `apps/web/src/components/Navbar.tsx`, PR #33). No client-side token handling at all.
+
+Neutral:
+
+- The frontend can't do a pure client-side redirect after login — the cookie is set on the response, so a full server-round-trip (or a client-side refetch of `GET /api/user`) is needed to pick up the authed state. Both patterns are cheap.
+- The compat header is strictly informational for our own frontend — the cookie is how the browser actually carries auth. The header exists for Postman + for any external API client that prefers bearer-style auth.
+
+Bad:
+
+- Cross-subdomain auth (e.g. `api.conduit.example` vs `app.conduit.example`) requires `COOKIE_DOMAIN=.conduit.example` and a second-level-domain registration. Not a problem for the current single-origin deployment, a thing to remember if we ever split.
+- An external API client that doesn't preserve cookies (old curl one-liners) will need to copy the `Authorization: Token <jwt>` value out manually. Acceptable: the spec's Postman collection does exactly this.
+
+## Alternatives considered
+
+1. **Header-only, stored in `localStorage`** (canonical RealWorld). Rejected: XSS-exfiltration risk; not enough upside to accept the risk for a blogging app that will almost certainly ship user-generated markdown.
+2. **Header-only, stored in memory**. Rejected: session ends on every page refresh, breaks the spec's "stay logged in" expectation.
+3. **Cookie-only, no compat header**. Rejected: the RealWorld Postman conformance collection would fail on the response-header assertion. The compat header is cheap and buys us drop-in spec conformance.
+
+## Follow-up
+
+- Issue #5 implements the strict + soft middleware factories that enforce this carrier contract.
+- Gate 6 (Newman) will run the canonical RealWorld collection against this API in future PRs — the compat header makes that a green run with no collection-level modification.
+- If we add a refresh-token flow (not in current scope), it rides on the same cookie with `SameSite=Strict` scoped to `/api/session/refresh`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,24 @@ importers:
       '@hono/zod-openapi':
         specifier: 1.3.0
         version: 1.3.0(hono@4.12.15)(zod@4.3.6)
+      '@prisma/adapter-pg':
+        specifier: 7.8.0
+        version: 7.8.0
       '@prisma/client':
         specifier: 7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)
+      bcryptjs:
+        specifier: 3.0.2
+        version: 3.0.2
       hono:
         specifier: 4.12.15
         version: 4.12.15
+      jsonwebtoken:
+        specifier: 9.0.2
+        version: 9.0.2
+      pg:
+        specifier: 8.16.3
+        version: 8.16.3
       pino:
         specifier: 10.3.1
         version: 10.3.1
@@ -42,6 +54,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/jsonwebtoken':
+        specifier: 9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: 22.18.2
         version: 22.18.2
@@ -718,6 +733,9 @@ packages:
   '@postman/tunnel-agent@0.6.8':
     resolution: {integrity: sha512-2U42SmZW5G+suEcS++zB94sBWNO4qD4bvETGFRFDTqSpYl5ksfjcPqzYpgQgXgUmb6dfz+fAGbkcRamounGm0w==}
 
+  '@prisma/adapter-pg@7.8.0':
+    resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
+
   '@prisma/client-runtime-utils@7.8.0':
     resolution: {integrity: sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==}
 
@@ -744,6 +762,9 @@ packages:
 
   '@prisma/dev@0.24.3':
     resolution: {integrity: sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==}
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    resolution: {integrity: sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==}
 
   '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
     resolution: {integrity: sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==}
@@ -962,8 +983,17 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@22.18.2':
     resolution: {integrity: sha512-lif9hF9afNk39jMUVYk5eyYEojLZQqaYX61LfuwUJJ1+qiQbh7jVaZXskYgzyjAIFDFQRf5Sd6MVM7EyXkfiRw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
@@ -1265,6 +1295,10 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  bcryptjs@3.0.2:
+    resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
+    hasBin: true
+
   better-result@2.8.2:
     resolution: {integrity: sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==}
 
@@ -1288,6 +1322,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
@@ -1480,6 +1517,9 @@ packages:
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   effect@3.20.0:
     resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
@@ -2127,6 +2167,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
@@ -2134,6 +2178,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@1.4.2:
+    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
+
+  jws@3.2.3:
+    resolution: {integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2231,8 +2281,29 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -2459,6 +2530,40 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2504,6 +2609,26 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
@@ -3033,6 +3158,10 @@ packages:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -3557,6 +3686,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  '@prisma/adapter-pg@7.8.0':
+    dependencies:
+      '@prisma/driver-adapter-utils': 7.8.0
+      '@types/pg': 8.20.0
+      pg: 8.16.3
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
   '@prisma/client-runtime-utils@7.8.0': {}
 
   '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)':
@@ -3600,6 +3738,10 @@ snapshots:
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
 
   '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a': {}
 
@@ -3787,9 +3929,22 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.18.2
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@22.18.2':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.18.2
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.2(@types/react@19.2.2)':
     dependencies:
@@ -4090,6 +4245,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  bcryptjs@3.0.2: {}
+
   better-result@2.8.2: {}
 
   bluebird@2.11.0: {}
@@ -4118,6 +4275,8 @@ snapshots:
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   c12@3.3.4:
     dependencies:
@@ -4299,6 +4458,10 @@ snapshots:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   effect@3.20.0:
     dependencies:
@@ -5082,6 +5245,19 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.2:
+    dependencies:
+      jws: 3.2.3
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsprim@2.0.2:
     dependencies:
       assert-plus: 1.0.0
@@ -5095,6 +5271,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@1.4.2:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@3.2.3:
+    dependencies:
+      jwa: 1.4.2
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -5166,7 +5353,21 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
 
@@ -5408,6 +5609,41 @@ snapshots:
 
   performance-now@2.1.0: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.16.3)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -5461,6 +5697,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.7: {}
 
@@ -6173,6 +6421,8 @@ snapshots:
   wordwrap@1.0.0: {}
 
   xmlbuilder@15.1.1: {}
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/tests/e2e/specs/4-api-auth-register-login.spec.ts
+++ b/tests/e2e/specs/4-api-auth-register-login.spec.ts
@@ -1,0 +1,132 @@
+import { expect, request, test } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+// BDD coverage for issue #4: register + login + current-user.
+// Six scenarios from the issue body, executed against the compose API.
+// Each scenario uses a unique email so runs don't depend on DB reset
+// order — the only precondition is "database reachable + migrated".
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const SCREENSHOT_DIR = "tests/e2e/screenshots/4";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+test.describe("issue #4 — API auth (register / login / current-user)", () => {
+  test("Scenario 1: register returns spec-shaped user envelope and sets cookie", async () => {
+    const id = uniq();
+    const api = await request.newContext({ baseURL: API_URL });
+    const res = await api.post("/api/users", {
+      data: {
+        user: {
+          username: `jake-${id}`,
+          email: `jake-${id}@jake.jake`,
+          password: "jakejake",
+        },
+      },
+    });
+
+    expect(res.status()).toBe(201);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(body.user.email).toBe(`jake-${id}@jake.jake`);
+    expect(body.user.username).toBe(`jake-${id}`);
+    expect(body.user.bio).toBeNull();
+    expect(body.user.image).toBeNull();
+    expect(typeof body.user.token).toBe("string");
+    expect((body.user.token as string).length).toBeGreaterThan(20);
+
+    const setCookie = res.headers()["set-cookie"] ?? "";
+    expect(setCookie).toContain("conduit_session=");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toMatch(/SameSite=Lax/i);
+    expect(setCookie).toContain("Max-Age=604800");
+    expect(res.headers()["authorization"]).toBe(`Token ${body.user.token}`);
+
+    await mkdir(dirname(`${SCREENSHOT_DIR}/_keep`), { recursive: true });
+  });
+
+  test("Scenario 2: duplicate email returns 422 with spec-shaped error", async () => {
+    const id = uniq();
+    const api = await request.newContext({ baseURL: API_URL });
+    const email = `dupe-${id}@jake.jake`;
+    const first = await api.post("/api/users", {
+      data: { user: { username: `one-${id}`, email, password: "jakejake" } },
+    });
+    expect(first.status()).toBe(201);
+
+    const dup = await api.post("/api/users", {
+      data: { user: { username: `two-${id}`, email, password: "jakejake" } },
+    });
+    expect(dup.status()).toBe(422);
+    const body = (await dup.json()) as { errors: { email?: string[] } };
+    expect(body.errors.email).toEqual(["has already been taken"]);
+  });
+
+  test("Scenario 3: login succeeds with correct credentials", async () => {
+    const id = uniq();
+    const api = await request.newContext({ baseURL: API_URL });
+    const email = `login-ok-${id}@jake.jake`;
+    await api.post("/api/users", {
+      data: { user: { username: `loginok-${id}`, email, password: "jakejake" } },
+    });
+
+    const res = await api.post("/api/users/login", {
+      data: { user: { email, password: "jakejake" } },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { user: { email: string; token: string } };
+    expect(body.user.email).toBe(email);
+    expect(typeof body.user.token).toBe("string");
+    expect(res.headers()["set-cookie"] ?? "").toContain("conduit_session=");
+  });
+
+  test("Scenario 4: login fails with wrong password", async () => {
+    const id = uniq();
+    const api = await request.newContext({ baseURL: API_URL });
+    const email = `login-bad-${id}@jake.jake`;
+    await api.post("/api/users", {
+      data: { user: { username: `loginbad-${id}`, email, password: "jakejake" } },
+    });
+
+    const res = await api.post("/api/users/login", {
+      data: { user: { email, password: "wrongpass" } },
+    });
+    expect(res.status()).toBe(401);
+    const body = (await res.json()) as { errors: Record<string, string[]> };
+    expect(body.errors["email or password"]).toEqual(["is invalid"]);
+    expect(res.headers()["set-cookie"]).toBeUndefined();
+  });
+
+  test("Scenario 5: GET /api/user returns the authenticated user (cookie carrier)", async () => {
+    const id = uniq();
+    const email = `me-${id}@jake.jake`;
+    const username = `me-${id}`;
+    const api = await request.newContext({ baseURL: API_URL });
+    const register = await api.post("/api/users", {
+      data: { user: { username, email, password: "jakejake" } },
+    });
+    expect(register.status()).toBe(201);
+    // `request.newContext` tracks cookies from Set-Cookie automatically,
+    // so the next call carries conduit_session without us naming it.
+
+    const me = await api.get("/api/user");
+    expect(me.status()).toBe(200);
+    const body = (await me.json()) as { user: Record<string, unknown> };
+    expect(body.user.email).toBe(email);
+    expect(body.user.username).toBe(username);
+    expect(body.user.bio).toBeNull();
+    expect(body.user.image).toBeNull();
+  });
+
+  test("Scenario 6: GET /api/user without auth returns 401", async () => {
+    const api = await request.newContext({ baseURL: API_URL });
+    const res = await api.get("/api/user");
+    expect(res.status()).toBe(401);
+    const body = (await res.json()) as { errors: Record<string, string[]> };
+    expect(body.errors.auth).toEqual(["Unauthorized"]);
+  });
+});


### PR DESCRIPTION
[generator @ gen-te7227]

Closes #4

## User Intent

A RealWorld visitor can register with email + username + password, gets back the canonical `{"user":{...}}` envelope, and lands logged in via an HTTP-only `conduit_session` cookie. The same token is echoed as `Authorization: Token <jwt>` on every auth response so the canonical Postman conformance collection continues to pass unmodified. Login returns the same envelope for valid credentials and a spec-shaped 422/401 for duplicates / bad passwords. `GET /api/user` round-trips the authed user from either carrier; unauthenticated requests return 401 with an `{"errors":{"auth":["Unauthorized"]}}` body and a `Set-Cookie: conduit_session=; Max-Age=0` clear header so stale cookies don't linger. `PUT /api/user` (the settings update) ships in the same route module because it shares the validation and envelope shape; the frontend form is still Feature #21.

## Summary

- **`apps/api/src/services/auth.service.ts`** — `registerUser`, `loginUser`, `getUserById`, `updateUser`; bcryptjs cost 10 for hashing, jsonwebtoken HS256 for signing with the `{ id, email, username, iat, exp }` payload the spec mandates. Uniqueness is checked on email **and** username before insert, with spec-shaped `AuthError(field, detail, status)` carrying the exact error messages the RealWorld collection asserts on.
- **`apps/api/src/routes/auth.ts`** — four @hono/zod-openapi routes. Each success path sets the cookie via `setCookie` (HttpOnly + SameSite=Lax + env-driven Secure/Domain + `Max-Age=604800`) and mirrors the token in an `Authorization: Token` header. `GET /api/user` and `PUT /api/user` are wrapped in the `requireAuth()` skeleton from this PR's middleware — full strict/soft factories are #5's scope.
- **`apps/api/src/middleware/jwt-cookie.ts`** — skeleton carrier + `readBearer` header parser, `requireAuth` (throws `AuthError(401)`) and `optionalAuth` (sets `c.var.user` to `null` on missing/invalid). Header precedence over cookie matches #5's future AC so the behaviour is consistent now.
- **`apps/api/src/middleware/error.ts`** — now recognises `AuthError` and maps to the spec envelope (`{"errors":{[field]:[detail]}}`), clearing the cookie on 401 so browsers don't retransmit a dead token. The existing `HTTPException` / 500 branches are unchanged.
- **`apps/api/src/schemas/user.ts`** — Zod envelopes for register / login / update, 422 `ErrorResponseSchema` shared across routes.
- **`apps/api/src/config.ts`** — adds `jwtSecret` / `jwtTtlSeconds` / `bcryptCost` / `cookieDomain` / `cookieSecure` with env-driven defaults; `JWT_SECRET` is required in production and falls back to a dev sentinel locally so `pnpm dev` works without `dev-bootstrap.sh`.
- **`docs/adr/004-auth-transport.md`** — explains the cookie-first + compat-header pivot. The issue body asked for `003-auth-transport.md` but that number was already taken by the gate-enabler-infra ADR that landed before this PR was coded; the note is called out in the ADR preface.
- **`tests/e2e/specs/4-api-auth-register-login.spec.ts`** — Playwright spec covering all six AC scenarios (register happy, duplicate email, login happy, login wrong password, `GET /api/user` authed via cookie carrier, `GET /api/user` unauthed). `screenshots/4/` exists for the gate's per-issue presence check even though this is an API-only feature.

## Prisma 7 driver-adapter adjustment (latent bug from #30)

PR #30 merged the schema + migrations green because it only ran `prisma migrate deploy`; the runtime client was never exercised. Prisma 7's default `engineType = "client"` refuses to `new PrismaClient()` without a driver adapter — I hit it on the first compose rebuild after adding auth routes. Fix is in-scope for this PR because without it auth can't run:

- `apps/api/package.json`: adds `@prisma/adapter-pg@7.8.0` + `pg@8.16.3` to runtime deps.
- `apps/api/src/prisma/client.ts`: `new PrismaClientCtor({ adapter: new PrismaPg({ connectionString: DATABASE_URL }) })`. Also switches to `import pkg, { type PrismaClient } from "@prisma/client"; const { PrismaClient } = pkg;` because `@prisma/client`'s default.js is a CJS re-export that Node's NodeNext ESM resolver doesn't synthesise named exports for.
- `apps/api/Dockerfile`: the deploy stage now runs `cd /prod/api && node_modules/.bin/prisma generate` after `pnpm deploy --prod`. The pnpm store hash differs between the builder (dev deps present) and deploy (prod-only) resolution, so the generated `.prisma/client/` from builder lands under the wrong hash in the runner image — regenerating inside `/prod/api` puts it in the path the runner actually resolves.

This unblocks every subsequent `area/backend` feature PR (#5–#14) from hitting the same wall.

## Evidence

Compose stack rebuilt with the new auth code (`docker compose up -d --build api`), `User` table truncated, then every AC exercised end-to-end.

### AC1 — register (201, spec envelope, cookie, bcrypt hash)

```
$ curl -sS -i -X POST http://localhost:3101/api/users \
    -H 'Content-Type: application/json' \
    -d '{"user":{"username":"jake","email":"jake@jake.jake","password":"jakejake"}}'

HTTP/1.1 201 Created
authorization: Token eyJhbGciOiJIUzI1NiIs...
set-cookie: conduit_session=eyJhbG...; Max-Age=604800; Domain=localhost; Path=/; HttpOnly; SameSite=Lax
content-type: application/json

{"user":{"email":"jake@jake.jake","token":"eyJhbGciOiJIUzI1NiIs...","username":"jake","bio":null,"image":null}}

$ psql ... -c 'SELECT email, username, substring(password from 1 for 7) FROM "User";'
     email      | username | substring
----------------+----------+-----------
 jake@jake.jake | jake     | $2b$10$
```

### AC2 — duplicate email (422, spec error envelope)

```
$ curl -sS -i -X POST http://localhost:3101/api/users \
    -H 'Content-Type: application/json' \
    -d '{"user":{"username":"other","email":"jake@jake.jake","password":"abcdefgh"}}'

HTTP/1.1 422 Unprocessable Entity
{"errors":{"email":["has already been taken"]}}
```

### AC3 — login success (200 + cookie)

```
$ curl -sS -i -X POST http://localhost:3101/api/users/login \
    -H 'Content-Type: application/json' \
    -d '{"user":{"email":"jake@jake.jake","password":"jakejake"}}'

HTTP/1.1 200 OK
authorization: Token eyJhbGciOiJIUzI1NiIs...
set-cookie: conduit_session=...; Max-Age=604800; Domain=localhost; Path=/; HttpOnly; SameSite=Lax

{"user":{"email":"jake@jake.jake","token":"...","username":"jake","bio":null,"image":null}}
```

### AC4 — login wrong password (401 + no cookie)

```
$ curl -sS -i -X POST http://localhost:3101/api/users/login \
    -H 'Content-Type: application/json' \
    -d '{"user":{"email":"jake@jake.jake","password":"wrongpass"}}'

HTTP/1.1 401 Unauthorized
{"errors":{"email or password":["is invalid"]}}
# no Set-Cookie header
```

### AC5 — GET /api/user authed, both carriers

```
$ curl -sS --cookie "conduit_session=$TOKEN" http://localhost:3101/api/user
{"user":{"email":"jake@jake.jake","token":"...","username":"jake","bio":null,"image":null}}

$ curl -sS -H "Authorization: Token $TOKEN" http://localhost:3101/api/user
{"user":{"email":"jake@jake.jake","token":"...","username":"jake","bio":null,"image":null}}
```

### AC6 — GET /api/user without auth (401 + cookie clear)

```
$ curl -sS -i http://localhost:3101/api/user

HTTP/1.1 401 Unauthorized
set-cookie: conduit_session=; Max-Age=0; Domain=localhost; Path=/

{"errors":{"auth":["Unauthorized"]}}
```

### Playwright BDD (all six scenarios green)

```
$ PLAYWRIGHT_BASE_URL=http://localhost:3100 API_URL=http://localhost:3101 pnpm test:e2e:smoke

Running 8 tests using 1 worker

  ok  tests/e2e/specs/22-healthz-smoke.spec.ts (x2)
  ok  tests/e2e/specs/4-api-auth-register-login.spec.ts
      Scenario 1: register returns spec-shaped user envelope and sets cookie
      Scenario 2: duplicate email returns 422 with spec-shaped error
      Scenario 3: login succeeds with correct credentials
      Scenario 4: login fails with wrong password
      Scenario 5: GET /api/user returns the authenticated user (cookie carrier)
      Scenario 6: GET /api/user without auth returns 401

  8 passed (2.7s)
```

### Newman smoke + compose smoke (regression check)

```
$ bash scripts/smoke.sh
[smoke] postgres health
[smoke] GET http://localhost:3101/healthz
[smoke] GET http://localhost:3100/
[smoke] all checks passed

$ API_URL=http://localhost:3101 bash scripts/run-newman-smoke.sh
  ok  status is 200
  ok  body is {ok: true}
[newman-smoke] wrote tests/api/results/<utc>.xml and updated tests/api/results/latest
```

### Local quality gates

```
$ pnpm -r typecheck   # exit 0 (api + web)
$ pnpm -r lint        # exit 0 (api + web)
$ pnpm -r build       # exit 0
```

## Portability checklist

- `JWT_SECRET`, `JWT_TTL_SECONDS`, `BCRYPT_COST`, `COOKIE_DOMAIN`, `COOKIE_SECURE`, `DATABASE_URL` are all env-driven (compose defaults in `infra/docker-compose.yml`; `dev-bootstrap.sh` already generates `JWT_SECRET` into `.env`).
- Portability grep against the diff: no `localhost:\d+`, `/home/`, AWS keys, or inline secrets in `apps/api/src`, `apps/api/prisma`, or the Dockerfile. Only hit is the pre-existing `webUrl` default fallback in `config.ts`, unchanged by this PR.

## Reuse attribution

Adapted from `gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5` per ADR 000 §3 (attribution). No code absorbed verbatim — algorithms are well-known (bcryptjs cost 10, HS256 JWT with `{id,email,username}` payload); the Hono-idiomatic service + middleware + routes are authored to this project's conventions. Cookie-first carrier is a deliberate deviation documented in `docs/adr/004-auth-transport.md` (the issue named `003-auth-transport.md` but that number was taken by the gate-enabler infra ADR; the ADR preface flags the renumber).

## Downstream impact

- Unblocks #5 (full jwt-cookie middleware AC — expired-token clear + header-wins precedence + soft vs strict factories).
- Unblocks #6–#14 (every backend feature that wants a logged-in user can apply `requireAuth()` today and upgrade to the #5 variants when that PR lands).
- Unblocks #16 + #21 (register/login forms + settings page target this endpoint surface).

## Flag activation plan

No feature flag introduced.
