### PR TITLE
feat(web): register + login pages with conform-to server actions (#16)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,9 +10,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@conform-to/react": "^1.19.1",
+    "@conform-to/zod": "^1.19.1",
     "next": "16.2.4",
     "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.4",

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,11 +1,27 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { LoginForm } from "@/features/auth/LoginForm";
+import { isAuthenticated } from "@/features/auth/session";
 
 export const metadata = { title: "Sign in — Conduit" };
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  if (await isAuthenticated()) {
+    redirect("/");
+  }
   return (
-    <ComingSoon title="Sign in">
-      <p>The login form and server action land in issue #16.</p>
-    </ComingSoon>
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Sign in</h1>
+            <p className="text-xs-center">
+              <Link href="/register">Need an account?</Link>
+            </p>
+            <LoginForm />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -1,11 +1,27 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { RegisterForm } from "@/features/auth/RegisterForm";
+import { isAuthenticated } from "@/features/auth/session";
 
 export const metadata = { title: "Sign up — Conduit" };
 
-export default function RegisterPage() {
+export default async function RegisterPage() {
+  if (await isAuthenticated()) {
+    redirect("/");
+  }
   return (
-    <ComingSoon title="Sign up">
-      <p>The registration form and server action land in issue #16.</p>
-    </ComingSoon>
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Sign up</h1>
+            <p className="text-xs-center">
+              <Link href="/login">Have an account?</Link>
+            </p>
+            <RegisterForm />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -187,3 +187,84 @@ footer .attribution {
   color: var(--conduit-green);
   margin-bottom: 1rem;
 }
+
+/* ── Auth pages (sign in / sign up) ────────────────────────── */
+
+.auth-page {
+  padding: 1.5rem 0;
+}
+
+.auth-page h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.auth-page p {
+  margin-bottom: 1rem;
+}
+
+.auth-page .error-messages {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  color: #b85c5c;
+  font-weight: 700;
+}
+
+.auth-page .error-messages li {
+  margin: 0;
+}
+
+.form-group {
+  border: 0;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+.form-control,
+.form-control-lg {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #55595c;
+  background-color: #ffffff;
+  background-image: none;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.3rem;
+}
+
+.form-control-lg {
+  padding: 1rem 1.25rem;
+  font-size: 1.25rem;
+}
+
+.btn-primary {
+  color: #ffffff;
+  background-color: var(--conduit-green);
+  border-color: var(--conduit-green);
+  padding: 0.5rem 1rem;
+  border-radius: 0.3rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: var(--conduit-green-dark);
+  border-color: var(--conduit-green-dark);
+}
+
+.btn-lg {
+  padding: 0.75rem 1.5rem;
+  font-size: 1.25rem;
+}
+
+.pull-xs-right {
+  float: right;
+}
+
+.text-xs-center {
+  text-align: center;
+}

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useActionState } from "react";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { loginAction } from "./actions";
+import { loginSchema } from "./schema";
+
+type LastResult = {
+  initialValue?: Record<string, string | string[] | undefined>;
+} | null;
+
+const echoed = (lastResult: LastResult, field: string): string => {
+  const raw = lastResult?.initialValue?.[field];
+  return typeof raw === "string" ? raw : "";
+};
+
+export const LoginForm = () => {
+  const [lastResult, action] = useActionState(loginAction, null);
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate: ({ formData }) =>
+      parseWithZod(formData, { schema: loginSchema }),
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
+
+  const formErrors = form.errors ?? [];
+  const emailErrors = fields.email.errors ?? [];
+  const passwordErrors = fields.password.errors ?? [];
+  const allErrors = [...formErrors, ...emailErrors, ...passwordErrors];
+
+  const typed = lastResult as LastResult;
+  const remountKey = typed?.initialValue
+    ? `echo-${echoed(typed, "email")}`
+    : "initial";
+
+  return (
+    <form id={form.id} action={action} onSubmit={form.onSubmit} noValidate>
+      {allErrors.length > 0 ? (
+        <ul className="error-messages">
+          {allErrors.map((msg) => (
+            <li key={msg}>{msg}</li>
+          ))}
+        </ul>
+      ) : null}
+      <fieldset className="form-group">
+        <input
+          key={`email-${remountKey}`}
+          id={fields.email.id}
+          form={fields.email.formId}
+          type="email"
+          name={fields.email.name}
+          defaultValue={echoed(typed, "email")}
+          className="form-control form-control-lg"
+          placeholder="Email"
+          aria-invalid={emailErrors.length > 0 || undefined}
+          aria-describedby={
+            emailErrors.length > 0 ? fields.email.errorId : undefined
+          }
+        />
+      </fieldset>
+      <fieldset className="form-group">
+        <input
+          key={`password-${remountKey}`}
+          id={fields.password.id}
+          form={fields.password.formId}
+          type="password"
+          name={fields.password.name}
+          className="form-control form-control-lg"
+          placeholder="Password"
+          autoComplete="current-password"
+          aria-invalid={passwordErrors.length > 0 || undefined}
+          aria-describedby={
+            passwordErrors.length > 0 ? fields.password.errorId : undefined
+          }
+        />
+      </fieldset>
+      <button className="btn btn-lg btn-primary pull-xs-right" type="submit">
+        Sign in
+      </button>
+    </form>
+  );
+};

--- a/apps/web/src/features/auth/RegisterForm.tsx
+++ b/apps/web/src/features/auth/RegisterForm.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useActionState } from "react";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { registerAction } from "./actions";
+import { registerSchema } from "./schema";
+
+// Conform-wrapped register form. Progressive enhancement: the `<form
+// action={...}>` prop works without JS by posting to the Server Action
+// route, and `useActionState` layers client-side re-render on top once
+// JS runs. Client-side zod validation (`onValidate`) short-circuits the
+// network call for purely-structural mistakes — the matching server-
+// side parse in the action is the source of truth.
+//
+// When the server action replies with an error, its SubmissionResult
+// carries the submitted payload in `initialValue`. We thread that
+// straight onto the inputs' `defaultValue` (keyed so React remounts
+// with the new defaults) — conform-to's internal `defaultValue`
+// snapshots on first mount only, so it won't rehydrate the inputs
+// for us on the re-render. Spec #16 AC: "username and email are
+// preserved (not cleared)" after a 422 from the API.
+
+type LastResult = {
+  initialValue?: Record<string, string | string[] | undefined>;
+} | null;
+
+const echoed = (lastResult: LastResult, field: string): string => {
+  const raw = lastResult?.initialValue?.[field];
+  return typeof raw === "string" ? raw : "";
+};
+
+export const RegisterForm = () => {
+  const [lastResult, action] = useActionState(registerAction, null);
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate: ({ formData }) =>
+      parseWithZod(formData, { schema: registerSchema }),
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
+
+  const formErrors = form.errors ?? [];
+  const usernameErrors = fields.username.errors ?? [];
+  const emailErrors = fields.email.errors ?? [];
+  const passwordErrors = fields.password.errors ?? [];
+  const allErrors = [
+    ...formErrors,
+    ...usernameErrors,
+    ...emailErrors,
+    ...passwordErrors,
+  ];
+
+  const typed = lastResult as LastResult;
+  // Keys flip on every reply so React remounts the inputs with the
+  // freshly-echoed defaults.
+  const remountKey = typed?.initialValue
+    ? `echo-${echoed(typed, "username")}-${echoed(typed, "email")}`
+    : "initial";
+
+  return (
+    <form id={form.id} action={action} onSubmit={form.onSubmit} noValidate>
+      {allErrors.length > 0 ? (
+        <ul className="error-messages">
+          {allErrors.map((msg) => (
+            <li key={msg}>{msg}</li>
+          ))}
+        </ul>
+      ) : null}
+      <fieldset className="form-group">
+        <input
+          key={`username-${remountKey}`}
+          id={fields.username.id}
+          form={fields.username.formId}
+          type="text"
+          name={fields.username.name}
+          defaultValue={echoed(typed, "username")}
+          className="form-control form-control-lg"
+          placeholder="Your Name"
+          aria-invalid={usernameErrors.length > 0 || undefined}
+          aria-describedby={
+            usernameErrors.length > 0 ? fields.username.errorId : undefined
+          }
+        />
+      </fieldset>
+      <fieldset className="form-group">
+        <input
+          key={`email-${remountKey}`}
+          id={fields.email.id}
+          form={fields.email.formId}
+          type="email"
+          name={fields.email.name}
+          defaultValue={echoed(typed, "email")}
+          className="form-control form-control-lg"
+          placeholder="Email"
+          aria-invalid={emailErrors.length > 0 || undefined}
+          aria-describedby={
+            emailErrors.length > 0 ? fields.email.errorId : undefined
+          }
+        />
+      </fieldset>
+      <fieldset className="form-group">
+        <input
+          key={`password-${remountKey}`}
+          id={fields.password.id}
+          form={fields.password.formId}
+          type="password"
+          name={fields.password.name}
+          className="form-control form-control-lg"
+          placeholder="Password"
+          autoComplete="new-password"
+          aria-invalid={passwordErrors.length > 0 || undefined}
+          aria-describedby={
+            passwordErrors.length > 0 ? fields.password.errorId : undefined
+          }
+        />
+      </fieldset>
+      <button className="btn btn-lg btn-primary pull-xs-right" type="submit">
+        Sign up
+      </button>
+    </form>
+  );
+};

--- a/apps/web/src/features/auth/actions.ts
+++ b/apps/web/src/features/auth/actions.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { apiFetch } from "@/lib/api/client";
+import { loginSchema, registerSchema } from "./schema";
+import { writeSession } from "./session";
+
+// Pattern adapted from yukicountry/realworld-nextjs-rsc @ f455599f
+// (`src/modules/features/auth/actions.ts`, MIT). The shape — Server
+// Action + @conform-to/zod parse + SubmissionResult reply on failure —
+// is the same; the transport is ours (our cookie-first API per ADR 004,
+// not the demo remote).
+//
+// Failure returns a SubmissionResult so @conform-to/react can render
+// per-field errors on the client. Success redirects, which throws the
+// special NEXT_REDIRECT — we never return from the success branch.
+
+type UserEnvelope = {
+  user: {
+    email: string;
+    token: string;
+    username: string;
+    bio: string | null;
+    image: string | null;
+  };
+};
+
+type ApiErrors = { errors?: Record<string, string[]> };
+
+// Map the API's 422 `{ errors: { email: ["has already been taken"] } }`
+// into conform-to's `{ field: [msg] }` shape, keying every error under
+// the form's canonical field name so the inline error element renders
+// next to the right input. Unknown keys (e.g. the API's generic "body"
+// validation failures) surface on the form root.
+const mergeApiErrors = (
+  api: ApiErrors,
+  knownFields: readonly string[],
+): Record<string, string[]> => {
+  const out: Record<string, string[]> = {};
+  for (const [field, msgs] of Object.entries(api.errors ?? {})) {
+    if (knownFields.includes(field)) {
+      out[field] = msgs.map((m) => `${field} ${m}`);
+    } else {
+      out[""] = [...(out[""] ?? []), ...msgs.map((m) => `${field} ${m}`)];
+    }
+  }
+  if (Object.keys(out).length === 0) {
+    out[""] = ["something went wrong — please try again"];
+  }
+  return out;
+};
+
+export const registerAction = async (
+  _prev: unknown,
+  formData: FormData,
+) => {
+  const submission = parseWithZod(formData, { schema: registerSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const res = await apiFetch<UserEnvelope>("/api/users", {
+    method: "POST",
+    body: JSON.stringify({ user: submission.value }),
+  });
+
+  if (!res.ok) {
+    if (res.status === 422) {
+      return submission.reply({
+        fieldErrors: mergeApiErrors(res.data, ["username", "email", "password"]),
+      });
+    }
+    return submission.reply({
+      formErrors: ["server error — please try again"],
+    });
+  }
+
+  await writeSession(res.setCookie, {
+    username: res.data.user.username,
+    image: res.data.user.image,
+  });
+  redirect("/");
+};
+
+export const loginAction = async (
+  _prev: unknown,
+  formData: FormData,
+) => {
+  const submission = parseWithZod(formData, { schema: loginSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const res = await apiFetch<UserEnvelope>("/api/users/login", {
+    method: "POST",
+    body: JSON.stringify({ user: submission.value }),
+  });
+
+  if (!res.ok) {
+    // 401 here means "email or password is invalid" — the API emits
+    // `{ errors: { "email or password": ["is invalid"] } }`. The key
+    // has a space in it (spec-mandated), so we surface it as a form-
+    // level error rather than trying to map it to a field.
+    if (res.status === 401) {
+      return submission.reply({
+        formErrors: ["email or password is invalid"],
+      });
+    }
+    if (res.status === 422) {
+      return submission.reply({
+        fieldErrors: mergeApiErrors(res.data, ["email", "password"]),
+      });
+    }
+    return submission.reply({
+      formErrors: ["server error — please try again"],
+    });
+  }
+
+  await writeSession(res.setCookie, {
+    username: res.data.user.username,
+    image: res.data.user.image,
+  });
+  redirect("/");
+};

--- a/apps/web/src/features/auth/schema.ts
+++ b/apps/web/src/features/auth/schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// The shapes mirror the API's RegisterRequestSchema / LoginRequestSchema
+// field-for-field so server-side validation rejects the same inputs the
+// API would, preventing a wasted round-trip when JS is on (scenario 3
+// in issue #16). Error messages here are what the user sees inline;
+// API-origin errors (e.g. "email has already been taken") are merged in
+// the server action after a 422 response.
+
+export const registerSchema = z.object({
+  username: z
+    .string({ message: "username can't be blank" })
+    .min(1, "username can't be blank")
+    .max(100, "username is too long (maximum is 100 characters)"),
+  email: z
+    .string({ message: "email can't be blank" })
+    .min(1, "email can't be blank")
+    .email("email must be a valid email"),
+  password: z
+    .string({ message: "password can't be blank" })
+    .min(1, "password can't be blank")
+    .min(8, "password is too short (minimum is 8 characters)"),
+});
+
+export const loginSchema = z.object({
+  email: z
+    .string({ message: "email can't be blank" })
+    .min(1, "email can't be blank")
+    .email("email must be a valid email"),
+  password: z
+    .string({ message: "password can't be blank" })
+    .min(1, "password can't be blank"),
+});
+
+export type RegisterInput = z.infer<typeof registerSchema>;
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/apps/web/src/features/auth/session.ts
+++ b/apps/web/src/features/auth/session.ts
@@ -1,0 +1,99 @@
+import "server-only";
+import { cookies } from "next/headers";
+
+// Server-only session helpers.
+//
+// Two cookies are in play:
+//   - `conduit_session` (HttpOnly) — JWT carried inbound on every API
+//     request, set by the API. The web server receives it in the
+//     `Set-Cookie` response header and re-emits it to the browser on
+//     the web origin so future requests carry it.
+//   - `conduit-user` (readable server-side via `cookies()`) — small
+//     JSON blob `{ username, image }` the Navbar reads to render the
+//     authed chrome. It is not a credential, purely presentation.
+//
+// Keeping `conduit_session` HttpOnly means the web server is the only
+// place that touches the raw JWT. That matches ADR 004's cookie-first
+// transport posture end-to-end.
+
+export const SESSION_COOKIE = "conduit_session";
+export const USER_COOKIE = "conduit-user";
+
+// The API response carries one or more `Set-Cookie` headers. We only
+// need the conduit_session value + its Max-Age; attributes (HttpOnly,
+// SameSite, Path, Secure, Domain) are set deterministically by the web
+// layer based on its own env (WEB_COOKIE_SECURE / COOKIE_DOMAIN). That
+// way the web origin doesn't accidentally inherit the API's domain
+// attribute when they live on different hostnames.
+const parseSessionCookie = (
+  setCookie: string[],
+): { value: string; maxAge: number } | null => {
+  for (const raw of setCookie) {
+    const [kv, ...attrs] = raw.split(";").map((s) => s.trim());
+    const eq = kv.indexOf("=");
+    if (eq < 0) continue;
+    const name = kv.slice(0, eq);
+    const value = kv.slice(eq + 1);
+    if (name !== SESSION_COOKIE) continue;
+    let maxAge = 604800;
+    for (const attr of attrs) {
+      const [k, v] = attr.split("=");
+      if (k?.toLowerCase() === "max-age" && v) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n > 0) maxAge = n;
+      }
+    }
+    return { value, maxAge };
+  }
+  return null;
+};
+
+type UserForNav = { username: string; image: string | null };
+
+const cookieSecure = process.env.COOKIE_SECURE === "true";
+const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
+
+export const writeSession = async (
+  setCookie: string[],
+  user: UserForNav,
+): Promise<void> => {
+  const session = parseSessionCookie(setCookie);
+  if (!session) {
+    throw new Error("API did not set conduit_session cookie");
+  }
+  const jar = await cookies();
+  jar.set(SESSION_COOKIE, session.value, {
+    httpOnly: true,
+    secure: cookieSecure,
+    sameSite: "lax",
+    path: "/",
+    maxAge: session.maxAge,
+    domain: cookieDomain,
+  });
+  jar.set(
+    USER_COOKIE,
+    encodeURIComponent(
+      JSON.stringify({ username: user.username, image: user.image }),
+    ),
+    {
+      httpOnly: false,
+      secure: cookieSecure,
+      sameSite: "lax",
+      path: "/",
+      maxAge: session.maxAge,
+      domain: cookieDomain,
+    },
+  );
+};
+
+export const readSessionCookie = async (): Promise<string | null> => {
+  const jar = await cookies();
+  return jar.get(SESSION_COOKIE)?.value ?? null;
+};
+
+export const isAuthenticated = async (): Promise<boolean> => {
+  const jar = await cookies();
+  // Either cookie is enough to treat the viewer as authed for redirect
+  // purposes; the API will reject forged tokens on its own.
+  return Boolean(jar.get(SESSION_COOKIE)?.value || jar.get(USER_COOKIE)?.value);
+};

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,0 +1,58 @@
+// Minimal fetch wrapper for server-side API calls.
+//
+// Pattern adapted from yukicountry/realworld-nextjs-rsc @ f455599f
+// (`src/utils/api/client.ts`, MIT) — we keep the "fetch JSON, return
+// envelope" shape but strip the runtime-validated zod parsing for now.
+// The wrapper is server-only: `API_URL` points at the internal
+// container hostname (`http://api:3001` inside compose), which must
+// not leak into the browser bundle.
+//
+// Response shape is intentionally raw — the API's envelope
+// (`{ user }` / `{ errors }`) is what the caller asserts against,
+// so the wrapper stays schema-agnostic.
+
+import "server-only";
+
+export type ApiResult<T> =
+  | { ok: true; status: number; data: T; setCookie: string[] }
+  | { ok: false; status: number; data: { errors?: Record<string, string[]> }; setCookie: string[] };
+
+const API_URL = process.env.API_URL ?? "http://localhost:3001";
+
+// Node's fetch collapses multiple Set-Cookie headers into a single
+// comma-joined string on `headers.get("set-cookie")`. `getSetCookie`
+// is the Node 20+ / undici way to get them as a proper list.
+const readSetCookie = (headers: Headers): string[] => {
+  const h = headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof h.getSetCookie === "function") {
+    return h.getSetCookie();
+  }
+  const raw = headers.get("set-cookie");
+  return raw ? [raw] : [];
+};
+
+export const apiFetch = async <T>(
+  path: string,
+  init: RequestInit & { cookie?: string } = {},
+): Promise<ApiResult<T>> => {
+  const { cookie, headers: initHeaders, ...rest } = init;
+  const headers = new Headers(initHeaders);
+  headers.set("Content-Type", "application/json");
+  headers.set("Accept", "application/json");
+  if (cookie) headers.set("cookie", cookie);
+
+  const res = await fetch(`${API_URL}${path}`, {
+    ...rest,
+    headers,
+    cache: "no-store",
+  });
+
+  const text = await res.text();
+  const data = text.length > 0 ? JSON.parse(text) : {};
+  const setCookie = readSetCookie(res.headers);
+
+  if (!res.ok) {
+    return { ok: false, status: res.status, data, setCookie };
+  }
+  return { ok: true, status: res.status, data: data as T, setCookie };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@conform-to/react':
+        specifier: ^1.19.1
+        version: 1.19.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@conform-to/zod':
+        specifier: ^1.19.1
+        version: 1.19.1(zod@4.3.6)
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -84,6 +90,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: 4.2.4
@@ -194,6 +203,20 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@conform-to/dom@1.19.1':
+    resolution: {integrity: sha512-h4/T04zgASuiHMVEiXiyQA4jIW9zhpVFbp0HrWCQUDBxd8Zc1JbTarR7cuJyzkmqshC4tdm4VKIHguLp+7AYCw==}
+
+  '@conform-to/react@1.19.1':
+    resolution: {integrity: sha512-RrSfpy3B7bn1RoXCztlmQYMs113AWcvtqAluDqAx4yVbbVB+EcHWc3Ze/EXJhbtFDmljT2nMtcx/VY8f2RPGFg==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@conform-to/zod@1.19.1':
+    resolution: {integrity: sha512-S/C+Byhk87RdutjCuxhKcDf9lrmTx0V1OrtZPt5zrVG3RqcXVZz3NvLLZ7pNqdSg5DHGvuzPuotGfmPVu936ow==}
+    peerDependencies:
+      zod: ^3.21.0 || ^4.0.0
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -3301,6 +3324,19 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@conform-to/dom@1.19.1': {}
+
+  '@conform-to/react@1.19.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@conform-to/dom': 1.19.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@conform-to/zod@1.19.1(zod@4.3.6)':
+    dependencies:
+      '@conform-to/dom': 1.19.1
+      zod: 4.3.6
+
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
       '@electric-sql/pglite': 0.4.1
@@ -4622,8 +4658,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.38.0(jiti@2.6.1))
@@ -4645,7 +4681,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4656,21 +4692,21 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4681,7 +4717,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/tests/e2e/specs/16-web-auth-register-login.spec.ts
+++ b/tests/e2e/specs/16-web-auth-register-login.spec.ts
@@ -1,0 +1,248 @@
+import { expect, test } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+
+// BDD coverage for issue #16: register + login pages backed by Next.js
+// Server Actions. Exercises the UI against the live compose web +
+// API stack; nothing here mocks the API so a regression in the auth
+// transport or the session-cookie handling also shows up here.
+//
+// Each scenario gets a fresh user (unique email / username suffix) so
+// runs are independent of DB state. The only precondition is "web +
+// api + postgres healthy".
+
+const SCREENSHOT_DIR = "tests/e2e/screenshots/16";
+const SESSION_COOKIE = "conduit_session";
+const USER_COOKIE = "conduit-user";
+
+const uniq = () => `${Date.now()}${Math.floor(Math.random() * 1e4)}`;
+
+test.beforeAll(async () => {
+  await mkdir(SCREENSHOT_DIR, { recursive: true });
+});
+
+test.describe("issue #16 — web register / login", () => {
+  test("Scenario 1: register with valid data lands logged in on /", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const username = `jake${id}`;
+    await page.goto("/register");
+    await page.getByPlaceholder("Your Name").fill(username);
+    await page.getByPlaceholder("Email").fill(`${username}@jake.jake`);
+    await page.getByPlaceholder("Password").fill("jakejake");
+
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign up" }).click(),
+    ]);
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(
+      page.locator("nav.navbar").getByRole("link", { name: new RegExp(`@${username}`) }),
+    ).toBeVisible();
+
+    const cookieNames = (await context.cookies()).map((c) => c.name);
+    expect(cookieNames).toContain(SESSION_COOKIE);
+    expect(cookieNames).toContain(USER_COOKIE);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-1-register-success.png`,
+    });
+  });
+
+  test("Scenario 2: duplicate email shows inline error and preserves inputs", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const username = `jake${id}`;
+    const email = `${username}@jake.jake`;
+
+    // Seed: register once, then log out by clearing cookies so the
+    // second attempt sees the duplicate-email path, not the
+    // "already authed → redirect" path.
+    await page.goto("/register");
+    await page.getByPlaceholder("Your Name").fill(username);
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("jakejake");
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign up" }).click(),
+    ]);
+    await page.context().clearCookies();
+
+    await page.goto("/register");
+    const secondUsername = `dupe${id}`;
+    await page.getByPlaceholder("Your Name").fill(secondUsername);
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("jakejake");
+    await page.getByRole("button", { name: "Sign up" }).click();
+
+    await expect(page).toHaveURL(/\/register/);
+    await expect(page.locator(".error-messages")).toContainText(
+      "email has already been taken",
+    );
+    // Inputs are preserved — conform-to's reply() echoes submitted
+    // values back on the next render.
+    await expect(page.getByPlaceholder("Your Name")).toHaveValue(secondUsername);
+    await expect(page.getByPlaceholder("Email")).toHaveValue(email);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-2-duplicate-email.png`,
+    });
+  });
+
+  test("Scenario 3: invalid input shows per-field errors and stays on /register", async ({
+    page,
+  }) => {
+    await page.goto("/register");
+
+    await page.getByPlaceholder("Your Name").fill("jake");
+    await page.getByPlaceholder("Email").fill("notAnEmail");
+    // Tab off email to trigger conform-to's onBlur validation.
+    await page.getByPlaceholder("Email").press("Tab");
+    await page.getByRole("button", { name: "Sign up" }).click();
+
+    // Client-side zod intercepts the submit; the page never navigates.
+    await expect(page).toHaveURL(/\/register/);
+    const errors = page.locator(".error-messages");
+    await expect(errors).toContainText("email must be a valid email");
+    await expect(errors).toContainText("password can't be blank");
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-3-invalid-input.png`,
+    });
+  });
+
+  test("Scenario 4: login with correct credentials redirects to /", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const username = `login${id}`;
+    const email = `${username}@jake.jake`;
+
+    await page.goto("/register");
+    await page.getByPlaceholder("Your Name").fill(username);
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("jakejake");
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign up" }).click(),
+    ]);
+    await page.context().clearCookies();
+
+    await page.goto("/login");
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("jakejake");
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign in" }).click(),
+    ]);
+    await expect(page).toHaveURL(/\/$/);
+    await expect(
+      page.locator("nav.navbar").getByRole("link", { name: new RegExp(`@${username}`) }),
+    ).toBeVisible();
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-4-login-success.png`,
+    });
+  });
+
+  test("Scenario 5: login with wrong password shows form-level error", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const username = `wrong${id}`;
+    const email = `${username}@jake.jake`;
+
+    await page.goto("/register");
+    await page.getByPlaceholder("Your Name").fill(username);
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("jakejake");
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign up" }).click(),
+    ]);
+    await page.context().clearCookies();
+
+    await page.goto("/login");
+    await page.getByPlaceholder("Email").fill(email);
+    await page.getByPlaceholder("Password").fill("wrongwrong");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.locator(".error-messages")).toContainText(
+      "email or password is invalid",
+    );
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-5-login-wrong-password.png`,
+    });
+  });
+
+  test("Scenario 6: register works with JavaScript disabled (progressive enhancement)", async ({
+    browser,
+  }) => {
+    // A fresh browser context with JS disabled simulates a visitor
+    // who has toggled JS off in devtools. The <form action={action}>
+    // still targets the Server Action endpoint; Next.js handles the
+    // native POST without any client-side hydration.
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    const id = uniq();
+    const username = `nojs${id}`;
+
+    await page.goto("/register");
+    await page.getByPlaceholder("Your Name").fill(username);
+    await page.getByPlaceholder("Email").fill(`${username}@jake.jake`);
+    await page.getByPlaceholder("Password").fill("jakejake");
+
+    await Promise.all([
+      page.waitForURL("**/"),
+      page.getByRole("button", { name: "Sign up" }).click(),
+    ]);
+    await expect(page).toHaveURL(/\/$/);
+    const cookieNames = (await context.cookies()).map((c) => c.name);
+    expect(cookieNames).toContain(SESSION_COOKIE);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-6-progressive-enhancement.png`,
+    });
+    await context.close();
+  });
+
+  test("Scenario 7: already-authenticated visitor skips /login and /register", async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    // Pretend the visitor is already authed by seeding the USER_COOKIE
+    // directly — we don't need the real JWT for this scenario because
+    // the redirect logic keys off cookie presence, not validity.
+    const url = new URL(baseURL ?? "http://localhost:3100");
+    await context.addCookies([
+      {
+        name: USER_COOKIE,
+        value: encodeURIComponent(
+          JSON.stringify({ username: "jake", image: null }),
+        ),
+        domain: url.hostname,
+        path: "/",
+        httpOnly: false,
+        secure: false,
+        sameSite: "Lax",
+      },
+    ]);
+
+    for (const path of ["/login", "/register"]) {
+      const res = await page.goto(path);
+      // Next.js redirects follow the 307/308 chain; the final URL is /.
+      expect(res?.url()).toMatch(/\/$/);
+      await expect(page).toHaveURL(/\/$/);
+    }
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/scenario-7-already-authed.png`,
+    });
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8io0]

Closes #16

## User Intent

A visitor fills `/register` (username + email + password) or `/login` (email + password), submits, and lands on `/` as a logged-in user. Server-side validation errors display inline; the API's 422/401 errors are surfaced on the form without a redirect; inputs preserve what the user typed; the pages work without JavaScript; and an already-authenticated visitor to `/login`/`/register` is redirected to `/`.

## Upstream reuse

Adapted from `yukicountry/realworld-nextjs-rsc @ f455599f` (MIT) — Server Action + `@conform-to/zod` form pattern per ADR `docs/adr/000-reference-review.md §3, §10`. The transport is ours (cookie-first per ADR 004). Attribution header referenced in `apps/web/src/features/auth/actions.ts` and `apps/web/src/lib/api/client.ts`.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -f infra/docker-compose.yml --env-file .env ps
NAME                 SERVICE    STATUS                        PORTS
conduit-api-1        api        Up 8 minutes (healthy)        0.0.0.0:3101->3001/tcp
conduit-postgres-1   postgres   Up 10 minutes (healthy)       0.0.0.0:5433->5432/tcp
conduit-web-1        web        Up About a minute (healthy)   0.0.0.0:3100->3000/tcp
```

### BDD scenarios

All 7 scenarios from the issue body are covered in `tests/e2e/specs/16-web-auth-register-login.spec.ts`. Run:
`PLAYWRIGHT_BASE_URL=http://localhost:3100 API_URL=http://localhost:3101 pnpm exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/specs/16-web-auth-register-login.spec.ts`

- ✓ Scenario 1: register with valid data lands logged in on / — `tests/e2e/screenshots/16/scenario-1-register-success.png`
- ✓ Scenario 2: duplicate email shows inline error and preserves inputs — `scenario-2-duplicate-email.png`
- ✓ Scenario 3: invalid input shows per-field errors and stays on `/register` — `scenario-3-invalid-input.png`
- ✓ Scenario 4: login with correct credentials redirects to `/` — `scenario-4-login-success.png`
- ✓ Scenario 5: login with wrong password shows form-level error — `scenario-5-login-wrong-password.png`
- ✓ Scenario 6: register works with JavaScript disabled (progressive enhancement) — `scenario-6-progressive-enhancement.png`
- ✓ Scenario 7: already-authenticated visitor skips `/login` and `/register` — `scenario-7-already-authed.png`

### Full local E2E

```
Running 20 tests using 1 worker
  20 passed (10.5s)
```

Suites: `15-web-layout-shell` (5 ✓), `16-web-auth-register-login` (7 ✓), `22-healthz-smoke` (2 ✓), `4-api-auth-register-login` (6 ✓). Command: `PLAYWRIGHT_BASE_URL=http://localhost:3100 API_URL=http://localhost:3101 pnpm exec playwright test --config tests/e2e/playwright.config.ts`.

Newman conformance smoke green: `API_URL=http://localhost:3101 pnpm test:conformance:smoke` → 2/2 assertions, `tests/api/results/20260429T034405Z.xml`.

### Portability check

```
$ grep -rn "localhost:[0-9]\|http://localhost\|127\.0\.0\.1:" apps/web/src/ apps/api/src/
apps/web/src/lib/api/client.ts:20:const API_URL = process.env.API_URL ?? "http://localhost:3001";
apps/api/src/config.ts:16:  webUrl: required("WEB_URL", "http://localhost:3000"),
```

Both sites are env-driven defaults; compose overrides with `API_URL=http://api:3001` and `WEB_URL=http://localhost:3100`. No new hardcoded hosts, no inline secrets, no absolute host paths.

### Root quality gates

- `pnpm typecheck` — ✓ both apps
- `pnpm lint` — ✓ both apps
- `pnpm --filter @conduit/web build` — ✓ (production build clean)

### Infra

No infra change. Compose + API unchanged; only `apps/web/**` and the new E2E spec moved.
