### PR TITLE
feat(api): comments CRUD on articles (#13)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { requestLogger } from "./middleware/logger.js";
 import { requestId, type RequestIdVars } from "./middleware/request-id.js";
 import { registerArticleRoutes } from "./routes/articles.js";
 import { registerAuthRoutes } from "./routes/auth.js";
+import { registerCommentRoutes } from "./routes/comments.js";
 import { registerHealthzRoute } from "./routes/healthz.js";
 import { registerInternalThrowRoute } from "./routes/internal-throw.js";
 import { registerProfileRoutes } from "./routes/profiles.js";
@@ -51,6 +52,7 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
   registerAuthRoutes(app);
   registerProfileRoutes(app);
   registerArticleRoutes(app);
+  registerCommentRoutes(app);
   registerTagsRoutes(app);
   registerInternalThrowRoute(app);
 

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -1,0 +1,174 @@
+import { createRoute, type OpenAPIHono } from "@hono/zod-openapi";
+import { z } from "@hono/zod-openapi";
+import type { AppEnv } from "../app.js";
+import {
+  CommentError,
+  addComment,
+  deleteComment,
+  listComments,
+} from "../services/comments.service.js";
+import { optionalAuth, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
+import { ErrorResponseSchema } from "../schemas/user.js";
+import {
+  CommentListResponseSchema,
+  CommentResponseSchema,
+  CreateCommentRequestSchema,
+} from "../schemas/comment.js";
+
+type CommentVars = AppEnv["Variables"] & UserVars;
+type CommentEnv = { Variables: CommentVars };
+
+const SlugParam = z
+  .object({
+    slug: z.string().min(1).openapi({ param: { name: "slug", in: "path" } }),
+  })
+  .openapi("CommentSlugParam");
+
+const SlugAndIdParams = z
+  .object({
+    slug: z.string().min(1).openapi({ param: { name: "slug", in: "path" } }),
+    id: z.coerce
+      .number()
+      .int()
+      .positive()
+      .openapi({ param: { name: "id", in: "path" } }),
+  })
+  .openapi("CommentSlugAndIdParams");
+
+const jsonError = (field: string, detail: string) => ({
+  errors: { [field]: [detail] },
+});
+
+const listCommentsRoute = createRoute({
+  method: "get",
+  path: "/api/articles/{slug}/comments",
+  tags: ["comments"],
+  summary: "List comments on an article",
+  request: { params: SlugParam },
+  responses: {
+    200: {
+      description: "Comments",
+      content: { "application/json": { schema: CommentListResponseSchema } },
+    },
+    404: {
+      description: "Article not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const addCommentRoute = createRoute({
+  method: "post",
+  path: "/api/articles/{slug}/comments",
+  tags: ["comments"],
+  summary: "Add a comment on an article",
+  request: {
+    params: SlugParam,
+    body: {
+      required: true,
+      content: { "application/json": { schema: CreateCommentRequestSchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created",
+      content: { "application/json": { schema: CommentResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Article not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Unprocessable entity",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const deleteCommentRoute = createRoute({
+  method: "delete",
+  path: "/api/articles/{slug}/comments/{id}",
+  tags: ["comments"],
+  summary: "Delete own comment on an article",
+  request: { params: SlugAndIdParams },
+  responses: {
+    204: { description: "Deleted" },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "Forbidden — viewer is not the comment author",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Article or comment not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const registerCommentRoutes = (app: OpenAPIHono<AppEnv>): void => {
+  const authed = app as unknown as OpenAPIHono<CommentEnv>;
+
+  // GET is anonymous-friendly; viewer-relative `following` only meaningful
+  // for authenticated callers but the endpoint never 401s.
+  authed.use(listCommentsRoute.getRoutingPath(), optionalAuth());
+  authed.openapi(listCommentsRoute, async (c) => {
+    const viewer = c.get("user");
+    const { slug } = c.req.valid("param");
+    try {
+      const comments = await listComments(slug, viewer?.id ?? null);
+      return c.json({ comments }, 200);
+    } catch (err) {
+      if (err instanceof CommentError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
+      }
+      throw err;
+    }
+  });
+
+  // Same path-shape discipline as articles update/delete: GET + POST
+  // share `/api/articles/{slug}/comments`, and Hono's `app.use(path,...)`
+  // is method-agnostic. Handler-level `if (!viewer) → 401` is what
+  // keeps anonymous GET working while POST enforces auth.
+  authed.openapi(addCommentRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { slug } = c.req.valid("param");
+    const { comment } = c.req.valid("json");
+    try {
+      const envelope = await addComment(viewer.id, slug, comment.body);
+      return c.json({ comment: envelope }, 201);
+    } catch (err) {
+      if (err instanceof CommentError && err.status === 404) {
+        return c.json(jsonError(err.field, err.detail), 404);
+      }
+      throw err;
+    }
+  });
+
+  // DELETE /api/articles/{slug}/comments/{id} — mount requireAuth here;
+  // it's a distinct path from the shared slug/comments prefix so no
+  // stacking risk on the GET route.
+  authed.use(deleteCommentRoute.getRoutingPath(), requireAuth());
+  authed.openapi(deleteCommentRoute, async (c) => {
+    const viewer = c.get("user");
+    if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);
+    const { slug, id } = c.req.valid("param");
+    try {
+      await deleteComment(viewer.id, slug, id);
+      return c.body(null, 204);
+    } catch (err) {
+      if (err instanceof CommentError) {
+        if (err.status === 404) return c.json(jsonError(err.field, err.detail), 404);
+        if (err.status === 403) return c.json(jsonError(err.field, err.detail), 403);
+      }
+      throw err;
+    }
+  });
+};

--- a/apps/api/src/schemas/comment.ts
+++ b/apps/api/src/schemas/comment.ts
@@ -1,0 +1,28 @@
+import { z } from "@hono/zod-openapi";
+import { ProfileSchema } from "./profile.js";
+
+export const CommentSchema = z
+  .object({
+    id: z.number().int(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    body: z.string(),
+    author: ProfileSchema,
+  })
+  .openapi("Comment");
+
+export const CommentResponseSchema = z
+  .object({ comment: CommentSchema })
+  .openapi("CommentResponse");
+
+export const CommentListResponseSchema = z
+  .object({ comments: z.array(CommentSchema) })
+  .openapi("CommentListResponse");
+
+export const CreateCommentRequestSchema = z
+  .object({
+    comment: z.object({
+      body: z.string().min(1, "can't be blank").max(10_000),
+    }),
+  })
+  .openapi("CreateCommentRequest");

--- a/apps/api/src/services/comments.service.ts
+++ b/apps/api/src/services/comments.service.ts
@@ -1,0 +1,125 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../prisma/client.js";
+
+// Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5
+// (`src/app/routes/services/comments.service.ts`, attribution). The
+// reference emits the same `{id, createdAt, updatedAt, body, author}`
+// envelope with viewer-relative `following`. We reuse the narrow
+// `followedBy` include pattern used by profile / article services so
+// the follow check is a tiny join rather than a row scan.
+
+export type CommentEnvelope = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: {
+    username: string;
+    bio: string | null;
+    image: string | null;
+    following: boolean;
+  };
+};
+
+export class CommentError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly detail: string,
+    public readonly status: 403 | 404 | 422,
+  ) {
+    super(`${field}: ${detail}`);
+    this.name = "CommentError";
+  }
+}
+
+const commentInclude = {
+  author: { include: { followedBy: { select: { id: true } } } },
+} as const;
+
+type CommentWithIncludes = Prisma.CommentGetPayload<{
+  include: typeof commentInclude;
+}>;
+
+const toEnvelope = (
+  comment: CommentWithIncludes,
+  viewerId: number | null,
+): CommentEnvelope => ({
+  id: comment.id,
+  createdAt: comment.createdAt.toISOString(),
+  updatedAt: comment.updatedAt.toISOString(),
+  body: comment.body,
+  author: {
+    username: comment.author.username,
+    bio: comment.author.bio,
+    image: comment.author.image,
+    following:
+      viewerId !== null &&
+      comment.author.id !== viewerId &&
+      comment.author.followedBy.some((f) => f.id === viewerId),
+  },
+});
+
+// Narrow helper — every entry point needs to resolve "does this slug
+// exist" before touching comments. Returns the article row (id only)
+// or throws 404. Kept private so route handlers can't skip it.
+const requireArticleId = async (slug: string): Promise<number> => {
+  const article = await prisma.article.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!article) {
+    throw new CommentError("article", "not found", 404);
+  }
+  return article.id;
+};
+
+export const listComments = async (
+  slug: string,
+  viewerId: number | null,
+): Promise<CommentEnvelope[]> => {
+  const articleId = await requireArticleId(slug);
+  const comments = await prisma.comment.findMany({
+    where: { articleId },
+    include: commentInclude,
+    orderBy: { createdAt: "desc" },
+  });
+  return comments.map((c) => toEnvelope(c, viewerId));
+};
+
+export const addComment = async (
+  viewerId: number,
+  slug: string,
+  body: string,
+): Promise<CommentEnvelope> => {
+  const articleId = await requireArticleId(slug);
+  const comment = await prisma.comment.create({
+    data: {
+      body,
+      article: { connect: { id: articleId } },
+      author: { connect: { id: viewerId } },
+    },
+    include: commentInclude,
+  });
+  return toEnvelope(comment, viewerId);
+};
+
+export const deleteComment = async (
+  viewerId: number,
+  slug: string,
+  commentId: number,
+): Promise<void> => {
+  const articleId = await requireArticleId(slug);
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+    select: { id: true, articleId: true, authorId: true },
+  });
+  // 404 if comment is missing OR belongs to a different article (so a
+  // client can't discover comment ids by probing other slugs).
+  if (!comment || comment.articleId !== articleId) {
+    throw new CommentError("comment", "not found", 404);
+  }
+  if (comment.authorId !== viewerId) {
+    throw new CommentError("comment", "forbidden", 403);
+  }
+  await prisma.comment.delete({ where: { id: commentId } });
+};

--- a/tests/e2e/specs/13-api-comments.spec.ts
+++ b/tests/e2e/specs/13-api-comments.spec.ts
@@ -1,0 +1,219 @@
+import { expect, request, test } from "@playwright/test";
+
+// BDD coverage for issue #13: comments CRUD on articles.
+// Seven AC scenarios. Each test seeds its own jake / dan / article so
+// suites are independent of other specs running against the same
+// compose stack.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const registerUser = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  username: string,
+) => {
+  const res = await api.post("/api/users", {
+    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
+  });
+  expect(res.status()).toBe(201);
+};
+
+const createArticle = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  title: string,
+): Promise<string> => {
+  const res = await api.post("/api/articles", {
+    data: { article: { title, description: "d", body: "b" } },
+  });
+  expect(res.status()).toBe(201);
+  const body = (await res.json()) as { article: { slug: string } };
+  return body.article.slug;
+};
+
+const addComment = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  slug: string,
+  body: string,
+): Promise<number> => {
+  const res = await api.post(`/api/articles/${slug}/comments`, {
+    data: { comment: { body } },
+  });
+  expect(res.status()).toBe(201);
+  const payload = (await res.json()) as { comment: { id: number } };
+  return payload.comment.id;
+};
+
+test.describe("issue #13 — API comments CRUD", () => {
+  test("Scenario 1: anonymous list — 200, shape + order", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    const slug = await createArticle(jakeApi, `List ${id}`);
+
+    await addComment(jakeApi, slug, "jake's first");
+    // A hair of delay so createdAt values are strictly increasing at
+    // the ms granularity postgres exposes.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await addComment(danApi, slug, "dan replies");
+
+    const anon = await request.newContext({ baseURL: API_URL });
+    const res = await anon.get(`/api/articles/${slug}/comments`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      comments: Array<{
+        id: number;
+        createdAt: string;
+        updatedAt: string;
+        body: string;
+        author: {
+          username: string;
+          bio: string | null;
+          image: string | null;
+          following: boolean;
+        };
+      }>;
+    };
+    expect(body.comments.length).toBe(2);
+    // Descending by createdAt — dan's "dan replies" (newer) comes first.
+    expect(body.comments[0].author.username).toBe(dan);
+    expect(body.comments[1].author.username).toBe(jake);
+    expect(body.comments[0].body).toBe("dan replies");
+    expect(body.comments[1].body).toBe("jake's first");
+    expect(Date.parse(body.comments[0].createdAt)).toBeGreaterThanOrEqual(
+      Date.parse(body.comments[1].createdAt),
+    );
+    // Envelope shape: author is a Profile with viewer-relative flag.
+    expect(body.comments[0].author.following).toBe(false);
+    // Fresh users have bio = null and image = null (our register path
+    // stores the defaults as nulls, matching #4's established shape).
+    expect(body.comments[0].author.bio).toBeNull();
+    expect(body.comments[0].author.image).toBeNull();
+  });
+
+  test("Scenario 2: add comment as authenticated user → 201 + envelope", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    const slug = await createArticle(jakeApi, `Add ${id}`);
+
+    const res = await jakeApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: "Thank you!" } },
+    });
+    expect(res.status()).toBe(201);
+    const body = (await res.json()) as {
+      comment: {
+        id: number;
+        body: string;
+        author: { username: string };
+      };
+    };
+    expect(body.comment.body).toBe("Thank you!");
+    expect(body.comment.author.username).toBe(jake);
+    expect(Number.isInteger(body.comment.id)).toBe(true);
+
+    // Round-trip: GET lists it.
+    const listRes = await jakeApi.get(`/api/articles/${slug}/comments`);
+    const list = (await listRes.json()) as { comments: Array<{ id: number }> };
+    expect(list.comments.map((c) => c.id)).toContain(body.comment.id);
+  });
+
+  test("Scenario 3: delete own comment → 204, subsequent list omits it", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    const slug = await createArticle(jakeApi, `Del ${id}`);
+    const commentId = await addComment(jakeApi, slug, "delete me");
+
+    const del = await jakeApi.delete(`/api/articles/${slug}/comments/${commentId}`);
+    expect(del.status()).toBe(204);
+    const delBody = await del.body();
+    expect(delBody.byteLength).toBe(0);
+
+    const list = await jakeApi.get(`/api/articles/${slug}/comments`);
+    const body = (await list.json()) as { comments: Array<{ id: number }> };
+    expect(body.comments.map((c) => c.id)).not.toContain(commentId);
+  });
+
+  test("Scenario 4: delete someone else's comment → 403", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    const slug = await createArticle(jakeApi, `Owned ${id}`);
+    const danCommentId = await addComment(danApi, slug, "dan's comment");
+
+    const res = await jakeApi.delete(`/api/articles/${slug}/comments/${danCommentId}`);
+    expect(res.status()).toBe(403);
+
+    // Sanity: comment still exists.
+    const list = await jakeApi.get(`/api/articles/${slug}/comments`);
+    const body = (await list.json()) as { comments: Array<{ id: number }> };
+    expect(body.comments.map((c) => c.id)).toContain(danCommentId);
+  });
+
+  test("Scenario 5: anon POST + DELETE → 401 each", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    const slug = await createArticle(jakeApi, `Auth ${id}`);
+    const commentId = await addComment(jakeApi, slug, "gate");
+
+    const anon = await request.newContext({ baseURL: API_URL });
+    const post = await anon.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: "anon try" } },
+    });
+    expect(post.status()).toBe(401);
+    const del = await anon.delete(`/api/articles/${slug}/comments/${commentId}`);
+    expect(del.status()).toBe(401);
+  });
+
+  test("Scenario 6: any comment op on non-existent slug → 404", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+
+    const anon = await request.newContext({ baseURL: API_URL });
+    const missing = `does-not-exist-${id}`;
+    const getRes = await anon.get(`/api/articles/${missing}/comments`);
+    expect(getRes.status()).toBe(404);
+
+    const postRes = await jakeApi.post(`/api/articles/${missing}/comments`, {
+      data: { comment: { body: "ghost" } },
+    });
+    expect(postRes.status()).toBe(404);
+
+    const delRes = await jakeApi.delete(`/api/articles/${missing}/comments/1`);
+    expect(delRes.status()).toBe(404);
+  });
+
+  test("Scenario 7: empty body → 422 with errors.body", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    const slug = await createArticle(jakeApi, `Empty ${id}`);
+
+    const res = await jakeApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: "" } },
+    });
+    expect(res.status()).toBe(422);
+    const body = (await res.json()) as { errors: Record<string, string[]> };
+    const allMessages = Object.values(body.errors).flat().join(" ");
+    expect(allMessages.toLowerCase()).toContain("can't be blank");
+  });
+});


### PR DESCRIPTION
[generator @ gen-kxe47s]

Closes #13

## User Intent

Three comment endpoints under `/api/articles/:slug/comments`: anonymous list, authenticated add, author-scoped delete. Comment envelope carries the author as a Profile with viewer-relative `following`.

## Upstream reuse

Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5 (attribution, per docs/adr/000-reference-review.md §6). The service shape (`get / add / delete`) mirrors upstream. One local decision: the 404 for deletes cross-checks that the comment's `articleId` matches the route's slug, so clients can't discover comment ids by probing other articles.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -p conduit-gen -f infra/docker-compose.yml --env-file /tmp/.env.gen ps
conduit-gen-api-1        api        Up (healthy)      :3201
conduit-gen-postgres-1   postgres   Up (healthy)      :5533
conduit-gen-web-1        web        Up (healthy)      :3200
```

(Using `-p conduit-gen` with offset ports to avoid cross-worktree collision per feedback_compose_port_collision_cross_worktree memory; the shared `conduit` project currently points at the evaluator worktree's compose file.)

### BDD scenarios — all 7 AC scenarios

`tests/e2e/specs/13-api-comments.spec.ts` — 7/7 green:

- ✓ Scenario 1 — anonymous list: 200, envelope shape, ordered by createdAt desc.
- ✓ Scenario 2 — add comment as authenticated user: 201 + envelope + round-trips through list.
- ✓ Scenario 3 — delete own comment: 204 + empty body; list omits afterwards.
- ✓ Scenario 4 — delete someone else's comment: 403; comment still exists.
- ✓ Scenario 5 — anon POST + DELETE both 401.
- ✓ Scenario 6 — GET/POST/DELETE on non-existent slug: all 404.
- ✓ Scenario 7 — empty body POST: 422 with `errors.body` saying "can't be blank".

### Full local E2E

Against the generator-isolated stack, the #13 spec is green along with every article / profile / auth / tags / layout / web-auth spec (57 scenarios total). The `#25` observability spec fails 4 scenarios **only** against this isolated stack because `readApiLogs()` hard-codes container name `conduit-api-1` while my isolated project's container is `conduit-gen-api-1`; those same four scenarios pass against the shared `conduit` stack. The evaluator runs against the shared stack, where all specs pass — I did not touch `25-api-observability-floor.spec.ts` in this PR.

### Portability check

```
$ git diff --unified=0 origin/latest...HEAD -- ':!tests/e2e/specs' | \
    grep -E '^\+' | grep -Ev '^\+\+\+' | \
    grep -E 'localhost:[0-9]|/home/|AKIA|sk_live'
(no output — clean)
```

### Typecheck + lint

Both clean.

### Infra

No infra change.

## Notes for the evaluator

- **Auth mounting**: GET uses `optionalAuth()` on the shared `/api/articles/{slug}/comments` path. POST to the same path does its own handler-level `if (!viewer) → 401` (same discipline as #9 and #12 where the shared-path pattern also arose). DELETE sits under a distinct `/:id` path and uses `requireAuth()` as a middleware.
- **Cross-slug 404 on delete**: the service treats "comment exists but belongs to a different article" as 404 rather than passing it through. That prevents a client from enumerating comment ids by DELETE-probing other slugs. Upstream doesn't make this explicit; I thought it was worth the extra `articleId` check.
- **`requireArticleId()` helper**: private to the service file — the goal is that no entry point can reach comment logic without first resolving the slug, which is what guarantees the scenario 6 "non-existent slug → 404" behaviour uniformly across GET/POST/DELETE.

Timestamp: 2026-04-29 15:40 KST (06:40Z)
