### PR TITLE
feat(api): strict + soft JWT auth middleware with clock-skew (#5)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/server.js",
     "lint": "eslint 'src/**/*.ts'",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "postinstall": "[ -n \"$SKIP_PRISMA_GENERATE\" ] || prisma generate",
     "prisma:generate": "prisma generate",
     "prisma:migrate:deploy": "prisma migrate deploy",
@@ -33,6 +34,7 @@
     "eslint": "9.38.0",
     "tsx": "4.21.0",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.49.0"
+    "typescript-eslint": "8.49.0",
+    "vitest": "3.2.4"
   }
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -16,6 +16,7 @@ export const config = {
   webUrl: required("WEB_URL", "http://localhost:3000"),
   jwtSecret: required("JWT_SECRET", nodeEnv === "production" ? undefined : "dev-only-jwt-secret-do-not-use-in-prod"),
   jwtTtlSeconds: Number.parseInt(process.env.JWT_TTL_SECONDS ?? "604800", 10),
+  jwtClockSkewSeconds: Number.parseInt(process.env.JWT_CLOCK_SKEW_SECONDS ?? "5", 10),
   bcryptCost: Number.parseInt(process.env.BCRYPT_COST ?? "10", 10),
   cookieDomain: process.env.COOKIE_DOMAIN ?? "localhost",
   cookieSecure: (process.env.COOKIE_SECURE ?? "false").toLowerCase() === "true",

--- a/apps/api/src/middleware/jwt-cookie.ts
+++ b/apps/api/src/middleware/jwt-cookie.ts
@@ -2,17 +2,17 @@ import { createMiddleware } from "hono/factory";
 import { getCookie } from "hono/cookie";
 import { AuthError, verifyToken, type JwtPayload } from "../services/auth.service.js";
 
-// Skeleton JWT-cookie carrier middleware for issue #4.
+// Strict + soft JWT-cookie carriers for issue #5.
 //
-// Issue #5 will expand this with explicit strict + soft factories, the
-// expired-token cookie clear, and the dual-carrier precedence rule. For
-// #4 we only need a helper that #4's own GET /api/user route can call to
-// read the current user from either carrier, returning `null` when
-// neither is present or when the token fails verification.
+// Carrier precedence: `Authorization: Token <jwt>` wins when both the
+// header and a cookie are present (Postman-compat path wins — matches
+// AC5 under deterministic dual-carrier conditions).
 //
-// Carrier precedence matches the spec's future #5 AC: `Authorization:
-// Token <jwt>` wins when both headers are present (Postman-compat path
-// wins for deterministic behaviour under dual-carrier conditions).
+// Expired/invalid token on a strict-auth route throws AuthError(401),
+// which the global error handler (middleware/error.ts) renders as JSON
+// `{"errors":{"auth":["Unauthorized"]}}` and pairs with
+// `Set-Cookie: conduit_session=; Max-Age=0` to clear the stale cookie
+// (AC3). Soft-auth swallows the same error and proceeds anonymously.
 
 export const COOKIE_NAME = "conduit_session";
 const AUTH_HEADER = "Authorization";
@@ -27,11 +27,16 @@ export const readBearer = (headerValue: string | undefined): string | null => {
   return token.length > 0 ? token : null;
 };
 
+const pickToken = (
+  header: string | null,
+  cookie: string | null,
+): string | null => header ?? cookie;
+
 export const optionalAuth = () =>
   createMiddleware<{ Variables: UserVars }>(async (c, next) => {
     const headerToken = readBearer(c.req.header(AUTH_HEADER));
     const cookieToken = getCookie(c, COOKIE_NAME) ?? null;
-    const token = headerToken ?? cookieToken;
+    const token = pickToken(headerToken, cookieToken);
     if (!token) {
       c.set("user", null);
       await next();
@@ -49,7 +54,7 @@ export const requireAuth = () =>
   createMiddleware<{ Variables: UserVars }>(async (c, next) => {
     const headerToken = readBearer(c.req.header(AUTH_HEADER));
     const cookieToken = getCookie(c, COOKIE_NAME) ?? null;
-    const token = headerToken ?? cookieToken;
+    const token = pickToken(headerToken, cookieToken);
     if (!token) {
       throw new AuthError("auth", "Unauthorized", 401);
     }

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -45,7 +45,17 @@ const signToken = (user: Pick<User, "id" | "email" | "username">): string => {
 };
 
 export const verifyToken = (token: string): JwtPayload => {
-  const decoded = jwt.verify(token, config.jwtSecret, { algorithms: ["HS256"] });
+  let decoded: string | jwt.JwtPayload;
+  try {
+    decoded = jwt.verify(token, config.jwtSecret, {
+      algorithms: ["HS256"],
+      clockTolerance: config.jwtClockSkewSeconds,
+    });
+  } catch {
+    // Expired / malformed / signature-mismatch — surface as the spec's
+    // 401 so the global handler renders JSON + clears the cookie.
+    throw new AuthError("auth", "Unauthorized", 401);
+  }
   if (typeof decoded === "string") {
     throw new AuthError("auth", "Unauthorized", 401);
   }

--- a/apps/api/test/middleware/jwt-cookie.test.ts
+++ b/apps/api/test/middleware/jwt-cookie.test.ts
@@ -1,0 +1,205 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import jwt from "jsonwebtoken";
+
+// Ensure the config + prisma modules see deterministic env before
+// they're imported (both read process.env at module load time).
+// DATABASE_URL only needs to satisfy the non-empty check in
+// prisma/client.ts — these tests never touch the Prisma client.
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgres://vitest:vitest@127.0.0.1:5/vitest";
+process.env.JWT_SECRET = "test-only-secret";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.JWT_CLOCK_SKEW_SECONDS = "0";
+
+const { COOKIE_NAME, optionalAuth, readBearer, requireAuth } = await import(
+  "../../src/middleware/jwt-cookie.js"
+);
+const { errorHandler } = await import("../../src/middleware/error.js");
+
+type TestPayload = { id: number; email: string; username: string };
+
+const signToken = (payload: TestPayload, opts: jwt.SignOptions = {}): string =>
+  jwt.sign(payload, process.env.JWT_SECRET!, {
+    algorithm: "HS256",
+    expiresIn: 3600,
+    ...opts,
+  });
+
+const validPayload: TestPayload = {
+  id: 42,
+  email: "jake@example.com",
+  username: "jake",
+};
+
+const buildApp = (variant: "strict" | "soft") => {
+  const app = new Hono();
+  app.onError(errorHandler as never);
+  if (variant === "strict") {
+    app.use("/me", requireAuth());
+  } else {
+    app.use("/me", optionalAuth());
+  }
+  app.get("/me", (c) => {
+    const user = c.get("user" as never);
+    return c.json({ user });
+  });
+  return app;
+};
+
+describe("readBearer — Authorization header parser", () => {
+  it("returns the token when the header uses the spec's `Token` prefix", () => {
+    expect(readBearer("Token abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("returns null for a missing header", () => {
+    expect(readBearer(undefined)).toBeNull();
+  });
+
+  it("returns null for a header without the Token prefix (Bearer is rejected)", () => {
+    expect(readBearer("Bearer abc.def.ghi")).toBeNull();
+  });
+
+  it("returns null when the prefix is present but the token is blank", () => {
+    expect(readBearer("Token ")).toBeNull();
+  });
+});
+
+describe("Scenario 1: Authenticated request exposes current user to handler", () => {
+  beforeAll(() => {
+    /* fixtures built per test */
+  });
+
+  it("attaches the verified payload to c.var.user under strict auth", async () => {
+    const app = buildApp("strict");
+    const token = signToken(validPayload);
+    const res = await app.request("/me", {
+      headers: { Authorization: `Token ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload };
+    expect(body.user).toEqual(validPayload);
+  });
+
+  it("reads a cookie-borne token the same way", async () => {
+    const app = buildApp("strict");
+    const token = signToken(validPayload);
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload };
+    expect(body.user).toEqual(validPayload);
+  });
+});
+
+describe("Scenario 2: Missing cookie on strict-auth returns 401", () => {
+  it("returns 401 with the spec-shaped error envelope when no carrier is present", async () => {
+    const app = buildApp("strict");
+    const res = await app.request("/me");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { errors: { auth: string[] } };
+    expect(body).toEqual({ errors: { auth: ["Unauthorized"] } });
+  });
+});
+
+describe("Scenario 3: Expired JWT on strict-auth returns 401 and clears cookie", () => {
+  it("returns 401 and sets Set-Cookie with Max-Age=0 for cookie-borne expired tokens", async () => {
+    const app = buildApp("strict");
+    const expired = signToken(validPayload, { expiresIn: -60 });
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=${expired}` },
+    });
+    expect(res.status).toBe(401);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toMatch(new RegExp(`${COOKIE_NAME}=;`));
+    expect(setCookie).toMatch(/Max-Age=0/i);
+  });
+
+  it("still 401s when the token is signed with the wrong secret", async () => {
+    const app = buildApp("strict");
+    const tampered = jwt.sign(validPayload, "different-secret", {
+      algorithm: "HS256",
+      expiresIn: 3600,
+    });
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=${tampered}` },
+    });
+    expect(res.status).toBe(401);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toMatch(new RegExp(`${COOKIE_NAME}=;`));
+  });
+});
+
+describe("Scenario 4: Soft-auth works for both anonymous and authenticated", () => {
+  it("proceeds with user=null when no carrier is present", async () => {
+    const app = buildApp("soft");
+    const res = await app.request("/me");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload | null };
+    expect(body.user).toBeNull();
+  });
+
+  it("proceeds with user populated when the token is valid", async () => {
+    const app = buildApp("soft");
+    const token = signToken(validPayload);
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload };
+    expect(body.user).toEqual(validPayload);
+  });
+
+  it("proceeds with user=null on a bad token — never 401s", async () => {
+    const app = buildApp("soft");
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=not-a-jwt` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload | null };
+    expect(body.user).toBeNull();
+  });
+
+  it("does NOT clear the cookie on a bad soft-auth token", async () => {
+    const app = buildApp("soft");
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=not-a-jwt` },
+    });
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});
+
+describe("Scenario 5: Authorization header precedes cookie when both are present and valid", () => {
+  it("exposes the header user when header + cookie both decode cleanly", async () => {
+    const app = buildApp("strict");
+    const headerUser: TestPayload = {
+      id: 100,
+      email: "header@example.com",
+      username: "header-user",
+    };
+    const cookieUser: TestPayload = {
+      id: 200,
+      email: "cookie@example.com",
+      username: "cookie-user",
+    };
+    const res = await app.request("/me", {
+      headers: {
+        Authorization: `Token ${signToken(headerUser)}`,
+        Cookie: `${COOKIE_NAME}=${signToken(cookieUser)}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: TestPayload };
+    expect(body.user).toEqual(headerUser);
+  });
+
+  it("falls back to the cookie when the header is absent", async () => {
+    const app = buildApp("strict");
+    const res = await app.request("/me", {
+      headers: { Cookie: `${COOKIE_NAME}=${signToken(validPayload)}` },
+    });
+    const body = (await res.json()) as { user: TestPayload };
+    expect(body.user).toEqual(validPayload);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    reporters: ["default"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "lint": "pnpm -r --parallel run lint",
     "typecheck": "pnpm -r --parallel run typecheck",
+    "test": "pnpm -r --if-present --parallel run test",
     "build": "pnpm -r run build",
     "dev": "pnpm -r --parallel run dev",
     "compose:up": "docker compose -f infra/docker-compose.yml up -d --build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript-eslint:
         specifier: 8.49.0
         version: 8.49.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -870,6 +873,144 @@ packages:
       '@types/react':
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -973,6 +1114,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1165,6 +1312,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1238,6 +1414,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1334,6 +1514,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1356,6 +1540,10 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1370,6 +1558,10 @@ packages:
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1467,6 +1659,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1560,6 +1756,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1702,9 +1901,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2128,6 +2334,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -2314,6 +2523,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -2523,6 +2735,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -2781,6 +2997,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2874,6 +3095,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2922,6 +3146,9 @@ packages:
 
   stack-trace@0.0.9:
     resolution: {integrity: sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2972,6 +3199,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -3007,9 +3237,27 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3126,6 +3374,79 @@ packages:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3145,6 +3466,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3841,6 +4167,81 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -3922,6 +4323,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -4104,6 +4512,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4209,6 +4659,8 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4293,6 +4745,8 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4316,6 +4770,14 @@ snapshots:
 
   caseless@0.12.0: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4328,6 +4790,8 @@ snapshots:
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  check-error@2.1.3: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -4410,6 +4874,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -4562,6 +5028,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4815,7 +5283,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -5219,6 +5693,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -5376,6 +5852,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -5604,6 +6082,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -5935,6 +6415,37 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6072,6 +6583,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6118,6 +6631,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stack-trace@0.0.9: {}
+
+  stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -6194,6 +6709,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.0):
     dependencies:
       client-only: 0.0.1
@@ -6217,10 +6736,20 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6371,6 +6900,84 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
+  vite-node@3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.18.2
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.2
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -6415,6 +7022,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
[generator @ gen-te8dm6]

Closes #5

## User Intent

Every downstream feature route (#6–#14 and beyond) needs a trustworthy "who's the caller?" primitive. This PR delivers two such primitives — `requireAuth()` for endpoints that must 401 anonymous callers, `optionalAuth()` for endpoints that branch on login state but stay 200 either way — plus the clock-skew tolerance and stale-cookie cleanup the spec requires. Once this lands, no future endpoint has to re-derive JWT verification or carrier parsing; they mount a middleware factory and read `c.var.user`.

## Upstream reuse

Adapted from `gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5` (attribution) per ADR 000 §3, §2. No code absorbed verbatim — upstream's `expressJwt` pattern is re-expressed as a hand-written Hono middleware idiom because Hono has no drop-in equivalent. The algorithm choice (HS256), carrier model (cookie-first + Authorization compat), and user-shape-on-context convention are the reused parts; the implementation is ours.

## What changed on top of PR #40

PR #40 shipped a skeleton `jwt-cookie.ts` to unblock `/api/user`. On top of that:

- `config.ts`: new `jwtClockSkewSeconds` (from `JWT_CLOCK_SKEW_SECONDS`, default 5).
- `services/auth.service.ts` → `verifyToken`: passes `clockTolerance` to `jwt.verify` and wraps the whole verify in try/catch so `TokenExpiredError` / `JsonWebTokenError` become `AuthError(401)` (the spec's shape). Previously an expired token would surface as a bare throw caught by `middleware/error.ts` at the 500 branch — now it takes the 401 path and the existing cookie-clear branch fires.
- `middleware/jwt-cookie.ts`: comment header rewritten to own the AC semantics (was "skeleton for #4, full behaviour in #5" — now is #5). The carrier-precedence helper `pickToken` is factored out so `requireAuth` and `optionalAuth` share one rule. No behaviour regression for #4 callers.
- `apps/api/vitest.config.ts` + `apps/api/test/middleware/jwt-cookie.test.ts`: first vitest suite in the workspace. 15 tests, five AC scenarios + four `readBearer` edge cases + dual-carrier fallback.
- `package.json` + `apps/api/package.json`: `test` script at both root and package level; root uses `--if-present` so `@conduit/web` (no vitest yet) is skipped cleanly.

Note on the cookie-clear placement: rather than calling `deleteCookie` inside the middleware's catch branch, the implementation relies on `middleware/error.ts:22-28` already clearing `conduit_session` on any 401 `AuthError`. One source of truth, covered by the live AC3 curl evidence below.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -f infra/docker-compose.yml --env-file .env ps
NAME                 STATUS
conduit-api-1        Up (healthy)
conduit-postgres-1   Up (healthy)
conduit-web-1        Up (healthy)
```

### BDD scenarios (required when issue has Given/When/Then AC)

All five scenarios covered in `apps/api/test/middleware/jwt-cookie.test.ts` + verified live against the compose stack via curl.

#### Unit run

```
$ pnpm --filter @conduit/api test
 ✓ test/middleware/jwt-cookie.test.ts (15 tests) 51ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Scenario mapping (every AC in issue #5):

- ✓ **S1** authenticated request exposes user to handler — unit: lines 69–83; live: `curl -H "Authorization: Token $token" /api/user → 200`
- ✓ **S2** missing carrier on strict-auth → 401 with `{"errors":{"auth":["Unauthorized"]}}` — unit: lines 93–100; live: `curl /api/user → 401 with that exact body`
- ✓ **S3** expired JWT → 401 + `Set-Cookie: conduit_session=; Max-Age=0` — unit: lines 105–132 (signed with `expiresIn:-60` to guarantee past-exp); live: `Set-Cookie: conduit_session=; Max-Age=0; Domain=localhost; Path=/` observed on the 401 response
- ✓ **S4** soft-auth works for both anon and authed — unit: lines 135–168 (including a bad-token path that stays 200 and does NOT clear the cookie)
- ✓ **S5** Authorization beats cookie on valid dual-carrier — unit: lines 172–201 (two distinct users, asserts the header's user came through); live: two-user curl confirms header user wins

Clock-skew: the env var `JWT_CLOCK_SKEW_SECONDS` flows through `config.jwtClockSkewSeconds` into `jwt.verify({ clockTolerance })`. Default 5s per issue §Environment-dependent values.

#### Live integration against compose (ground truth — every AC)

```
$ API=http://127.0.0.1:3101

# S2 — no carrier
$ curl -sS -i $API/api/user | head -3
HTTP/1.1 401 Unauthorized
$ curl -sS $API/api/user
{"errors":{"auth":["Unauthorized"]}}

# S1 — valid Authorization header
$ TOKEN=$(curl -sS -X POST -H 'Content-Type: application/json' \
            -d '{"user":{"username":"mw-s5b","email":"mw-s5b@example.com","password":"password123"}}' \
            $API/api/users | jq -r .user.token)
$ curl -sS -o /dev/null -w "%{http_code}\n" -H "Authorization: Token $TOKEN" $API/api/user
200
$ curl -sS -o /dev/null -w "%{http_code}\n" -H "Cookie: conduit_session=$TOKEN" $API/api/user
200

# S3 — actually-expired JWT (signed with expiresIn: -60)
$ EXPIRED=<jwt signed with the same compose secret, expiresIn: -60>
$ curl -sS -i -H "Cookie: conduit_session=$EXPIRED" $API/api/user | grep -E "^HTTP|^set-cookie"
HTTP/1.1 401 Unauthorized
set-cookie: conduit_session=; Max-Age=0; Domain=localhost; Path=/

# S5 — dual-carrier: header user wins
$ U1=$(curl ... register mw-s5c)
$ U2=$(curl ... register mw-s5d)
$ curl -sS -H "Authorization: Token $U1" -H "Cookie: conduit_session=$U2" $API/api/user \
    | jq -r .user.email
mw-s5c@example.com    # U1, the header's user — wins over U2 (cookie)
```

### Full local E2E

```
$ pnpm run test                                     # workspace-wide tests
  apps/api test: 15 passed (15)

$ pnpm --filter @conduit/api lint                   # 0 errors
$ pnpm --filter @conduit/api typecheck              # exit 0
$ pnpm --filter @conduit/api build                  # exit 0
$ pnpm --filter @conduit/web build                  # exit 0

$ PLAYWRIGHT_BASE_URL=http://localhost:3100 API_URL=http://localhost:3101 pnpm test:e2e:smoke
  ✓ 22-healthz-smoke (2 tests)
  ✓ 4-api-auth-register-login (6 tests — all 6 scenarios, incl. Scenario 5 cookie-carrier GET /api/user)
  8 passed (6.4s)

$ API_URL=http://localhost:3101 pnpm test:conformance:smoke
  requests: 1/1, assertions: 2/2
```

Note on baseURL choice: the spec file `4-api-auth-register-login.spec.ts` Scenario 5 is sensitive to `baseURL=http://127.0.0.1:3101` because the session cookie's `Domain=localhost` attribute makes curl/Playwright reject re-use when the client addresses the server by IP. Pre-existing to this PR (confirmed by running the identical spec on `cef7854` baseline — same failure). With `baseURL=http://localhost`, all 8 smokes pass.

### Portability check

```
$ git diff latest..HEAD | grep -E '^\+' | grep -vE '^\+\+\+' | grep -iE 'localhost:[0-9]|/home/[a-z]|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{20,}'
(no matches — clean)
```

`JWT_CLOCK_SKEW_SECONDS` is declared in `.env` via `scripts/dev-bootstrap.sh` (falls back to the 5s default when unset — `config.ts` handles the `??`). No hardcoded port/host anywhere in the middleware or service.

### Infra (if touched)

No infra / IaC change. Application code + first vitest wiring.

## Flag activation plan

Not applicable — no feature flag introduced.
