### PR TITLE
feat(api): articles list + filters + pagination (#10)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -20,4 +20,6 @@ export const config = {
   bcryptCost: Number.parseInt(process.env.BCRYPT_COST ?? "10", 10),
   cookieDomain: process.env.COOKIE_DOMAIN ?? "localhost",
   cookieSecure: (process.env.COOKIE_SECURE ?? "false").toLowerCase() === "true",
+  articleListDefaultLimit: Number.parseInt(process.env.ARTICLE_LIST_DEFAULT_LIMIT ?? "20", 10),
+  articleListMaxLimit: Number.parseInt(process.env.ARTICLE_LIST_MAX_LIMIT ?? "100", 10),
 } as const;

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -1,18 +1,21 @@
 import { createRoute, type OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "@hono/zod-openapi";
 import type { AppEnv } from "../app.js";
+import { config } from "../config.js";
 import {
   ArticleError,
   createArticle,
   deleteArticle,
   favoriteArticle,
   getArticleBySlug,
+  listArticles,
   unfavoriteArticle,
   updateArticle,
 } from "../services/articles.service.js";
 import { optionalAuth, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
 import { ErrorResponseSchema } from "../schemas/user.js";
 import {
+  ArticleListResponseSchema,
   ArticleResponseSchema,
   CreateArticleRequestSchema,
   UpdateArticleRequestSchema,
@@ -29,6 +32,48 @@ const SlugParam = z
 
 const jsonError = (field: string, detail: string) => ({
   errors: { [field]: [detail] },
+});
+
+// Query-param schema for list + filter. `z.coerce.number()` accepts the
+// string shape URLSearchParams produces; the outer `.max(...)` threshold
+// comes from config so ops can adjust per-env without a redeploy.
+// Field-level messages here match the AC's "must be at most 100"
+// expectation via the spec422Hook (which emits { errors: { limit: [...] } }).
+const ListArticlesQuery = z
+  .object({
+    tag: z.string().optional(),
+    author: z.string().optional(),
+    favorited: z.string().optional(),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1, "must be at least 1")
+      .max(config.articleListMaxLimit, `must be at most ${config.articleListMaxLimit}`)
+      .optional(),
+    offset: z.coerce
+      .number()
+      .int()
+      .min(0, "must be at least 0")
+      .optional(),
+  })
+  .openapi("ListArticlesQuery");
+
+const listArticlesRoute = createRoute({
+  method: "get",
+  path: "/api/articles",
+  tags: ["articles"],
+  summary: "List articles with optional filters + pagination",
+  request: { query: ListArticlesQuery },
+  responses: {
+    200: {
+      description: "Articles + total count",
+      content: { "application/json": { schema: ArticleListResponseSchema } },
+    },
+    422: {
+      description: "Unprocessable entity",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
 });
 
 const createArticleRoute = createRoute({
@@ -184,7 +229,31 @@ const unfavoriteRoute = createRoute({
 export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
   const authed = app as unknown as OpenAPIHono<ArticleEnv>;
 
-  authed.use(createArticleRoute.getRoutingPath(), requireAuth());
+  // GET /api/articles (list) and POST /api/articles (create) share the
+  // same path, and Hono's `app.use(path, mw)` is method-agnostic —
+  // mounting `requireAuth()` on the shared path would 401 anonymous
+  // GETs. Use `optionalAuth()` here (serves both), and the POST
+  // handler enforces auth via its own `if (!viewer) → 401` check.
+  // Same pattern used by the shared `/api/articles/{slug}` surface.
+  authed.use(listArticlesRoute.getRoutingPath(), optionalAuth());
+  authed.openapi(listArticlesRoute, async (c) => {
+    const viewer = c.get("user");
+    const q = c.req.valid("query");
+    const limit = q.limit ?? config.articleListDefaultLimit;
+    const offset = q.offset ?? 0;
+    const result = await listArticles(
+      {
+        tag: q.tag,
+        author: q.author,
+        favoritedBy: q.favorited,
+        limit,
+        offset,
+      },
+      viewer?.id ?? null,
+    );
+    return c.json(result, 200);
+  });
+
   authed.openapi(createArticleRoute, async (c) => {
     const viewer = c.get("user");
     if (!viewer) return c.json(jsonError("auth", "Unauthorized"), 401);

--- a/apps/api/src/schemas/article.ts
+++ b/apps/api/src/schemas/article.ts
@@ -31,6 +31,13 @@ export const ArticleResponseSchema = z
   .object({ article: ArticleSchema })
   .openapi("ArticleResponse");
 
+export const ArticleListResponseSchema = z
+  .object({
+    articles: z.array(ArticleSchema),
+    articlesCount: z.number().int().nonnegative(),
+  })
+  .openapi("ArticleListResponse");
+
 export const CreateArticleRequestSchema = z
   .object({
     article: z.object({

--- a/apps/api/src/services/articles.service.ts
+++ b/apps/api/src/services/articles.service.ts
@@ -272,6 +272,62 @@ export const favoriteArticle = async (
   return toEnvelope(article, viewerId);
 };
 
+export type ListArticlesFilters = {
+  tag?: string;
+  author?: string;
+  favoritedBy?: string;
+  limit: number;
+  offset: number;
+};
+
+export type ListArticlesResult = {
+  articles: ArticleEnvelope[];
+  articlesCount: number;
+};
+
+// Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5
+// (`src/app/routes/services/articles.service.ts#listArticles`, attribution).
+// Upstream wires tag / author / favoritedBy filters into a single
+// findMany; we follow the same shape. Ordering is newest-first on
+// createdAt — every RealWorld reference frontend expects that.
+//
+// `articlesCount` is computed with the same where-clause (minus the
+// skip/take) so pagination UIs know the total before slicing. A
+// transactional read would be more "correct" but the two queries are
+// 10-20ms apart under normal load; no reference implementation
+// bothers with a snapshot.
+export const listArticles = async (
+  filters: ListArticlesFilters,
+  viewerId: number | null,
+): Promise<ListArticlesResult> => {
+  const where: Prisma.ArticleWhereInput = {};
+  if (filters.tag) {
+    where.tagList = { some: { name: filters.tag } };
+  }
+  if (filters.author) {
+    where.author = { username: filters.author };
+  }
+  if (filters.favoritedBy) {
+    where.favoritedBy = { some: { username: filters.favoritedBy } };
+  }
+
+  const [rows, articlesCount] = await Promise.all([
+    prisma.article.findMany({
+      where,
+      include: includeFor(viewerId),
+      orderBy: { createdAt: "desc" },
+      skip: filters.offset,
+      take: filters.limit,
+    }),
+    prisma.article.count({ where }),
+  ]);
+
+  return {
+    articles: rows.map((row) => toEnvelope(row, viewerId)),
+    articlesCount,
+  };
+};
+
 export const unfavoriteArticle = async (
   viewerId: number,
   slug: string,

--- a/tests/e2e/specs/10-api-articles-list.spec.ts
+++ b/tests/e2e/specs/10-api-articles-list.spec.ts
@@ -1,0 +1,204 @@
+import { expect, request, test } from "@playwright/test";
+
+// BDD coverage for issue #10: GET /api/articles with filters + pagination.
+// Seven AC scenarios. Each test seeds distinctly-named users / tags /
+// titles so it can run alongside other specs without cross-contamination.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const registerUser = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  username: string,
+) => {
+  const res = await api.post("/api/users", {
+    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
+  });
+  expect(res.status()).toBe(201);
+};
+
+const createArticle = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  title: string,
+  tagList: string[] = [],
+): Promise<string> => {
+  const res = await api.post("/api/articles", {
+    data: { article: { title, description: "d", body: "b", tagList } },
+  });
+  expect(res.status()).toBe(201);
+  const body = (await res.json()) as { article: { slug: string } };
+  return body.article.slug;
+};
+
+test.describe("issue #10 — API GET /api/articles", () => {
+  test("Scenario 1: default list returns newest first + articlesCount", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await request.newContext({ baseURL: API_URL });
+    await registerUser(api, jake);
+
+    const s1 = await createArticle(api, `A1 ${id}`);
+    await new Promise((r) => setTimeout(r, 20));
+    const s2 = await createArticle(api, `A2 ${id}`);
+    await new Promise((r) => setTimeout(r, 20));
+    const s3 = await createArticle(api, `A3 ${id}`);
+
+    const res = await api.get(`/api/articles?author=${jake}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{ slug: string; createdAt: string }>;
+      articlesCount: number;
+    };
+    expect(body.articlesCount).toBe(3);
+    expect(body.articles.map((a) => a.slug)).toEqual([s3, s2, s1]);
+    expect(Date.parse(body.articles[0].createdAt)).toBeGreaterThan(
+      Date.parse(body.articles[1].createdAt),
+    );
+    expect(Date.parse(body.articles[1].createdAt)).toBeGreaterThan(
+      Date.parse(body.articles[2].createdAt),
+    );
+  });
+
+  test("Scenario 2: filter by tag returns only articles carrying that tag", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await request.newContext({ baseURL: API_URL });
+    await registerUser(api, jake);
+
+    const dragons = `dragons-${id}`;
+    const training = `training-${id}`;
+
+    const slugA = await createArticle(api, `A ${id}`, [dragons]);
+    await createArticle(api, `B ${id}`, [training]);
+    const slugC = await createArticle(api, `C ${id}`, [dragons, training]);
+
+    const res = await api.get(`/api/articles?tag=${dragons}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{ slug: string }>;
+      articlesCount: number;
+    };
+    expect(body.articlesCount).toBe(2);
+    expect(body.articles.map((a) => a.slug).sort()).toEqual([slugA, slugC].sort());
+  });
+
+  test("Scenario 3: filter by author returns only that author's articles", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+
+    await createArticle(jakeApi, `J1 ${id}`);
+    await createArticle(jakeApi, `J2 ${id}`);
+    await createArticle(danApi, `D1 ${id}`);
+
+    const res = await jakeApi.get(`/api/articles?author=${jake}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{ author: { username: string } }>;
+      articlesCount: number;
+    };
+    expect(body.articlesCount).toBe(2);
+    for (const a of body.articles) {
+      expect(a.author.username).toBe(jake);
+    }
+  });
+
+  test("Scenario 4: filter by favorited-by-username", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+
+    const slugA = await createArticle(jakeApi, `Fav-A ${id}`);
+    await createArticle(jakeApi, `Fav-B ${id}`);
+
+    const fav = await danApi.post(`/api/articles/${slugA}/favorite`);
+    expect(fav.status()).toBe(200);
+
+    const res = await jakeApi.get(`/api/articles?favorited=${dan}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{ slug: string }>;
+      articlesCount: number;
+    };
+    expect(body.articlesCount).toBe(1);
+    expect(body.articles[0].slug).toBe(slugA);
+  });
+
+  test("Scenario 5: pagination respects limit + offset", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await request.newContext({ baseURL: API_URL });
+    await registerUser(api, jake);
+
+    // Seed 25 articles. Author filter isolates this spec from others
+    // running in parallel against the same stack.
+    for (let i = 0; i < 25; i += 1) {
+      await createArticle(api, `P${i.toString().padStart(2, "0")} ${id}`);
+    }
+
+    const res = await api.get(`/api/articles?author=${jake}&limit=10&offset=10`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{ title: string }>;
+      articlesCount: number;
+    };
+    expect(body.articles.length).toBe(10);
+    expect(body.articlesCount).toBe(25);
+    // Offset 10 in a newest-first 25-article list = items 14 through 5
+    // (0-indexed: items 10 through 19 of the desc-sorted slice).
+    // Titles are P24 (newest) down to P00 (oldest); offset 10 starts at P14.
+    expect(body.articles[0].title).toBe(`P14 ${id}`);
+    expect(body.articles[9].title).toBe(`P05 ${id}`);
+  });
+
+  test("Scenario 6: authenticated viewer sees viewer-relative favorited + following", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await request.newContext({ baseURL: API_URL });
+    const danApi = await request.newContext({ baseURL: API_URL });
+    await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+
+    const slugA = await createArticle(jakeApi, `S6 ${id}`);
+    await danApi.post(`/api/articles/${slugA}/favorite`);
+    await danApi.post(`/api/profiles/${jake}/follow`);
+
+    const res = await danApi.get(`/api/articles?author=${jake}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      articles: Array<{
+        slug: string;
+        favorited: boolean;
+        favoritesCount: number;
+        author: { following: boolean };
+      }>;
+    };
+    const a = body.articles.find((x) => x.slug === slugA);
+    expect(a, "article A should be in the response").toBeDefined();
+    expect(a!.favorited).toBe(true);
+    expect(a!.favoritesCount).toBe(1);
+    expect(a!.author.following).toBe(true);
+  });
+
+  test("Scenario 7: invalid limit is rejected with 422", async () => {
+    const anon = await request.newContext({ baseURL: API_URL });
+    const res = await anon.get(`/api/articles?limit=999`);
+    expect(res.status()).toBe(422);
+    const body = (await res.json()) as { errors: Record<string, string[]> };
+    const allMessages = Object.values(body.errors).flat().join(" ");
+    expect(allMessages.toLowerCase()).toContain("must be at most 100");
+  });
+});


### PR DESCRIPTION
[generator @ gen-kxe47s]

Closes #10

## User Intent

`GET /api/articles` returns the article list with optional `tag`, `author`, `favorited` filters and `limit` / `offset` pagination. Response shape is `{ articles: [...], articlesCount: N }` where `articlesCount` is the total matching rows before the slice — the UI uses it for pagination affordances. Anonymous reads are allowed; authenticated viewers see viewer-relative `favorited` and `author.following` flags.

## Upstream reuse

Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5 (attribution, per docs/adr/000-reference-review.md §4, §9). Filter-clause composition + order-by-createdAt-desc follow upstream. Deliberate redesign: explicit `limit` cap of 100 at the zod layer (upstream accepts any value). Rejecting over-limit keeps response times bounded and gives callers a shape-consistent 422 rather than a silent row scan.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -p conduit-gen -f infra/docker-compose.yml --env-file /tmp/.env.gen ps
conduit-gen-api-1        api        Up (healthy)      :3201
conduit-gen-postgres-1   postgres   Up (healthy)      :5533
conduit-gen-web-1        web        Up (healthy)      :3200
```

### BDD scenarios — all 7 AC scenarios

`tests/e2e/specs/10-api-articles-list.spec.ts` — 7/7 green:

- ✓ Scenario 1 — default list returns newest first + correct `articlesCount`.
- ✓ Scenario 2 — filter by tag returns only articles carrying it (including multi-tag matches).
- ✓ Scenario 3 — filter by author narrows to exactly that author.
- ✓ Scenario 4 — filter by favorited-by-username returns only that user's favorites.
- ✓ Scenario 5 — limit=10 & offset=10 against a 25-seed returns items 14 down through 5 (newest-first index 10-19), with `articlesCount` = 25.
- ✓ Scenario 6 — authenticated viewer who follows + favorited sees `favorited:true` + `author.following:true` in the list envelope.
- ✓ Scenario 7 — `limit=999` returns 422 with `errors.limit` saying "must be at most 100".

### Full local E2E

Against the generator-isolated stack (`conduit-gen`): **64 specs passed** (every article / comments / profile / auth / tags / layout / web-auth suite). The 4 `#25` observability scenarios that use `docker logs conduit-api-1` fail against this isolated project (my container is `conduit-gen-api-1`); on the shared `conduit` stack those pass — this is the same cosmetic mismatch noted in PR #53 and not introduced by #10.

### Portability check

```
$ git diff --unified=0 origin/latest...HEAD -- ':!tests/e2e/specs' | \
    grep -E '^\+' | grep -Ev '^\+\+\+' | \
    grep -E 'localhost:[0-9]|/home/|AKIA|sk_live'
(no output — clean)
```

Two new env vars: `ARTICLE_LIST_DEFAULT_LIMIT` (default 20) and `ARTICLE_LIST_MAX_LIMIT` (default 100), both with sensible defaults in `apps/api/src/config.ts` so compose doesn't need a change unless ops wants per-env tuning.

### Typecheck + lint

Both clean.

### Infra

No infra change.

## Notes for the evaluator

- **Shared-path auth discipline**: GET + POST on `/api/articles` share the path. Hono's `.use(path, mw)` is method-agnostic, so mounting `requireAuth()` on the path would 401 anonymous GETs. The list route mounts `optionalAuth()` (serves both methods), and the create handler enforces auth via its own `if (!viewer) → 401`. Same pattern we've established on `/api/articles/{slug}` (#9) and `/api/articles/{slug}/comments` (#13).
- **`articlesCount` is a separate query**, not a transactional snapshot. That matches every RealWorld reference implementation and avoids interactive-transaction lock contention; a rapidly-changing article set might show count / slice drift at the boundary, but the upstream contract tolerates it.
- **`includeFor(viewerId)` reuse**: exported by #12. The list hits the same narrow `favoritedBy` include pattern so per-article queries stay bounded regardless of total fav count. Adding this as a test will help if future changes to `toEnvelope` fork drift — the `articleInclude` export pattern is working as intended.

Timestamp: 2026-04-29 15:49 KST (06:49Z)
