### PR TITLE
fix(ci): smoke job missing corepack + pnpm setup (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: enable corepack + pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@"${PNPM_VERSION}" --activate
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: install
+        run: pnpm install --frozen-lockfile=false
+
       - name: bootstrap .env
         run: bash scripts/dev-bootstrap.sh
 


### PR DESCRIPTION
[generator @ gen-te8dm6]

Closes #39

## User Intent

Every `latest`-targeting PR currently shows a red `compose up + smoke both services` check because the smoke job calls `pnpm` without first installing corepack + pnpm on PATH. After this fix, the smoke job runs Newman + Playwright against the live compose stack end-to-end and produces the gate-3/4 artifacts the evaluator's merge gate expects. The red check goes away, planner's Branch-5 audits stop surfacing CI noise, and the in-CI smoke becomes actual ground truth for future PRs.

## Upstream reuse

n/a — three-step addition that mirrors the pattern already used by the sibling `install` job on lines 32–43 of the same file. Scratch discipline fix.

## Evidence (required)

### Reproducible local environment

Not applicable — this PR changes only `.github/workflows/ci.yml`, which never runs on developer laptops. Verification happens on GitHub's hosted runners; see "CI run (ground truth)" below. Source tree confirms no application code or compose wiring was touched:

```
$ git diff --stat latest
 .github/workflows/ci.yml | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```

### BDD scenarios (required when issue has Given/When/Then AC)

The three AC scenarios on issue #39 are CI-job behaviors, not user-visible behaviors; they are verified by the CI run itself. Mapping:

- **Scenario 1** — `smoke` job runs Newman + Playwright against the compose stack
  → verified by `run newman smoke` step exit 0 + `upload newman smoke artifacts` step uploading `tests/api/results/<utc-ts>.xml`. Observable on the CI run this PR triggers.
- **Scenario 2** — Playwright smoke step produces gate-3/4 artifacts in CI
  → verified by `run playwright smoke` step exit 0 + `upload playwright smoke artifacts` uploading `summary.json` + `root-page.png`.
- **Scenario 3** — total smoke job time stays within the 10-min budget
  → verified by `timeout-minutes: 10` on the job + wall-clock in the run summary. Incremental install cost is ~30s with `cache: pnpm` hit; plenty of headroom.

Per `prompts/generator.md` §DoD gate 2, BDD scenarios for UI behaviors require Playwright specs under `tests/e2e/specs/`. There is no UI behavior here — the subject of the scenarios is the workflow file itself — so a Playwright spec would be misclassified. The CI run is the fixture.

### Full local E2E

Full local lint + typecheck green on the branch head (`fe2ab2f`):

```
$ pnpm run lint
> realworld-conduit@0.0.0 lint
> pnpm -r --parallel run lint
apps/api lint: Done
apps/web lint: Done

$ pnpm run typecheck
> realworld-conduit@0.0.0 typecheck
> pnpm -r --parallel run typecheck
apps/web typecheck: Done
apps/api typecheck: Done
```

YAML validity:

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo OK
OK
```

### CI run (ground truth)

This PR's own CI run is the authoritative evidence. Watch the `compose up + smoke both services` job on this PR's checks — it should flip from red (on PR #40) to green here once CI completes. The three steps that were failing (`run newman smoke`, `install playwright browsers`, `run playwright smoke`) will all execute and the two upload-artifact steps will publish Newman XML + Playwright summary.json + screenshots.

### Portability check

No environment-dependent values introduced. `PNPM_VERSION` / `NODE_VERSION` are already defined in the workflow-level `env:` block (lines 21–22) and reused in the install job; the new steps consume the same two variables:

```
$ git diff .github/workflows/ci.yml | grep -E '^\+' | grep -vE '^\+\+\+' | grep -iE 'localhost:[0-9]|/home/|[A-Z0-9]{20,}'
(no matches — clean)
```

### Infra (if touched)

No infra/IaC change. Workflow-only edit.

## Flag activation plan

Not applicable.
