### PR TITLE
fix(test): parameterize docker container name in observability spec (#58)

### DIFF
--- a/tests/e2e/specs/25-api-observability-floor.spec.ts
+++ b/tests/e2e/specs/25-api-observability-floor.spec.ts
@@ -16,6 +16,15 @@ const API_URL =
 
 const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
 
+// The compose project name (default `conduit` from infra/docker-compose.yml's
+// `name:` field) prefixes every container: `<project>-<service>-1`. The
+// evaluator worktree runs under a distinct project (`-p conduit-eval`) to
+// avoid port collisions with the generator's concurrent stack — so the
+// API container name becomes `conduit-eval-api-1` there. Resolve from
+// env rather than hardcoding so both worktrees pass. See issue #58.
+const COMPOSE_PROJECT = process.env.COMPOSE_PROJECT ?? "conduit";
+const API_CONTAINER = `${COMPOSE_PROJECT}-api-1`;
+
 // Use execFile (no shell) so there's no command-injection surface.
 // `docker logs` prints to stdout; we filter in JS rather than piping
 // through `grep` under a shell.
@@ -23,7 +32,7 @@ const readApiLogs = (marker: string, tail = 600): string => {
   try {
     const out = execFileSync(
       "docker",
-      ["logs", "conduit-api-1", "--tail", String(tail)],
+      ["logs", API_CONTAINER, "--tail", String(tail)],
       { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
     return out


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #58.

## User Intent

The 4 Playwright scenarios in `25-api-observability-floor.spec.ts` that read `docker logs` pass under the default compose project (`conduit`) and under the evaluator's isolation project (`conduit-eval`). No one sees a log-reading failure again just because compose was launched with a different `-p` flag.

## Root cause + fix

`readApiLogs()` (line 26) hardcoded the API container name to `conduit-api-1`. Compose derives container names from the project name (default `conduit` via `infra/docker-compose.yml`'s `name:` field), so any runner using `docker compose -p conduit-eval …` gets `conduit-eval-api-1`, and `docker logs conduit-api-1` returns empty → every marker-grep assertion fails.

Fix: resolve the container name from a new `COMPOSE_PROJECT` env var (default `conduit`):

```ts
const COMPOSE_PROJECT = process.env.COMPOSE_PROJECT ?? "conduit";
const API_CONTAINER = `${COMPOSE_PROJECT}-api-1`;
```

## Runner integration (evaluator merge gate)

The evaluator's `eval-merge-gate.sh` (or whichever script launches compose under `-p conduit-eval`) must export `COMPOSE_PROJECT=conduit-eval` alongside the existing `PLAYWRIGHT_BASE_URL` / `API_URL` overrides, so the spec resolves the right container:

```bash
COMPOSE_PROJECT=conduit-eval \
PLAYWRIGHT_BASE_URL=http://localhost:3300 \
API_URL=http://localhost:3301 \
NEXT_PUBLIC_API_URL=http://localhost:3301 \
  node_modules/.bin/playwright test …
```

Default local / CI runs need no change — `COMPOSE_PROJECT` is unset, falls back to `conduit`.

## Evidence

- `pnpm lint` ✓, `pnpm typecheck` ✓.
- **Default project** (`docker compose -f infra/docker-compose.yml --env-file .env up -d --build`):
  ```
  Running 8 tests using 1 worker
  … 8 passed (3.9s)
  ```
- **Evaluator project** (`docker compose -p conduit-eval -f infra/docker-compose.yml --env-file /tmp/.env.eval up -d --build`) with `COMPOSE_PROJECT=conduit-eval` exported:
  ```
  Running 8 tests using 1 worker
  … 8 passed (3.8s)
  ```
- **Regression reproducer**: running under `-p conduit-eval` *without* `COMPOSE_PROJECT` set reproduces the evaluator's report exactly — scenarios 1 and 2a fail with "expected a log line tagged with obs-rid-…" because the spec looks for `conduit-api-1` which doesn't exist. With the env var, both pass.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`
- [x] Playwright spec under default compose project — 8/8 pass
- [x] Playwright spec under `-p conduit-eval` with `COMPOSE_PROJECT=conduit-eval` — 8/8 pass
- [x] Regression reproducer confirms the old hardcode is what the evaluator hit
- [ ] CI Playwright smoke stays green on this PR (CI doesn't use `-p`, so default `conduit` path applies)
- [ ] Evaluator merge gate exports `COMPOSE_PROJECT=conduit-eval` (runner change, outside this PR's diff)
