### PR TITLE
feat(api): profiles — view + follow / unfollow (#7)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { requestId, type RequestIdVars } from "./middleware/request-id.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerHealthzRoute } from "./routes/healthz.js";
 import { registerInternalThrowRoute } from "./routes/internal-throw.js";
+import { registerProfileRoutes } from "./routes/profiles.js";
 
 export type AppEnv = { Variables: RequestIdVars };
 
@@ -21,6 +22,7 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
 
   registerHealthzRoute(app);
   registerAuthRoutes(app);
+  registerProfileRoutes(app);
   registerInternalThrowRoute(app);
 
   app.doc("/docs/json", {

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -1,0 +1,142 @@
+import { createRoute, type OpenAPIHono } from "@hono/zod-openapi";
+import type { AppEnv } from "../app.js";
+import {
+  ProfileError,
+  followUser,
+  getProfile,
+  unfollowUser,
+} from "../services/profile.service.js";
+import { optionalAuth, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
+import { ErrorResponseSchema } from "../schemas/user.js";
+import { ProfileResponseSchema } from "../schemas/profile.js";
+import { z } from "@hono/zod-openapi";
+
+type ProfileVars = AppEnv["Variables"] & UserVars;
+type ProfileEnv = { Variables: ProfileVars };
+
+const UsernameParam = z
+  .object({
+    username: z.string().min(1).openapi({ param: { name: "username", in: "path" } }),
+  })
+  .openapi("UsernameParam");
+
+const jsonError = (field: string, detail: string) => ({
+  errors: { [field]: [detail] },
+});
+
+const getProfileRoute = createRoute({
+  method: "get",
+  path: "/api/profiles/{username}",
+  tags: ["profiles"],
+  summary: "View a user's profile",
+  request: { params: UsernameParam },
+  responses: {
+    200: {
+      description: "Profile",
+      content: { "application/json": { schema: ProfileResponseSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const followRoute = createRoute({
+  method: "post",
+  path: "/api/profiles/{username}/follow",
+  tags: ["profiles"],
+  summary: "Follow a user",
+  request: { params: UsernameParam },
+  responses: {
+    200: {
+      description: "Followed",
+      content: { "application/json": { schema: ProfileResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Unprocessable entity",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const unfollowRoute = createRoute({
+  method: "delete",
+  path: "/api/profiles/{username}/follow",
+  tags: ["profiles"],
+  summary: "Unfollow a user",
+  request: { params: UsernameParam },
+  responses: {
+    200: {
+      description: "Unfollowed",
+      content: { "application/json": { schema: ProfileResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const registerProfileRoutes = (app: OpenAPIHono<AppEnv>): void => {
+  const authed = app as unknown as OpenAPIHono<ProfileEnv>;
+
+  authed.use(getProfileRoute.getRoutingPath(), optionalAuth());
+  authed.openapi(getProfileRoute, async (c) => {
+    const viewer = c.get("user");
+    const { username } = c.req.valid("param");
+    try {
+      const profile = await getProfile(username, viewer?.id ?? null);
+      return c.json({ profile }, 200);
+    } catch (err) {
+      if (err instanceof ProfileError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
+      }
+      throw err;
+    }
+  });
+
+  authed.use(followRoute.getRoutingPath(), requireAuth());
+  authed.openapi(followRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { username } = c.req.valid("param");
+    try {
+      const profile = await followUser(viewer.id, username);
+      return c.json({ profile }, 200);
+    } catch (err) {
+      if (err instanceof ProfileError) {
+        if (err.status === 404) return c.json(jsonError(err.field, err.detail), 404);
+        return c.json(jsonError(err.field, err.detail), 422);
+      }
+      throw err;
+    }
+  });
+
+  authed.openapi(unfollowRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { username } = c.req.valid("param");
+    try {
+      const profile = await unfollowUser(viewer.id, username);
+      return c.json({ profile }, 200);
+    } catch (err) {
+      if (err instanceof ProfileError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
+      }
+      throw err;
+    }
+  });
+};

--- a/apps/api/src/schemas/profile.ts
+++ b/apps/api/src/schemas/profile.ts
@@ -1,0 +1,14 @@
+import { z } from "@hono/zod-openapi";
+
+export const ProfileSchema = z
+  .object({
+    username: z.string(),
+    bio: z.string().nullable(),
+    image: z.string().nullable(),
+    following: z.boolean(),
+  })
+  .openapi("Profile");
+
+export const ProfileResponseSchema = z
+  .object({ profile: ProfileSchema })
+  .openapi("ProfileResponse");

--- a/apps/api/src/services/profile.service.ts
+++ b/apps/api/src/services/profile.service.ts
@@ -1,0 +1,116 @@
+import { prisma } from "../prisma/client.js";
+
+// Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5
+// (`src/app/routes/services/profile.service.ts`, attribution). Behaviour
+// stays spec-conformant: getProfile returns the viewer-relative
+// `following` boolean; follow/unfollow toggle the implicit many-to-many
+// `UserFollows` relation via `connect`/`disconnect`.
+//
+// Redesign vs upstream: explicit self-follow guard — upstream silently
+// accepts it, we reject with ProfileError("cannot follow yourself")
+// because letting a user follow themselves corrupts the personalised
+// feed (#11).
+
+export type ProfileEnvelope = {
+  username: string;
+  bio: string | null;
+  image: string | null;
+  following: boolean;
+};
+
+export class ProfileError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly detail: string,
+    public readonly status: 404 | 422,
+  ) {
+    super(`${field}: ${detail}`);
+    this.name = "ProfileError";
+  }
+}
+
+const toEnvelope = (
+  user: { username: string; bio: string | null; image: string | null },
+  following: boolean,
+): ProfileEnvelope => ({
+  username: user.username,
+  bio: user.bio,
+  image: user.image,
+  following,
+});
+
+// `viewerId === null` means "anonymous viewer" — `following` is always
+// false. Otherwise we read the viewer's `following` relation and check
+// whether the target user's id appears.
+const isFollowing = async (
+  viewerId: number | null,
+  targetId: number,
+): Promise<boolean> => {
+  if (viewerId === null || viewerId === targetId) return false;
+  const link = await prisma.user.findFirst({
+    where: { id: viewerId, following: { some: { id: targetId } } },
+    select: { id: true },
+  });
+  return link !== null;
+};
+
+export const getProfile = async (
+  username: string,
+  viewerId: number | null,
+): Promise<ProfileEnvelope> => {
+  const target = await prisma.user.findUnique({
+    where: { username },
+    select: { id: true, username: true, bio: true, image: true },
+  });
+  if (!target) {
+    throw new ProfileError("profile", "not found", 404);
+  }
+  const following = await isFollowing(viewerId, target.id);
+  return toEnvelope(target, following);
+};
+
+export const followUser = async (
+  viewerId: number,
+  username: string,
+): Promise<ProfileEnvelope> => {
+  const target = await prisma.user.findUnique({
+    where: { username },
+    select: { id: true, username: true, bio: true, image: true },
+  });
+  if (!target) {
+    throw new ProfileError("profile", "not found", 404);
+  }
+  if (target.id === viewerId) {
+    throw new ProfileError("profile", "cannot follow yourself", 422);
+  }
+  await prisma.user.update({
+    where: { id: viewerId },
+    data: { following: { connect: { id: target.id } } },
+  });
+  return toEnvelope(target, true);
+};
+
+export const unfollowUser = async (
+  viewerId: number,
+  username: string,
+): Promise<ProfileEnvelope> => {
+  const target = await prisma.user.findUnique({
+    where: { username },
+    select: { id: true, username: true, bio: true, image: true },
+  });
+  if (!target) {
+    throw new ProfileError("profile", "not found", 404);
+  }
+  if (target.id === viewerId) {
+    // Unfollowing yourself is a no-op — we never connected the edge, so
+    // disconnect would be a noop anyway. Return the unchanged envelope
+    // rather than 422: the spec leaves this undefined and returning 200
+    // with following=false is the least-surprising behaviour.
+    return toEnvelope(target, false);
+  }
+  await prisma.user.update({
+    where: { id: viewerId },
+    data: { following: { disconnect: { id: target.id } } },
+  });
+  return toEnvelope(target, false);
+};

--- a/tests/e2e/specs/7-api-profiles-follow.spec.ts
+++ b/tests/e2e/specs/7-api-profiles-follow.spec.ts
@@ -1,0 +1,111 @@
+import { expect, request, test } from "@playwright/test";
+
+// BDD coverage for issue #7: GET /api/profiles/:username + POST/DELETE
+// /:username/follow. Six scenarios from the issue body. Profile
+// envelope shape is spec-literal: `{ profile: { username, bio, image,
+// following } }`. The viewer's follow relationship is expressed via
+// `following: boolean` (null-viewer → false).
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const register = async (api: ReturnType<typeof request.newContext> extends Promise<infer T> ? T : never, username: string) => {
+  const res = await api.post("/api/users", {
+    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
+  });
+  expect(res.status()).toBe(201);
+};
+
+test.describe("issue #7 — API profiles (view + follow / unfollow)", () => {
+  test("Scenario 1: anonymous profile view returns following=false", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const seedApi = await request.newContext({ baseURL: API_URL });
+    await register(seedApi, jake);
+
+    const anonApi = await request.newContext({ baseURL: API_URL });
+    const res = await anonApi.get(`/api/profiles/${jake}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { profile: Record<string, unknown> };
+    expect(body.profile.username).toBe(jake);
+    expect(body.profile.bio).toBeNull();
+    expect(body.profile.image).toBeNull();
+    expect(body.profile.following).toBe(false);
+  });
+
+  test("Scenario 2: authenticated profile view reflects follow state", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await register(jakeApi, jake);
+    await register(danApi, dan);
+
+    // Before follow: dan sees following=false on jake's profile.
+    const before = await danApi.get(`/api/profiles/${jake}`);
+    expect(before.status()).toBe(200);
+    expect(((await before.json()) as { profile: { following: boolean } }).profile.following).toBe(false);
+
+    // After follow: following=true.
+    const follow = await danApi.post(`/api/profiles/${jake}/follow`);
+    expect(follow.status()).toBe(200);
+    const after = await danApi.get(`/api/profiles/${jake}`);
+    expect(((await after.json()) as { profile: { following: boolean } }).profile.following).toBe(true);
+  });
+
+  test("Scenario 3: follow and unfollow round-trip flips the flag", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await register(jakeApi, jake);
+    await register(danApi, dan);
+
+    const follow = await danApi.post(`/api/profiles/${jake}/follow`);
+    expect(follow.status()).toBe(200);
+    expect(((await follow.json()) as { profile: { following: boolean } }).profile.following).toBe(true);
+
+    const unfollow = await danApi.delete(`/api/profiles/${jake}/follow`);
+    expect(unfollow.status()).toBe(200);
+    expect(((await unfollow.json()) as { profile: { following: boolean } }).profile.following).toBe(false);
+  });
+
+  test("Scenario 4: following a non-existent user returns 404", async () => {
+    const id = uniq();
+    const dan = `dan-${id}`;
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await register(danApi, dan);
+
+    const res = await danApi.post(`/api/profiles/nobody-${id}/follow`);
+    expect(res.status()).toBe(404);
+  });
+
+  test("Scenario 5: cannot follow yourself → 422", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await register(jakeApi, jake);
+
+    const res = await jakeApi.post(`/api/profiles/${jake}/follow`);
+    expect(res.status()).toBe(422);
+    const body = (await res.json()) as { errors: Record<string, string[]> };
+    expect(body.errors.profile).toEqual(["cannot follow yourself"]);
+  });
+
+  test("Scenario 6: follow endpoints require auth", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const seedApi = await request.newContext({ baseURL: API_URL });
+    await register(seedApi, jake);
+
+    const anonApi = await request.newContext({ baseURL: API_URL });
+    const res = await anonApi.post(`/api/profiles/${jake}/follow`);
+    expect(res.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8io0]

Closes #7

## User Intent

Anyone can view a user's public profile at `GET /api/profiles/:username` and see a viewer-relative `following` boolean (anonymous viewers → `false`, self → `false`). Authenticated users can `POST /api/profiles/:username/follow` or `DELETE` it to toggle the edge, which later powers the personalised feed (#11).

## Upstream reuse

Adapted from `gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5` (attribution) — `services/profile.service.ts` (`getProfile`, `followUser`, `unfollowUser`) using Prisma implicit M2M `connect`/`disconnect`. ADR `docs/adr/000-reference-review.md §8`.

**Redesign vs upstream**: explicit self-follow guard. Upstream silently accepts self-follow edges; we reject with 422 `{ errors: { profile: ["cannot follow yourself"] } }` because a self-follow would corrupt the viewer-filtered personalised feed.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -f infra/docker-compose.yml --env-file .env ps
NAME                 SERVICE    STATUS            PORTS
conduit-api-1        api        Up (healthy)      0.0.0.0:3101->3001/tcp
conduit-postgres-1   postgres   Up (healthy)      0.0.0.0:5433->5432/tcp
conduit-web-1        web        Up (healthy)      0.0.0.0:3100->3000/tcp
```

### BDD scenarios

`tests/e2e/specs/7-api-profiles-follow.spec.ts` covers all six AC scenarios:

- ✓ Scenario 1: anonymous profile view returns `following=false`
- ✓ Scenario 2: authenticated profile view reflects follow state (before/after toggle)
- ✓ Scenario 3: follow and unfollow round-trip flips the flag
- ✓ Scenario 4: following a non-existent user returns 404
- ✓ Scenario 5: cannot follow yourself → 422 with `errors.profile = ["cannot follow yourself"]`
- ✓ Scenario 6: follow endpoints require auth (anonymous → 401)

(API-only scenarios, no screenshots — per `prompts/generator.md` §DoD.2.)

### Full local E2E

```
Running 19 tests using 1 worker
  19 passed (6.6s)
```

Suites on this branch: `15-web-layout-shell`, `22-healthz-smoke`, `4-api-auth-register-login`, `7-api-profiles-follow`. Command: `PLAYWRIGHT_BASE_URL=http://localhost:3100 API_URL=http://localhost:3101 pnpm exec playwright test --config tests/e2e/playwright.config.ts`.

Newman conformance smoke green: `API_URL=http://localhost:3101 pnpm test:conformance:smoke` → 2/2 assertions, `tests/api/results/20260429T040126Z.xml`.

### Portability check

```
$ grep -rn "localhost:[0-9]\|127\.0\.0\.1:" apps/api/src/
apps/api/src/config.ts:16:  webUrl: required("WEB_URL", "http://localhost:3000"),
```

Single hit; env-driven default (compose overrides with `WEB_URL=http://localhost:3100`). No new hardcoded hosts, no inline secrets.

### Root quality gates

- `pnpm --filter @conduit/api typecheck` — ✓
- `pnpm --filter @conduit/api lint` — ✓

### Infra

No infra change.
