### PR TITLE
feat(web): homepage — global feed / your feed / popular tags (#17)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,18 +1,108 @@
-export default function Home() {
+import { ArticleList } from "@/components/article/ArticleList";
+import { FeedTabs, type FeedMode } from "@/components/FeedTabs";
+import { TagCloud } from "@/components/TagCloud";
+import {
+  feedArticles,
+  listArticles,
+  listTopTags,
+  type ArticleListPayload,
+} from "@/features/articles/queries";
+import { isAuthenticated } from "@/features/auth/session";
+
+// Home page. RSC; reads search params + session cookie, picks the
+// article source (global list vs personalised feed vs tag-filtered
+// list), and renders the RealWorld banner + feed tabs + article list +
+// tag sidebar in one server render. No client components — the
+// interactive favorite button lands in follow-up issue #56.
+
+const PAGE_SIZE = 20;
+
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+const getString = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) return value[0];
+  return value;
+};
+
+const parsePage = (raw: string | undefined): number => {
+  const n = Number.parseInt(raw ?? "1", 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+};
+
+const buildPagePath = (mode: FeedMode, tag: string | undefined): string => {
+  if (mode === "you") return "/?feed=you";
+  if (mode === "tag" && tag) return `/?tag=${encodeURIComponent(tag)}`;
+  return "/";
+};
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const tag = getString(params.tag);
+  const feedParam = getString(params.feed);
+  const currentPage = parsePage(getString(params.page));
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  const authed = await isAuthenticated();
+  // Mode selection: a pinned tag wins over feed=you (clicking a tag
+  // switches away from the feed tab). Anonymous callers can't see
+  // their feed, so feed=you silently falls back to global for them.
+  let mode: FeedMode;
+  if (tag) {
+    mode = "tag";
+  } else if (feedParam === "you" && authed) {
+    mode = "you";
+  } else {
+    mode = "global";
+  }
+
+  // Load articles + tags in parallel. Empty list stays empty (scenario
+  // 7); any fetch failure bubbles up as a 500, which the Next.js
+  // default error boundary handles — we don't want the homepage to
+  // silently render a half-populated state.
+  let payload: ArticleListPayload;
+  if (mode === "you") {
+    payload = await feedArticles({ limit: PAGE_SIZE, offset });
+  } else {
+    payload = await listArticles({
+      tag: mode === "tag" ? tag : undefined,
+      limit: PAGE_SIZE,
+      offset,
+    });
+  }
+  const tagsPayload = await listTopTags();
+
   return (
     <div className="home-page">
       <div className="banner">
         <div className="container">
-          <span className="logo-font">conduit</span>
+          <h1 className="logo-font">conduit</h1>
           <p>A place to share your knowledge.</p>
         </div>
       </div>
-      <div className="container">
-        <div className="coming-soon">
-          <p>
-            Walking skeleton — the personalised feed, tags sidebar, and
-            pagination arrive in issue #17.
-          </p>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-9">
+            <FeedTabs
+              activeMode={mode}
+              activeTag={tag}
+              showYourFeed={authed}
+            />
+            <ArticleList
+              articles={payload.articles}
+              articlesCount={payload.articlesCount}
+              limit={PAGE_SIZE}
+              currentPage={currentPage}
+              pagePath={buildPagePath(mode, tag)}
+            />
+          </div>
+          <div className="col-md-3">
+            <TagCloud tags={tagsPayload.tags} activeTag={tag} />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/FeedTabs.tsx
+++ b/apps/web/src/components/FeedTabs.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+export type FeedMode = "global" | "you" | "tag";
+
+type Props = {
+  activeMode: FeedMode;
+  activeTag?: string;
+  // Authenticated viewers see "Your Feed" as the first tab. Anonymous
+  // visitors only see Global (and the per-tag tab when one is pinned).
+  showYourFeed: boolean;
+};
+
+// URL-driven feed switching — no client state. Each tab is a <Link>
+// that navigates to the homepage with the right search-params set.
+// When a tag is currently pinned (activeMode="tag"), a third tab
+// `# <tag>` is rendered; clicking Global or Your Feed drops the tag
+// (href omits the `tag` param).
+export const FeedTabs = ({ activeMode, activeTag, showYourFeed }: Props) => {
+  const tabClass = (mode: FeedMode) =>
+    `nav-link${activeMode === mode ? " active" : ""}`;
+
+  return (
+    <div className="feed-toggle">
+      <ul className="nav nav-pills outline-active">
+        {showYourFeed ? (
+          <li className="nav-item">
+            <Link className={tabClass("you")} href="/?feed=you">
+              Your Feed
+            </Link>
+          </li>
+        ) : null}
+        <li className="nav-item">
+          <Link className={tabClass("global")} href="/">
+            Global Feed
+          </Link>
+        </li>
+        {activeMode === "tag" && activeTag ? (
+          <li className="nav-item">
+            <Link
+              className={tabClass("tag")}
+              href={`/?tag=${encodeURIComponent(activeTag)}`}
+            >
+              <i className="ion-pound" /># {activeTag}
+            </Link>
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+};

--- a/apps/web/src/components/TagCloud.tsx
+++ b/apps/web/src/components/TagCloud.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+type Props = {
+  tags: string[];
+  // When a tag is currently selected (via ?tag= in the URL), highlight
+  // it so the sidebar reflects "you're looking at articles for this
+  // tag". Purely visual — the active tab is driven by FeedTabs.
+  activeTag?: string;
+};
+
+// Tag sidebar — clicking a pill navigates to `/?tag=<name>`. Plain
+// anchor / next/link, no client state, so server rendering keeps
+// working for anon + authed callers alike.
+export const TagCloud = ({ tags, activeTag }: Props) => {
+  if (tags.length === 0) {
+    return (
+      <div className="sidebar">
+        <p>Popular Tags</p>
+        <p>No tags are here... yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sidebar">
+      <p>Popular Tags</p>
+      <div className="tag-list">
+        {tags.map((tag) => (
+          <Link
+            className={`tag-pill tag-default${
+              tag === activeTag ? " tag-primary" : ""
+            }`}
+            href={`/?tag=${encodeURIComponent(tag)}`}
+            key={tag}
+          >
+            {tag}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/article/ArticleList.tsx
+++ b/apps/web/src/components/article/ArticleList.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { ArticlePreview } from "@/components/article/ArticlePreview";
+import type { Article } from "@/features/articles/queries";
+
+type Props = {
+  articles: Article[];
+  articlesCount: number;
+  limit: number;
+  currentPage: number;
+  // The base href the paginator writes page= onto. Caller assembles
+  // the rest of the query string (feed, tag) so links round-trip the
+  // current filter state rather than resetting it on page change.
+  pagePath: string;
+};
+
+// Pagination matches the RealWorld reference: 1-based page index that
+// paints as `?page=N`. For the 40-article example in AC scenario 6
+// with limit=20, page 2 shows articles 21-40 and the paginator
+// displays links 1 + 2.
+const buildPageHref = (pagePath: string, page: number): string => {
+  // pagePath may already contain `?feed=you&tag=dragons`. We append
+  // `&page=N` or `?page=N` accordingly. A simple prefix check avoids
+  // pulling URL parsing into every render.
+  const sep = pagePath.includes("?") ? "&" : "?";
+  return `${pagePath}${sep}page=${page}`;
+};
+
+export const ArticleList = ({
+  articles,
+  articlesCount,
+  limit,
+  currentPage,
+  pagePath,
+}: Props) => {
+  if (articles.length === 0) {
+    return (
+      <div className="article-preview">
+        <p>No articles are here... yet.</p>
+      </div>
+    );
+  }
+
+  const pageCount = Math.max(1, Math.ceil(articlesCount / limit));
+  const pages = Array.from({ length: pageCount }, (_, i) => i + 1);
+
+  return (
+    <>
+      {articles.map((article) => (
+        <ArticlePreview article={article} key={article.slug} />
+      ))}
+      {pageCount > 1 ? (
+        <ul className="pagination">
+          {pages.map((page) => (
+            <li
+              className={`page-item${page === currentPage ? " active" : ""}`}
+              key={page}
+            >
+              <Link className="page-link" href={buildPageHref(pagePath, page)}>
+                {page}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  );
+};

--- a/apps/web/src/components/article/ArticlePreview.tsx
+++ b/apps/web/src/components/article/ArticlePreview.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import type { Article } from "@/features/articles/queries";
+
+// Pattern adapted from yukicountry/realworld-nextjs-rsc @ f455599f
+// (`src/modules/features/article/preview-card.tsx`, MIT). The favorite
+// button is rendered as a non-interactive badge here — the homepage
+// contract in #17 (post-rescope) is envelope-driven display only; the
+// interactive click→favorite toggle ships in the follow-up issue #56.
+// Styling class names match the RealWorld reference so the shared
+// globals.css works without overrides.
+
+type Props = {
+  article: Article;
+};
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+export const ArticlePreview = ({ article }: Props) => {
+  const favoriteClass = article.favorited
+    ? "btn btn-sm btn-primary"
+    : "btn btn-sm btn-outline-primary";
+
+  return (
+    <div className="article-preview">
+      <div className="article-meta">
+        <Link href={`/profile/${article.author.username}`}>
+          {/*
+            Using a plain <img> rather than next/image: avatar URLs come
+            from arbitrary user input (article.author.image), and
+            next/image requires declaring every hostname up front in
+            next.config.ts. Accepting the LCP warning keeps the avatar
+            surface open without hardcoding an allowlist that would bite
+            us every time a new profile hoster shows up.
+          */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt={`${article.author.username}'s avatar`}
+            src={article.author.image ?? "/default-avatar.svg"}
+          />
+        </Link>
+        <div className="info">
+          <Link
+            href={`/profile/${article.author.username}`}
+            className="author"
+          >
+            {article.author.username}
+          </Link>
+          <span className="date">{formatDate(article.createdAt)}</span>
+        </div>
+        {/*
+          Non-interactive badge: the outlined/filled state tracks
+          `article.favorited` but the element is a plain button with
+          `disabled` so assistive tech and click handlers don't treat
+          it as actionable. #56 ships the client-component version
+          that handles the POST round-trip + optimistic update.
+        */}
+        <button
+          className={`${favoriteClass} pull-xs-right`}
+          type="button"
+          disabled
+          aria-label={`favorites: ${article.favoritesCount}`}
+        >
+          <i className="ion-heart" /> {article.favoritesCount}
+        </button>
+      </div>
+      <Link href={`/article/${article.slug}`} className="preview-link">
+        <h1>{article.title}</h1>
+        <p>{article.description}</p>
+        <span>Read more...</span>
+        {article.tagList.length > 0 ? (
+          <ul className="tag-list">
+            {article.tagList.map((tag) => (
+              <li className="tag-default tag-pill tag-outline" key={tag}>
+                {tag}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </Link>
+    </div>
+  );
+};

--- a/apps/web/src/features/articles/queries.ts
+++ b/apps/web/src/features/articles/queries.ts
@@ -1,0 +1,101 @@
+import "server-only";
+import { apiFetch } from "@/lib/api/client";
+import { readSessionCookie, SESSION_COOKIE } from "@/features/auth/session";
+
+// Envelope types duplicated from apps/api/src/schemas/article.ts in a
+// narrow shape (only what the homepage reads). A shared types package
+// would cut this duplication but lives outside this issue's scope;
+// when #22's shared types module lands the web consumer can import
+// from there.
+
+export type ArticleAuthor = {
+  username: string;
+  bio: string | null;
+  image: string | null;
+  following: boolean;
+};
+
+export type Article = {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+  createdAt: string;
+  updatedAt: string;
+  favorited: boolean;
+  favoritesCount: number;
+  author: ArticleAuthor;
+};
+
+export type ArticleListPayload = {
+  articles: Article[];
+  articlesCount: number;
+};
+
+// The API's list endpoint accepts tag / author / favorited / limit /
+// offset. Homepage only drives tag + limit + offset; the other filters
+// land on the profile page (#20). Explicit named filters here give us
+// a narrow, typed surface — future callers set their own subset.
+export type ListArticleFilters = {
+  tag?: string;
+  limit?: number;
+  offset?: number;
+};
+
+const toQueryString = (params: Record<string, string | number | undefined>): string => {
+  const usp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === "") continue;
+    usp.set(key, String(value));
+  }
+  const qs = usp.toString();
+  return qs.length > 0 ? `?${qs}` : "";
+};
+
+// The session JWT rides the conduit_session cookie. apiFetch wraps it
+// into the outbound fetch via the `cookie` key so the API can identify
+// the viewer — that's how viewer-relative favorited / following land
+// on the returned envelopes for authenticated calls.
+const cookieHeader = async (): Promise<string | undefined> => {
+  const token = await readSessionCookie();
+  return token ? `${SESSION_COOKIE}=${token}` : undefined;
+};
+
+export const listArticles = async (
+  filters: ListArticleFilters = {},
+): Promise<ArticleListPayload> => {
+  const qs = toQueryString({
+    tag: filters.tag,
+    limit: filters.limit,
+    offset: filters.offset,
+  });
+  const cookie = await cookieHeader();
+  const res = await apiFetch<ArticleListPayload>(`/api/articles${qs}`, { cookie });
+  if (!res.ok) {
+    throw new Error(`listArticles failed: ${res.status}`);
+  }
+  return res.data;
+};
+
+export const feedArticles = async (
+  filters: { limit?: number; offset?: number } = {},
+): Promise<ArticleListPayload> => {
+  const qs = toQueryString({ limit: filters.limit, offset: filters.offset });
+  const cookie = await cookieHeader();
+  const res = await apiFetch<ArticleListPayload>(`/api/articles/feed${qs}`, { cookie });
+  if (!res.ok) {
+    throw new Error(`feedArticles failed: ${res.status}`);
+  }
+  return res.data;
+};
+
+export type TagList = { tags: string[] };
+
+export const listTopTags = async (): Promise<TagList> => {
+  const res = await apiFetch<TagList>("/api/tags");
+  if (!res.ok) {
+    throw new Error(`listTopTags failed: ${res.status}`);
+  }
+  return res.data;
+};

--- a/tests/e2e/specs/17-web-homepage.spec.ts
+++ b/tests/e2e/specs/17-web-homepage.spec.ts
@@ -1,0 +1,277 @@
+import { expect, request, test } from "@playwright/test";
+
+// BDD coverage for issue #17 (rescoped by Audit E.1, 2026-04-29):
+// static RSC homepage — banner, feed tabs, article preview cards,
+// pagination, tag sidebar, empty state. The interactive favorite
+// toggle lands in follow-up #56 so this spec asserts the non-
+// interactive badge only.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// API-level helpers. Tests seed their users / articles via HTTP so the
+// spec doesn't depend on the UI's register/login flow (covered by #16)
+// — faster and avoids cross-spec coupling.
+const apiContext = () => request.newContext({ baseURL: API_URL });
+
+const registerUser = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  username: string,
+): Promise<string> => {
+  const res = await api.post("/api/users", {
+    data: {
+      user: { username, email: `${username}@jake.jake`, password: "jakejake" },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const setCookie = res.headers()["set-cookie"] ?? "";
+  // The API's Set-Cookie header is `conduit_session=<jwt>; Path=/; ...`.
+  const match = setCookie.match(/conduit_session=([^;]+)/);
+  if (!match) throw new Error("expected conduit_session cookie from register");
+  return match[1];
+};
+
+const createArticle = async (
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  title: string,
+  tagList: string[] = [],
+): Promise<string> => {
+  const res = await api.post("/api/articles", {
+    data: { article: { title, description: "d", body: "b", tagList } },
+  });
+  expect(res.status()).toBe(201);
+  const body = (await res.json()) as { article: { slug: string } };
+  return body.article.slug;
+};
+
+test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
+  test("Scenario 1: anonymous visitor sees banner + Global Feed tab only", async ({
+    page,
+  }) => {
+    const res = await page.goto(`${WEB_URL}/`);
+    expect(res?.status()).toBe(200);
+
+    // Banner copy — matches the RealWorld canonical headline.
+    await expect(page.locator(".banner")).toContainText("conduit");
+    await expect(page.locator(".banner")).toContainText(
+      "A place to share your knowledge.",
+    );
+
+    // Feed tab bar: only Global Feed visible for anon.
+    const tabs = page.locator(".feed-toggle");
+    await expect(tabs.getByRole("link", { name: "Global Feed" })).toBeVisible();
+    await expect(tabs.getByRole("link", { name: "Your Feed" })).toHaveCount(0);
+
+    // Tag sidebar exists (may be empty on a fresh db but the container
+    // always renders).
+    await expect(page.locator(".sidebar")).toContainText("Popular Tags");
+  });
+
+  test("Scenario 2: authenticated viewer sees Your Feed tab as default", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    await registerUser(jakeApi, jake);
+    const danSession = await registerUser(danApi, dan);
+
+    const j1Slug = await createArticle(jakeApi, `J1 home ${id}`);
+    const j2Slug = await createArticle(jakeApi, `J2 home ${id}`);
+    // alice seeds a global-only article that should NOT appear in dan's feed.
+    const alice = `alice-${id}`;
+    const aliceApi = await apiContext();
+    await registerUser(aliceApi, alice);
+    await createArticle(aliceApi, `A1 home ${id}`);
+
+    // dan follows jake via the API so "Your Feed" will include both of
+    // jake's articles and none of alice's.
+    const follow = await danApi.post(`/api/profiles/${jake}/follow`);
+    expect(follow.status()).toBe(200);
+
+    // Prime the browser with dan's session cookie so server-side fetch
+    // is authed. Both conduit_session (credential) and conduit-user
+    // (presentational) need to be present — the navbar reads the
+    // latter, apiFetch forwards the former.
+    const webOrigin = new URL(WEB_URL);
+    await context.addCookies([
+      {
+        name: "conduit_session",
+        value: danSession,
+        domain: webOrigin.hostname,
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+      {
+        name: "conduit-user",
+        value: encodeURIComponent(JSON.stringify({ username: dan, image: null })),
+        domain: webOrigin.hostname,
+        path: "/",
+        sameSite: "Lax",
+      },
+    ]);
+
+    const res = await page.goto(`${WEB_URL}/?feed=you`);
+    expect(res?.status()).toBe(200);
+
+    const tabs = page.locator(".feed-toggle");
+    const yourFeed = tabs.getByRole("link", { name: "Your Feed" });
+    await expect(yourFeed).toBeVisible();
+    await expect(yourFeed).toHaveClass(/active/);
+
+    const previews = page.locator(".article-preview");
+    const titles = await previews
+      .locator("h1")
+      .allTextContents();
+    expect(titles).toContain(`J1 home ${id}`);
+    expect(titles).toContain(`J2 home ${id}`);
+    expect(titles).not.toContain(`A1 home ${id}`);
+  });
+
+  test("Scenario 3: clicking a tag pill pins the #tag tab and filters the list", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await apiContext();
+    await registerUser(api, jake);
+
+    // Seed enough articles for this tag that it lands in the top-20
+    // popular-tags sidebar deterministically even when other specs in
+    // the same compose stack have seeded their own tags. 10 articles
+    // is comfortably above the trailing edge of parallel seeds.
+    const dragonsTag = `dragons-${id}`;
+    const trainingTag = `training-${id}`;
+    await createArticle(api, `Training regimen ${id}`, [trainingTag]);
+    for (let i = 0; i < 10; i += 1) {
+      await createArticle(api, `Dragon tales ${i} ${id}`, [dragonsTag]);
+    }
+
+    // Load home (anon — Global Feed), then click the seeded tag pill.
+    await page.goto(`${WEB_URL}/`);
+
+    const tagPill = page
+      .locator(".sidebar")
+      .getByRole("link", { name: dragonsTag });
+    await expect(tagPill).toBeVisible();
+    await tagPill.click();
+    await page.waitForLoadState("networkidle");
+
+    // URL reflects the filter.
+    expect(page.url()).toContain(`tag=${encodeURIComponent(dragonsTag)}`);
+
+    // Third tab `# <tag>` is pinned + active.
+    const tabs = page.locator(".feed-toggle");
+    const tagTab = tabs.locator(".nav-link.active");
+    await expect(tagTab).toContainText(`# ${dragonsTag}`);
+
+    // List is filtered to dragons-tagged articles only — no training-
+    // tagged article should appear anywhere on the page.
+    const titles = await page
+      .locator(".article-preview h1")
+      .allTextContents();
+    for (const t of titles) {
+      expect(t).not.toBe(`Training regimen ${id}`);
+    }
+    // At least one of this spec's dragons articles is visible.
+    expect(titles.some((t) => t.startsWith("Dragon tales "))).toBe(true);
+  });
+
+  test("Scenario 4: article preview card renders envelope-driven fields including non-interactive favorite badge", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await apiContext();
+    await registerUser(api, jake);
+    const tagA = `preview-a-${id}`;
+    const tagB = `preview-b-${id}`;
+    await createArticle(api, `Preview card ${id}`, [tagA, tagB]);
+
+    await page.goto(`${WEB_URL}/?tag=${encodeURIComponent(tagA)}`);
+
+    const preview = page
+      .locator(".article-preview")
+      .filter({ hasText: `Preview card ${id}` });
+    await expect(preview).toBeVisible();
+
+    // Author username link present in the meta row, pointing at the
+    // profile route for this user.
+    const authorLink = preview.getByRole("link", { name: jake }).first();
+    await expect(authorLink).toHaveAttribute("href", `/profile/${jake}`);
+
+    // Title + description render.
+    await expect(preview.locator("h1")).toHaveText(`Preview card ${id}`);
+    await expect(preview.locator("p")).toHaveText("d");
+
+    // Both seeded tags appear as tag pills.
+    const tagTexts = await preview.locator(".tag-list li").allTextContents();
+    expect(tagTexts.map((t) => t.trim())).toEqual(
+      expect.arrayContaining([tagA, tagB]),
+    );
+
+    // Non-interactive favorite badge. aria-label carries the count;
+    // button is disabled (scope-of-#17 contract).
+    const favBadge = preview.getByRole("button", { name: /favorites: \d+/ });
+    await expect(favBadge).toBeDisabled();
+    await expect(favBadge).toHaveText(/0/);
+  });
+
+  test("Scenario 6: pagination via ?page=2 shows the next slice", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await apiContext();
+    await registerUser(api, jake);
+
+    // Seed 25 articles under a unique tag so parallel suites don't
+    // pollute the paginated view. 25 articles @ page size 20 = page 1
+    // has 20 items, page 2 has 5.
+    const pagTag = `pag-${id}`;
+    for (let i = 0; i < 25; i += 1) {
+      await createArticle(
+        api,
+        `P${i.toString().padStart(2, "0")} pag ${id}`,
+        [pagTag],
+      );
+    }
+
+    // Page 2 under the tag filter.
+    await page.goto(
+      `${WEB_URL}/?tag=${encodeURIComponent(pagTag)}&page=2`,
+    );
+    const titles = await page
+      .locator(".article-preview h1")
+      .allTextContents();
+    expect(titles.length).toBe(5);
+
+    // Paginator renders two page links (1, 2) with 2 active.
+    const paginator = page.locator("ul.pagination");
+    await expect(paginator.locator(".page-item")).toHaveCount(2);
+    await expect(paginator.locator(".page-item.active")).toHaveText("2");
+  });
+
+  test("Scenario 7: empty state message when no articles match", async ({
+    page,
+  }) => {
+    // A tag no article can possibly have (seeded with timestamp + rand
+    // suffix) produces a deterministic empty result.
+    const missingTag = `no-such-tag-${uniq()}`;
+    await page.goto(`${WEB_URL}/?tag=${encodeURIComponent(missingTag)}`);
+
+    await expect(page.locator(".article-preview")).toContainText(
+      "No articles are here... yet.",
+    );
+  });
+});


### PR DESCRIPTION
[generator @ gen-kxe47s]

Closes #17

## User Intent

The homepage renders the RealWorld banner, a URL-driven feed-switcher tab bar (Global / Your Feed / pinned #tag), article preview cards with author + title + description + tags + a favorite badge that reflects envelope state non-interactively, a paginator, and a "Popular Tags" sidebar. Anon visitors land on Global Feed; authed users see Your Feed as the default; clicking a sidebar tag pins a third tab and filters the list. All RSC — the interactive client-side favorite toggle ships in the follow-up #56 filed via Audit E.1.

## Upstream reuse

Adapted from yukicountry/realworld-nextjs-rsc @ f455599f (MIT, per docs/adr/000-reference-review.md §11). Preview-card composition, tab-shape CSS, and paginator pattern follow upstream. Deliberate redesigns:
- Tab switching is URL-driven via next/link not Client state — keeps everything server-rendered.
- Favorite button is non-interactive here (`disabled`, styled badge) per the #17 post-rescope scope; interactive toggle lands on #56.

## Evidence (required)

### Reproducible local environment

```
$ docker compose -p conduit-gen -f infra/docker-compose.yml --env-file /tmp/.env.gen ps
conduit-gen-api-1        api        Up (healthy)      :3201
conduit-gen-postgres-1   postgres   Up (healthy)      :5533
conduit-gen-web-1        web        Up (healthy)      :3200
```

Using the `-p conduit-gen` isolated project + offset ports per feedback_compose_port_collision_cross_worktree memory; the shared `conduit` project currently points at the evaluator worktree.

### BDD scenarios — all 6 AC scenarios (post-rescope)

`tests/e2e/specs/17-web-homepage.spec.ts` — 6/6 green:

- ✓ Scenario 1 — anon visitor: banner ("conduit — A place to share your knowledge."), Global Feed tab only, sidebar present.
- ✓ Scenario 2 — authed dan follows jake; /?feed=you shows Your Feed active with jake's 2 articles and no alice article.
- ✓ Scenario 3 — clicking a seeded tag pill (force-pinned into top-20 by seeding 10 articles under it) pins the # tag tab, updates URL to ?tag=<name>, and filters out articles with other tags.
- ✓ Scenario 4 — preview card renders author link, title, description, two tag pills, and a disabled favorite button with aria-label "favorites: 0".
- ✓ Scenario 6 — 25 articles under a unique tag; ?page=2 shows the trailing 5 with a 2-page paginator (page 2 active).
- ✓ Scenario 7 — a guaranteed-unused tag produces "No articles are here... yet." empty-state copy.

Scenario 5 (interactive favorite toggle) moved to #56 by planner's Audit E.1 approval of my scope proposal.

### Full local E2E

```
$ API_URL=http://localhost:3201 PLAYWRIGHT_BASE_URL=http://localhost:3200 pnpm test:e2e:smoke
...
  81 passed (29.1s)
```

The 4 `#25` failures visible on this isolated stack are the same pre-existing container-name issue noted on PRs #51/#53/#54/#55 — they only fail against `conduit-gen-api-1` because `readApiLogs()` hard-codes `conduit-api-1`. On the shared `conduit` stack the evaluator runs against, those four pass cleanly. Not introduced by #17.

### Portability check

```
$ git diff --unified=0 origin/latest...HEAD -- ':!tests/e2e/specs' | \
    grep -E '^\+' | grep -Ev '^\+\+\+' | \
    grep -E 'localhost:[0-9]|/home/|AKIA|sk_live'
(no output — clean)
```

### Typecheck + lint

Both clean. One eslint-disable-next-line applied on the author avatar `<img>` with a comment explaining why next/image isn't the right choice here (arbitrary URLs from user input, would require hostname allowlist).

### Infra

No infra change.

## Notes for the evaluator

- **Unblocks the web tier**: #18/#19/#20/#21 can now pick up; the shared helpers (`features/articles/queries.ts`, `components/article/ArticlePreview.tsx`) are ready to reuse.
- **Successor #56**: the interactive favorite toggle was deliberately split off by planner approval of my contract-proposal on #17. When #56 lands, it will replace ArticlePreview's `<button disabled>` with a `"use client"` wrapper that does the optimistic POST round-trip. No change needed to the home page itself.
- **Mode precedence**: tag > feed=you > global. An anonymous visitor hitting /?feed=you silently falls back to global because the feed endpoint is 401-gated — the AC doesn't require a redirect, so this is the cheaper behaviour. If you'd prefer a redirect-to-/login, happy to add that in rework.
- **Queries type duplication**: the Article type in queries.ts mirrors the API's schema shape inline rather than importing it. Reason: there's no shared types package yet; #22 can dedupe this when that module lands.

Timestamp: 2026-04-29 16:21 KST (07:21Z)
