### PR TITLE
feat(api): favorite / unfavorite article (#12)

### DIFF
--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -5,7 +5,9 @@ import {
   ArticleError,
   createArticle,
   deleteArticle,
+  favoriteArticle,
   getArticleBySlug,
+  unfavoriteArticle,
   updateArticle,
 } from "../services/articles.service.js";
 import { optionalAuth, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
@@ -135,6 +137,50 @@ const deleteArticleRoute = createRoute({
   },
 });
 
+const favoriteRoute = createRoute({
+  method: "post",
+  path: "/api/articles/{slug}/favorite",
+  tags: ["articles"],
+  summary: "Favorite an article",
+  request: { params: SlugParam },
+  responses: {
+    200: {
+      description: "Favorited (or already favorited — idempotent)",
+      content: { "application/json": { schema: ArticleResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const unfavoriteRoute = createRoute({
+  method: "delete",
+  path: "/api/articles/{slug}/favorite",
+  tags: ["articles"],
+  summary: "Unfavorite an article",
+  request: { params: SlugParam },
+  responses: {
+    200: {
+      description: "Unfavorited (or was never favorited — idempotent)",
+      content: { "application/json": { schema: ArticleResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
   const authed = app as unknown as OpenAPIHono<ArticleEnv>;
 
@@ -204,6 +250,41 @@ export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
       if (err instanceof ArticleError) {
         if (err.status === 404) return c.json(jsonError(err.field, err.detail), 404);
         if (err.status === 403) return c.json(jsonError(err.field, err.detail), 403);
+      }
+      throw err;
+    }
+  });
+
+  // Favorite + unfavorite share `/api/articles/{slug}/favorite`; the
+  // shared path is disjoint from the `/api/articles/{slug}` surface
+  // that `optionalAuth()` already covers, so mounting `requireAuth()`
+  // here is safe — it only affects POST + DELETE on this sub-path.
+  authed.use(favoriteRoute.getRoutingPath(), requireAuth());
+  authed.openapi(favoriteRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { slug } = c.req.valid("param");
+    try {
+      const envelope = await favoriteArticle(viewer.id, slug);
+      return c.json({ article: envelope }, 200);
+    } catch (err) {
+      if (err instanceof ArticleError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
+      }
+      throw err;
+    }
+  });
+
+  authed.openapi(unfavoriteRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { slug } = c.req.valid("param");
+    try {
+      const envelope = await unfavoriteArticle(viewer.id, slug);
+      return c.json({ article: envelope }, 200);
+    } catch (err) {
+      if (err instanceof ArticleError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
       }
       throw err;
     }

--- a/apps/api/src/services/articles.service.ts
+++ b/apps/api/src/services/articles.service.ts
@@ -7,8 +7,13 @@ import { prisma } from "../prisma/client.js";
 //   - `createArticle`: upstream computes `slug = slugify(title) + "-" + rand`
 //     and upserts tags; we keep the same shape.
 //   - `getArticle`: upstream includes author + favorites count + viewer-
-//     relative flags; we ship placeholders (favoritesCount:0, favorited:false)
-//     until Feature 12 adds real favorite tracking.
+//     relative flags. Since #12 we include real favorites: `_count.favoritedBy`
+//     gives `favoritesCount`, and a narrow `favoritedBy` include against the
+//     viewer computes `favorited` (empty array for anonymous viewers).
+//   - `favoriteArticle` / `unfavoriteArticle`: upstream does
+//     `user.update({ favorites: { connect / disconnect } })`. We do the same,
+//     with an explicit 404-if-missing guard before the connect (upstream
+//     relies on Prisma throwing P2025 which we surface uniformly).
 //
 // Tag upsert uses Prisma's `connectOrCreate`, so the first article that
 // mentions a tag creates it and subsequent articles reuse the row —
@@ -61,13 +66,31 @@ const slugify = (input: string): string =>
 const suffix = (): string =>
   randomBytes(3).toString("base64url").slice(0, 4).toLowerCase().replace(/[^a-z0-9]/g, "x");
 
+// Every article-returning endpoint must fetch with this include shape
+// so `toEnvelope` has what it needs for both `following` (viewer-relative
+// follow of author) and `favorited` / `favoritesCount` (viewer-relative
+// favorite + total count). Exported so the route handlers in
+// `routes/articles.ts` can reuse it without drifting the shape.
+export const articleInclude = {
+  tagList: true,
+  author: { include: { followedBy: { select: { id: true } } } },
+  _count: { select: { favoritedBy: true } },
+  // Narrowed favoritedBy include: when `viewerId` is a real user we
+  // filter to just that user's row (0 or 1 result, no count scan needed).
+  // Anonymous viewers pass an id that can never match so the include
+  // stays harmless and returns an empty array.
+  favoritedBy: {
+    where: { id: -1 },
+    select: { id: true },
+  },
+} as const;
+
+type ArticleWithIncludes = Prisma.ArticleGetPayload<{
+  include: typeof articleInclude;
+}>;
+
 const toEnvelope = (
-  article: Prisma.ArticleGetPayload<{
-    include: {
-      tagList: true;
-      author: { include: { followedBy: { select: { id: true } } } };
-    };
-  }>,
+  article: ArticleWithIncludes,
   viewerId: number | null,
 ): ArticleEnvelope => ({
   slug: article.slug,
@@ -77,10 +100,8 @@ const toEnvelope = (
   tagList: article.tagList.map((t) => t.name).sort(),
   createdAt: article.createdAt.toISOString(),
   updatedAt: article.updatedAt.toISOString(),
-  // Favorite tracking lands in #12 — until then the envelope shape is
-  // still complete but always reports "not favorited" with zero count.
-  favorited: false,
-  favoritesCount: 0,
+  favorited: article.favoritedBy.length > 0,
+  favoritesCount: article._count.favoritedBy,
   author: {
     username: article.author.username,
     bio: article.author.bio,
@@ -89,6 +110,17 @@ const toEnvelope = (
       viewerId !== null &&
       article.author.id !== viewerId &&
       article.author.followedBy.some((f) => f.id === viewerId),
+  },
+});
+
+// Caller always knows the viewer; we thread it into the `favoritedBy`
+// where-clause so the include only returns the viewer's own favorite
+// row if any. Keeps the query narrow regardless of total fav count.
+const includeFor = (viewerId: number | null) => ({
+  ...articleInclude,
+  favoritedBy: {
+    where: { id: viewerId ?? -1 },
+    select: { id: true },
   },
 });
 
@@ -124,10 +156,7 @@ export const createArticle = async (
         })),
       },
     },
-    include: {
-      tagList: true,
-      author: { include: { followedBy: { select: { id: true } } } },
-    },
+    include: includeFor(authorId),
   });
 
   return toEnvelope(article, authorId);
@@ -139,10 +168,7 @@ export const getArticleBySlug = async (
 ): Promise<ArticleEnvelope> => {
   const article = await prisma.article.findUnique({
     where: { slug },
-    include: {
-      tagList: true,
-      author: { include: { followedBy: { select: { id: true } } } },
-    },
+    include: includeFor(viewerId),
   });
   if (!article) {
     throw new ArticleError("article", "not found", 404);
@@ -167,8 +193,8 @@ export type UpdateArticleInput = {
 //      different suffix if Postgres returns P2002 on slug.
 // `updatedAt` is set explicitly because the schema's `updatedAt` column
 // has `@default(now())` but no `@updatedAt` directive (inherited from
-// upstream); Prisma won't bump it on plain updates. AC scenario 1
-// requires `updatedAt > createdAt`, which this write enforces.
+// upstream); Prisma won't bump it on plain updates. AC scenario 1 of
+// issue #9 requires `updatedAt > createdAt`, which this write enforces.
 export const updateArticle = async (
   viewerId: number,
   slug: string,
@@ -197,10 +223,7 @@ export const updateArticle = async (
   const updated = await prisma.article.update({
     where: { id: existing.id },
     data,
-    include: {
-      tagList: true,
-      author: { include: { followedBy: { select: { id: true } } } },
-    },
+    include: includeFor(viewerId),
   });
   return toEnvelope(updated, viewerId);
 };
@@ -221,4 +244,54 @@ export const deleteArticle = async (
   // (_UserFavorites) are cleared by Prisma automatically when the owning
   // row goes away — no manual cleanup needed.
   await prisma.article.delete({ where: { id: existing.id } });
+};
+
+export const favoriteArticle = async (
+  viewerId: number,
+  slug: string,
+): Promise<ArticleEnvelope> => {
+  const existing = await prisma.article.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!existing) {
+    throw new ArticleError("article", "not found", 404);
+  }
+  // user.update with favorites.connect is idempotent in Prisma: calling
+  // connect for a row already in the relation is a no-op and does not
+  // duplicate the join row. That means scenario 2's count-stays-1
+  // assertion falls out naturally — no extra guard needed here.
+  await prisma.user.update({
+    where: { id: viewerId },
+    data: { favorites: { connect: { id: existing.id } } },
+  });
+  const article = await prisma.article.findUniqueOrThrow({
+    where: { id: existing.id },
+    include: includeFor(viewerId),
+  });
+  return toEnvelope(article, viewerId);
+};
+
+export const unfavoriteArticle = async (
+  viewerId: number,
+  slug: string,
+): Promise<ArticleEnvelope> => {
+  const existing = await prisma.article.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!existing) {
+    throw new ArticleError("article", "not found", 404);
+  }
+  // `disconnect` is also idempotent; calling it when the row isn't in
+  // the relation is a no-op.
+  await prisma.user.update({
+    where: { id: viewerId },
+    data: { favorites: { disconnect: { id: existing.id } } },
+  });
+  const article = await prisma.article.findUniqueOrThrow({
+    where: { id: existing.id },
+    include: includeFor(viewerId),
+  });
+  return toEnvelope(article, viewerId);
 };

--- a/tests/e2e/specs/12-api-favorite-article.spec.ts
+++ b/tests/e2e/specs/12-api-favorite-article.spec.ts
@@ -1,0 +1,193 @@
+import { expect, request, test } from "@playwright/test";
+
+// BDD coverage for issue #12: POST + DELETE /api/articles/:slug/favorite.
+// Six of the seven AC scenarios run here; scenario 5 ("other article
+// envelopes reflect real favorite data") touches the list endpoint
+// (GET /api/articles) which ships in #10. The detail-endpoint half of
+// the integration (POST favorite → subsequent GET /:slug envelope
+// carries real favorited/favoritesCount) is exercised throughout.
+// When #10 merges its own spec can assert the list-envelope half with
+// one extra seed; no changes needed here.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const registerUser = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  username: string,
+) => {
+  const res = await api.post("/api/users", {
+    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
+  });
+  expect(res.status()).toBe(201);
+};
+
+const createArticle = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  title: string,
+): Promise<string> => {
+  const res = await api.post("/api/articles", {
+    data: { article: { title, description: "d", body: "b" } },
+  });
+  expect(res.status()).toBe(201);
+  const body = (await res.json()) as { article: { slug: string } };
+  return body.article.slug;
+};
+
+test.describe("issue #12 — API favorite / unfavorite article", () => {
+  test("Scenario 1: first favorite flips count 0 → 1 and favorited true", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    const slug = await createArticle(jakeApi, `Favorite me ${id}`);
+
+    // Baseline: envelope reports 0 + false pre-favorite.
+    const before = await danApi.get(`/api/articles/${slug}`);
+    const beforeBody = (await before.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(beforeBody.article.favoritesCount).toBe(0);
+    expect(beforeBody.article.favorited).toBe(false);
+
+    const fav = await danApi.post(`/api/articles/${slug}/favorite`);
+    expect(fav.status()).toBe(200);
+    const favBody = (await fav.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(favBody.article.favoritesCount).toBe(1);
+    expect(favBody.article.favorited).toBe(true);
+  });
+
+  test("Scenario 2: favoriting twice is idempotent — count stays 1", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    const slug = await createArticle(jakeApi, `Idempotent ${id}`);
+
+    await danApi.post(`/api/articles/${slug}/favorite`);
+    const second = await danApi.post(`/api/articles/${slug}/favorite`);
+    expect(second.status()).toBe(200);
+    const body = (await second.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(body.article.favoritesCount).toBe(1);
+    expect(body.article.favorited).toBe(true);
+  });
+
+  test("Scenario 3: unfavorite flips count 1 → 0 and favorited false", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    const slug = await createArticle(jakeApi, `Unfavorite ${id}`);
+
+    await danApi.post(`/api/articles/${slug}/favorite`);
+    const un = await danApi.delete(`/api/articles/${slug}/favorite`);
+    expect(un.status()).toBe(200);
+    const body = (await un.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(body.article.favoritesCount).toBe(0);
+    expect(body.article.favorited).toBe(false);
+  });
+
+  test("Scenario 4: favoritesCount reflects multiple users", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const alice = `alice-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    const aliceApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    await registerUser(aliceApi, alice);
+    const slug = await createArticle(jakeApi, `Multi-fav ${id}`);
+
+    await danApi.post(`/api/articles/${slug}/favorite`);
+    await aliceApi.post(`/api/articles/${slug}/favorite`);
+
+    const anon = await request.newContext({ baseURL: API_URL });
+    const res = await anon.get(`/api/articles/${slug}`);
+    const body = (await res.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(body.article.favoritesCount).toBe(2);
+    // Anonymous viewer sees favorited=false regardless of other users'
+    // state — `favorited` is strictly viewer-relative.
+    expect(body.article.favorited).toBe(false);
+  });
+
+  test("Scenario 5 (detail-endpoint half): viewer-relative favorited is per-user", async () => {
+    // The list-endpoint half (GET /api/articles) lands with #10. This
+    // spec covers the same invariant against GET /api/articles/:slug:
+    // when dan has favorited but alice hasn't, fetching the same slug
+    // with each viewer's cookie returns different `favorited` flags.
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const alice = `alice-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    const aliceApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    await registerUser(aliceApi, alice);
+    const slug = await createArticle(jakeApi, `Per-viewer ${id}`);
+
+    await danApi.post(`/api/articles/${slug}/favorite`);
+
+    const danView = await danApi.get(`/api/articles/${slug}`);
+    const danBody = (await danView.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(danBody.article.favorited).toBe(true);
+    expect(danBody.article.favoritesCount).toBe(1);
+
+    const aliceView = await aliceApi.get(`/api/articles/${slug}`);
+    const aliceBody = (await aliceView.json()) as {
+      article: { favorited: boolean; favoritesCount: number };
+    };
+    expect(aliceBody.article.favorited).toBe(false);
+    expect(aliceBody.article.favoritesCount).toBe(1);
+  });
+
+  test("Scenario 6: favorite endpoints require auth", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    const slug = await createArticle(jakeApi, `Auth-check ${id}`);
+
+    const anon = await request.newContext({ baseURL: API_URL });
+    const post = await anon.post(`/api/articles/${slug}/favorite`);
+    expect(post.status()).toBe(401);
+    const del = await anon.delete(`/api/articles/${slug}/favorite`);
+    expect(del.status()).toBe(401);
+  });
+
+  test("Scenario 7: favorite non-existent article → 404", async () => {
+    const id = uniq();
+    const dan = `dan-${id}`;
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(danApi, dan);
+
+    const res = await danApi.post(`/api/articles/no-such-slug-${id}/favorite`);
+    expect(res.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
[generator @ gen-kxe47s]

Closes #12

## User Intent

Authenticated users toggle favorite on an article via `POST /api/articles/:slug/favorite` and `DELETE /api/articles/:slug/favorite`. The `article.favoritesCount` + `article.favorited` fields in every article envelope — `createArticle`, `getArticleBySlug`, and the future list / feed endpoints — now reflect real data instead of the 0/false placeholders that #8 shipped.

## Upstream reuse

Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5 (attribution, per docs/adr/000-reference-review.md §7). The service-method shape (`user.update({ favorites: { connect / disconnect } })`) mirrors upstream. Explicit deviation from upstream: we guard with a 404-if-missing `findUnique` before the connect; upstream relies on Prisma throwing P2025 and mapping it in the error layer — our guard is one query and surfaces errors uniformly with the rest of `ArticleError`.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -f infra/docker-compose.yml --env-file .env ps
conduit-api-1        api        Up (healthy)
conduit-postgres-1   postgres   Up (healthy)
conduit-web-1        web        Up (healthy)
```

### BDD scenarios

6 of the 7 AC scenarios covered directly here; scenario 5's list-endpoint assertion is inherited by #10 when that ships. Seven specs green against compose:

- ✓ Scenario 1 — first favorite: count 0 → 1, favorited true.
- ✓ Scenario 2 — double favorite is idempotent; count stays 1.
- ✓ Scenario 3 — unfavorite: count 1 → 0, favorited false.
- ✓ Scenario 4 — count reflects multiple users (2 favs → count=2; anon viewer still sees favorited=false).
- ✓ Scenario 5 (detail-endpoint half) — viewer-relative favorited differs per viewer for the same article (dan sees true, alice sees false, both see favoritesCount=1). **List-endpoint half deferred to #10's spec** — the envelope serialiser is shared, so #10 inherits the correct values automatically when GET /api/articles lands.
- ✓ Scenario 6 — anon POST + DELETE → 401 each.
- ✓ Scenario 7 — favorite non-existent slug → 404.

### Full local E2E

```
$ API_URL=http://localhost:3101 PLAYWRIGHT_BASE_URL=http://localhost:3100 pnpm test:e2e:smoke
...
  51 passed (38.3s)
```

Every previously-green suite remains green. #8 × 6 still passes even though `toEnvelope` now computes real favoritesCount — #8's scenarios assert 0 / false for freshly-created articles that nobody has favorited, which is still the truth.

### Portability check

```
$ git diff --unified=0 origin/latest...HEAD -- ':!tests/e2e/specs' | \
    grep -E '^\+' | grep -Ev '^\+\+\+' | \
    grep -E 'localhost:[0-9]|/home/|AKIA|sk_live'
(no output — clean)
```

### Typecheck + lint

```
$ pnpm typecheck
apps/api typecheck: Done
apps/web typecheck: Done

$ pnpm -r --if-present --parallel lint
apps/api lint: Done
apps/web lint: Done
```

### Infra

No infra change.

## Notes for the evaluator

- `articleInclude` is now exported from the service so every future article-returning endpoint (#10 list, #11 feed, #13 comments → parent article embed) can use the same shape without drifting. Any drift would cause `toEnvelope` to fail at type-check — intentional.
- `favoritedBy` is always fetched with a narrow `where: { id: viewerId ?? -1 }`, so the include returns 0 or 1 rows regardless of how many users favorited the article. That keeps the query bounded at web scale; `_count.favoritedBy` does the actual counting. Prisma's viewer=null branch passes -1 which never matches a real user id.
- The post-mutation refetch in `favoriteArticle` / `unfavoriteArticle` is deliberate: `user.update` returns the user row, not the article, so we reload with `includeFor(viewerId)` to get a consistent envelope (including the fresh count). Two round-trips; the alternative (compute count client-side from the connect/disconnect result) would drift from the envelope shape used by read paths.
- This PR is independent of #9 (update+delete, still in review as PR #50). Both branches touched `articles.service.ts` and `routes/articles.ts`; if #50 merges first this PR will need a minor rebase (no semantic conflict — the edit regions are disjoint).

Timestamp: 2026-04-29 14:51 KST (05:51Z)
