### PR TITLE
feat(web): article detail page — markdown + comments + follow/favorite (#18)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,12 @@
     "next": "16.2.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "rehype-sanitize": "6.0.0",
+    "rehype-stringify": "10.0.1",
+    "remark-gfm": "4.0.1",
+    "remark-parse": "11.0.0",
+    "remark-rehype": "11.1.2",
+    "unified": "11.0.5",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/apps/web/src/app/article/[slug]/not-found.tsx
+++ b/apps/web/src/app/article/[slug]/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="container page article-not-found">
+      <h1>Article not found</h1>
+      <p>
+        The article you were looking for does not exist or has been removed.
+      </p>
+      <Link href="/" className="btn btn-primary">
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/article/[slug]/page.tsx
+++ b/apps/web/src/app/article/[slug]/page.tsx
@@ -1,6 +1,26 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArticleBody } from "@/components/article/ArticleBody";
+import { ArticleMeta } from "@/components/article/ArticleMeta";
+import { CommentList } from "@/components/comment/CommentList";
+import { CommentForm } from "@/components/comment/CommentForm";
+import {
+  getArticle,
+  listComments,
+  type Comment,
+} from "@/features/articles/queries";
+import {
+  isAuthenticated,
+  readCurrentUsername,
+} from "@/features/auth/session";
 
 export const metadata = { title: "Article — Conduit" };
+
+// Article detail page (#18). RSC: fetches article + comments + viewer
+// state in parallel, renders banner + meta + body + tag list + comments
+// region. Interactive buttons (follow, favorite, delete, comment form /
+// delete-comment) are client components that wrap server actions so
+// the initial paint is fully SSR'd and SEO-friendly.
 
 export default async function ArticlePage({
   params,
@@ -8,12 +28,91 @@ export default async function ArticlePage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
+
+  // Parallel fetches: the article + comments + viewer cookie read are
+  // independent, so don't serialize them. getArticle returns null on
+  // 404 so we can call notFound() for the correct Next.js 404 flow;
+  // listComments returns [] on 404, which is defensive — the article
+  // check already filters that case.
+  const [article, comments, authed, viewerUsername] = await Promise.all([
+    getArticle(slug),
+    listComments(slug),
+    isAuthenticated(),
+    readCurrentUsername(),
+  ]);
+
+  if (!article) {
+    notFound();
+  }
+
   return (
-    <ComingSoon title="Article">
-      <p>
-        Viewing <code>{slug}</code> — markdown rendering, comments, and
-        follow/favorite controls land in issue #18.
-      </p>
-    </ComingSoon>
+    <div className="article-page">
+      <div className="banner">
+        <div className="container">
+          <h1>{article.title}</h1>
+          <ArticleMeta
+            article={article}
+            viewerUsername={viewerUsername}
+            authed={authed}
+          />
+        </div>
+      </div>
+
+      <div className="container page">
+        <ArticleBody body={article.body} tagList={article.tagList} />
+
+        <hr />
+
+        <div className="article-actions">
+          <ArticleMeta
+            article={article}
+            viewerUsername={viewerUsername}
+            authed={authed}
+          />
+        </div>
+
+        <div className="row">
+          <div className="col-xs-12 col-md-8 offset-md-2">
+            <CommentsRegion
+              slug={article.slug}
+              comments={comments}
+              authed={authed}
+              viewerUsername={viewerUsername}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
+
+const CommentsRegion = ({
+  slug,
+  comments,
+  authed,
+  viewerUsername,
+}: {
+  slug: string;
+  comments: Comment[];
+  authed: boolean;
+  viewerUsername: string | null;
+}) => {
+  return (
+    <section aria-label="Comments">
+      <h2 className="sr-only">Comments</h2>
+      {authed && viewerUsername ? (
+        <CommentForm slug={slug} avatar={null} username={viewerUsername} />
+      ) : (
+        <p>
+          <Link href="/login">Sign in</Link> or{" "}
+          <Link href="/register">sign up</Link> to add comments on this article.
+        </p>
+      )}
+      <CommentList
+        slug={slug}
+        comments={comments}
+        viewerUsername={viewerUsername}
+      />
+    </section>
+  );
+};

--- a/apps/web/src/components/article/ArticleBody.tsx
+++ b/apps/web/src/components/article/ArticleBody.tsx
@@ -1,0 +1,37 @@
+import { renderMarkdown } from "@/lib/markdown";
+
+type Props = { body: string; tagList: string[] };
+
+// RSC markdown render. The pipeline runs server-side through
+// rehype-sanitize (lib/markdown.ts), so the returned HTML is already
+// XSS-safe: scripts, event handlers, and unsafe URL protocols are
+// stripped. dangerouslySetInnerHTML is the only way to inject
+// pre-rendered HTML into React; the "dangerous" naming is the React
+// convention, but the content here is sanitized input per ADR 000
+// §12 (rehype-sanitize is non-negotiable).
+//
+// data-testid on the wrapper scopes the Playwright assertion in AC
+// scenario 3 to the body region only.
+export const ArticleBody = async ({ body, tagList }: Props) => {
+  const html = await renderMarkdown(body);
+  return (
+    <div className="row article-content">
+      <div className="col-md-12">
+        <div
+          className="article-body"
+          data-testid="article-body"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+        {tagList.length > 0 ? (
+          <ul className="tag-list">
+            {tagList.map((tag) => (
+              <li key={tag} className="tag-default tag-pill tag-outline">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/article/ArticleMeta.tsx
+++ b/apps/web/src/components/article/ArticleMeta.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import type { Article } from "@/features/articles/queries";
+import { FollowButton } from "./FollowButton";
+import { FavoriteButton } from "./FavoriteButton";
+import { DeleteArticleButton } from "./DeleteArticleButton";
+
+type Props = {
+  article: Article;
+  viewerUsername: string | null;
+  authed: boolean;
+};
+
+const formatDate = (iso: string): string => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+};
+
+// Article author line + action buttons. Reused by both the banner
+// (top of page) and the footer meta (below body) per the RealWorld
+// UI spec — content identical, wrapper differs.
+export const ArticleMeta = ({ article, viewerUsername, authed }: Props) => {
+  const isOwn = viewerUsername === article.author.username;
+  const profileHref = `/profile/${encodeURIComponent(article.author.username)}`;
+
+  return (
+    <div className="article-meta">
+      <Link href={profileHref}>
+        {article.author.image ? (
+          // Remote user-supplied avatar URLs don't belong in next/image's
+          // domains allowlist; the bitmap is tiny (32–64 px) and cached
+          // by the browser. Matches the pattern in Navbar / ArticlePreview.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={article.author.image} alt={`${article.author.username} avatar`} />
+        ) : null}
+      </Link>
+      <div className="info">
+        <Link href={profileHref} className="author">
+          {article.author.username}
+        </Link>
+        <span className="date">{formatDate(article.createdAt)}</span>
+      </div>
+      {isOwn ? (
+        <>
+          <Link
+            href={`/editor/${encodeURIComponent(article.slug)}`}
+            className="btn btn-sm btn-outline-secondary"
+          >
+            <span aria-hidden="true">✎</span> Edit Article
+          </Link>
+          &nbsp;&nbsp;
+          <DeleteArticleButton slug={article.slug} />
+        </>
+      ) : authed ? (
+        <>
+          <FollowButton
+            username={article.author.username}
+            following={article.author.following}
+          />
+          &nbsp;&nbsp;
+          <FavoriteButton
+            slug={article.slug}
+            favorited={article.favorited}
+            favoritesCount={article.favoritesCount}
+          />
+        </>
+      ) : (
+        <>
+          <Link href="/login" className="btn btn-sm btn-outline-secondary">
+            <span aria-hidden="true">+</span> Follow {article.author.username}
+          </Link>
+          &nbsp;&nbsp;
+          <Link href="/login" className="btn btn-sm btn-outline-primary">
+            <span aria-hidden="true">♥</span> Favorite Article ({article.favoritesCount})
+          </Link>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/article/DeleteArticleButton.tsx
+++ b/apps/web/src/components/article/DeleteArticleButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useTransition } from "react";
+import { deleteArticle } from "@/features/articles/actions";
+
+type Props = { slug: string };
+
+// Confirm-before-delete is the browser-native confirm(). Spec
+// scenario 4 expects the delete to fire after the user confirms and
+// then redirect to `/` — the server action handles the redirect.
+// No additional client UI here; keeping the surface small.
+export const DeleteArticleButton = ({ slug }: Props) => {
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (!window.confirm("Delete this article?")) return;
+    startTransition(async () => {
+      await deleteArticle(slug);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-busy={isPending}
+      disabled={isPending}
+      onClick={onClick}
+      className="btn btn-sm btn-outline-danger"
+    >
+      <span aria-hidden="true">🗑</span> Delete Article
+    </button>
+  );
+};

--- a/apps/web/src/components/article/FavoriteButton.tsx
+++ b/apps/web/src/components/article/FavoriteButton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useOptimistic, useTransition } from "react";
+import {
+  favoriteArticle,
+  unfavoriteArticle,
+} from "@/features/articles/actions";
+
+type Props = {
+  slug: string;
+  favorited: boolean;
+  favoritesCount: number;
+  disabled?: boolean;
+  // variant=detail is the big banner/footer button; variant=compact
+  // is the preview card's right-aligned pill. Both flip the same
+  // state; they differ only in label + classes.
+  variant?: "detail" | "compact";
+};
+
+export const FavoriteButton = ({
+  slug,
+  favorited,
+  favoritesCount,
+  disabled,
+  variant = "detail",
+}: Props) => {
+  const [optimistic, setOptimistic] = useOptimistic(
+    { favorited, favoritesCount },
+    (
+      prev: { favorited: boolean; favoritesCount: number },
+      next: { favorited: boolean },
+    ) => ({
+      favorited: next.favorited,
+      favoritesCount:
+        prev.favoritesCount + (next.favorited === prev.favorited ? 0 : next.favorited ? 1 : -1),
+    }),
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (disabled) return;
+    const next = !optimistic.favorited;
+    startTransition(async () => {
+      setOptimistic({ favorited: next });
+      if (next) {
+        await favoriteArticle(slug);
+      } else {
+        await unfavoriteArticle(slug);
+      }
+    });
+  };
+
+  const label =
+    variant === "compact"
+      ? optimistic.favoritesCount
+      : `${optimistic.favorited ? "Unfavorite" : "Favorite"} Article (${optimistic.favoritesCount})`;
+
+  return (
+    <button
+      type="button"
+      aria-pressed={optimistic.favorited}
+      aria-busy={isPending}
+      disabled={disabled || isPending}
+      onClick={onClick}
+      className={`btn btn-sm ${
+        optimistic.favorited ? "btn-primary" : "btn-outline-primary"
+      } ${variant === "compact" ? "pull-xs-right" : ""}`}
+    >
+      <span aria-hidden="true">♥</span> {label}
+    </button>
+  );
+};

--- a/apps/web/src/components/article/FollowButton.tsx
+++ b/apps/web/src/components/article/FollowButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useOptimistic, useTransition } from "react";
+import { followAuthor, unfollowAuthor } from "@/features/articles/actions";
+
+// Client toggle for follow/unfollow. useOptimistic lets the label +
+// active class flip immediately on click, the server action runs in
+// a transition, and the RSC page revalidates so the persisted state
+// lands on the next render — matching AC scenario 2's "button
+// switches … without full reload / refresh shows persisted".
+
+type Props = {
+  username: string;
+  following: boolean;
+  // Anonymous viewers see a disabled-looking button that links to
+  // login (matches AC scenario 1 — we render it here rather than
+  // hiding entirely so the page structure is identical authed vs
+  // anonymous; the action just gates behind authed flag).
+  disabled?: boolean;
+};
+
+export const FollowButton = ({ username, following, disabled }: Props) => {
+  const [optimisticFollowing, setOptimisticFollowing] = useOptimistic(
+    following,
+    (_, next: boolean) => next,
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (disabled) return;
+    const next = !optimisticFollowing;
+    startTransition(async () => {
+      setOptimisticFollowing(next);
+      if (next) {
+        await followAuthor(username);
+      } else {
+        await unfollowAuthor(username);
+      }
+    });
+  };
+
+  const label = optimisticFollowing
+    ? `Unfollow ${username}`
+    : `Follow ${username}`;
+  const icon = optimisticFollowing ? "−" : "+";
+
+  return (
+    <button
+      type="button"
+      aria-pressed={optimisticFollowing}
+      aria-busy={isPending}
+      disabled={disabled || isPending}
+      onClick={onClick}
+      className={`btn btn-sm ${
+        optimisticFollowing ? "btn-secondary" : "btn-outline-secondary"
+      }`}
+    >
+      <span aria-hidden="true">{icon}</span> {label}
+    </button>
+  );
+};

--- a/apps/web/src/components/comment/CommentForm.tsx
+++ b/apps/web/src/components/comment/CommentForm.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useActionState, useRef, useEffect } from "react";
+import {
+  postCommentAction,
+  type PostCommentResult,
+} from "@/features/comments/actions";
+
+type Props = { slug: string; avatar: string | null; username: string };
+
+// Authenticated comment compose box. useActionState drives the
+// submission; on success we reset the textarea (the list below
+// re-renders from revalidatePath so the new comment appears at the
+// top per AC scenario 6). Errors render in-form.
+export const CommentForm = ({ slug, avatar, username }: Props) => {
+  const action = postCommentAction.bind(null, slug);
+  const [state, formAction, isPending] = useActionState<
+    PostCommentResult | null,
+    FormData
+  >(action, null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state?.ok) {
+      formRef.current?.reset();
+    }
+  }, [state]);
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="card comment-form"
+      aria-label="Post a comment"
+    >
+      <div className="card-block">
+        <textarea
+          name="body"
+          className="form-control"
+          placeholder="Write a comment..."
+          rows={3}
+          aria-label="Comment body"
+          required
+        />
+      </div>
+      <div className="card-footer">
+        {avatar ? (
+          // Tiny author avatar; see Navbar / ArticlePreview for the
+          // established pattern of plain <img> over next/image here.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatar}
+            alt={`${username} avatar`}
+            className="comment-author-img"
+          />
+        ) : null}
+        <button
+          type="submit"
+          className="btn btn-sm btn-primary"
+          disabled={isPending}
+          aria-busy={isPending}
+        >
+          Post Comment
+        </button>
+      </div>
+      {state && !state.ok ? (
+        <ul className="error-messages" role="alert">
+          {state.errors.map((e) => (
+            <li key={e}>{e}</li>
+          ))}
+        </ul>
+      ) : null}
+    </form>
+  );
+};

--- a/apps/web/src/components/comment/CommentItem.tsx
+++ b/apps/web/src/components/comment/CommentItem.tsx
@@ -1,0 +1,58 @@
+import type { Comment } from "@/features/articles/queries";
+import { DeleteCommentButton } from "./DeleteCommentButton";
+
+type Props = {
+  slug: string;
+  comment: Comment;
+  viewerUsername: string | null;
+};
+
+const formatDate = (iso: string): string => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+};
+
+export const CommentItem = ({ slug, comment, viewerUsername }: Props) => {
+  const isOwn = viewerUsername === comment.author.username;
+  return (
+    <div className="card" data-testid={`comment-${comment.id}`}>
+      <div className="card-block">
+        <p className="card-text">{comment.body}</p>
+      </div>
+      <div className="card-footer">
+        <a
+          href={`/profile/${encodeURIComponent(comment.author.username)}`}
+          className="comment-author"
+        >
+          {comment.author.image ? (
+            // Tiny comment-author avatar; see established pattern in
+            // Navbar / ArticlePreview for plain <img> vs next/image.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={comment.author.image}
+              alt={`${comment.author.username} avatar`}
+              className="comment-author-img"
+            />
+          ) : null}
+        </a>
+        &nbsp;
+        <a
+          href={`/profile/${encodeURIComponent(comment.author.username)}`}
+          className="comment-author"
+        >
+          {comment.author.username}
+        </a>
+        <span className="date-posted">{formatDate(comment.createdAt)}</span>
+        {isOwn ? (
+          <DeleteCommentButton slug={slug} commentId={comment.id} />
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/comment/CommentList.tsx
+++ b/apps/web/src/components/comment/CommentList.tsx
@@ -1,0 +1,32 @@
+import type { Comment } from "@/features/articles/queries";
+import { CommentItem } from "./CommentItem";
+
+type Props = {
+  slug: string;
+  comments: Comment[];
+  viewerUsername: string | null;
+};
+
+export const CommentList = ({ slug, comments, viewerUsername }: Props) => {
+  if (comments.length === 0) {
+    return <p className="empty-comments">No comments yet.</p>;
+  }
+  // Newest first per AC scenario 5. The API lists by createdAt desc
+  // already; re-sort defensively in case that ordering is ever
+  // relaxed upstream.
+  const sorted = [...comments].sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+  return (
+    <div data-testid="comment-list">
+      {sorted.map((c) => (
+        <CommentItem
+          key={c.id}
+          slug={slug}
+          comment={c}
+          viewerUsername={viewerUsername}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/comment/DeleteCommentButton.tsx
+++ b/apps/web/src/components/comment/DeleteCommentButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTransition } from "react";
+import { deleteComment } from "@/features/comments/actions";
+
+type Props = { slug: string; commentId: number };
+
+export const DeleteCommentButton = ({ slug, commentId }: Props) => {
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    startTransition(async () => {
+      await deleteComment(slug, commentId);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="mod-options"
+      aria-label="Delete comment"
+      aria-busy={isPending}
+      disabled={isPending}
+      onClick={onClick}
+    >
+      <span aria-hidden="true">🗑</span>
+    </button>
+  );
+};

--- a/apps/web/src/features/articles/actions.ts
+++ b/apps/web/src/features/articles/actions.ts
@@ -1,0 +1,102 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { apiFetch } from "@/lib/api/client";
+import { readSessionCookie, SESSION_COOKIE } from "@/features/auth/session";
+
+// Server actions for the article detail page (#18).
+//
+// Follow / unfollow, favorite / unfavorite, delete. Each swaps one
+// state, then calls `revalidatePath` so the article page's RSC
+// refreshes its cached fetch — the button components render their
+// own optimistic intermediate state via useOptimistic so the switch
+// looks instant while the revalidation round-trip completes.
+//
+// All five require an authenticated viewer; the client components
+// only render the actions for authed users, but we still guard here
+// because a server action is a public surface.
+
+const cookieHeader = async (): Promise<string | undefined> => {
+  const token = await readSessionCookie();
+  return token ? `${SESSION_COOKIE}=${token}` : undefined;
+};
+
+const requireSession = async (): Promise<string> => {
+  const cookie = await cookieHeader();
+  if (!cookie) {
+    throw new Error("unauthenticated");
+  }
+  return cookie;
+};
+
+export const followAuthor = async (username: string): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/profiles/${encodeURIComponent(username)}/follow`,
+    { method: "POST", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`followAuthor failed: ${res.status}`);
+  }
+  // The article page reads viewer-relative `following`, so bust its
+  // per-request cache. Profile page (#20) will share this path.
+  revalidatePath(`/article/[slug]`, "page");
+  revalidatePath(`/profile/${encodeURIComponent(username)}`, "page");
+};
+
+export const unfollowAuthor = async (username: string): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/profiles/${encodeURIComponent(username)}/follow`,
+    { method: "DELETE", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`unfollowAuthor failed: ${res.status}`);
+  }
+  revalidatePath(`/article/[slug]`, "page");
+  revalidatePath(`/profile/${encodeURIComponent(username)}`, "page");
+};
+
+export const favoriteArticle = async (slug: string): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/articles/${encodeURIComponent(slug)}/favorite`,
+    { method: "POST", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`favoriteArticle failed: ${res.status}`);
+  }
+  // Bust both the detail page (favoritesCount + favorited flip) and
+  // the homepage (favoritesCount in the preview list).
+  revalidatePath(`/article/[slug]`, "page");
+  revalidatePath("/");
+};
+
+export const unfavoriteArticle = async (slug: string): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/articles/${encodeURIComponent(slug)}/favorite`,
+    { method: "DELETE", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`unfavoriteArticle failed: ${res.status}`);
+  }
+  revalidatePath(`/article/[slug]`, "page");
+  revalidatePath("/");
+};
+
+export const deleteArticle = async (slug: string): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/articles/${encodeURIComponent(slug)}`,
+    { method: "DELETE", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`deleteArticle failed: ${res.status}`);
+  }
+  // Article is gone; homepage list must refresh, and then redirect
+  // out of the now-404 detail page to root (AC scenario 4).
+  revalidatePath("/");
+  redirect("/");
+};

--- a/apps/web/src/features/articles/queries.ts
+++ b/apps/web/src/features/articles/queries.ts
@@ -99,3 +99,46 @@ export const listTopTags = async (): Promise<TagList> => {
   }
   return res.data;
 };
+
+export type Comment = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: ArticleAuthor;
+};
+
+export type ArticlePayload = { article: Article };
+export type CommentsPayload = { comments: Comment[] };
+export type CommentPayload = { comment: Comment };
+
+// 404 is a documented AC scenario; surface it as a null rather than a
+// thrown error so the page handler can call notFound() for the
+// correct Next.js 404 flow (AC scenario 8). Any other non-2xx remains
+// an exception — unexpected API errors should surface as a 500
+// boundary rather than a silent empty page.
+export const getArticle = async (slug: string): Promise<Article | null> => {
+  const cookie = await cookieHeader();
+  const res = await apiFetch<ArticlePayload>(
+    `/api/articles/${encodeURIComponent(slug)}`,
+    { cookie },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`getArticle failed: ${res.status}`);
+  }
+  return res.data.article;
+};
+
+export const listComments = async (slug: string): Promise<Comment[]> => {
+  const cookie = await cookieHeader();
+  const res = await apiFetch<CommentsPayload>(
+    `/api/articles/${encodeURIComponent(slug)}/comments`,
+    { cookie },
+  );
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    throw new Error(`listComments failed: ${res.status}`);
+  }
+  return res.data.comments;
+};

--- a/apps/web/src/features/auth/session.ts
+++ b/apps/web/src/features/auth/session.ts
@@ -97,3 +97,24 @@ export const isAuthenticated = async (): Promise<boolean> => {
   // purposes; the API will reject forged tokens on its own.
   return Boolean(jar.get(SESSION_COOKIE)?.value || jar.get(USER_COOKIE)?.value);
 };
+
+// Presentation-only hint: who is the viewer, per the readable user
+// cookie. Used by the article detail page to decide between
+// author-only controls (Edit / Delete) and viewer controls (Follow /
+// Favorite) on its initial RSC render. Returning null for anonymous
+// viewers keeps the rendering branch simple.
+export const readCurrentUsername = async (): Promise<string | null> => {
+  const jar = await cookies();
+  const raw = jar.get(USER_COOKIE)?.value;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw)) as {
+      username?: unknown;
+    };
+    return typeof parsed.username === "string" && parsed.username.length > 0
+      ? parsed.username
+      : null;
+  } catch {
+    return null;
+  }
+};

--- a/apps/web/src/features/comments/actions.ts
+++ b/apps/web/src/features/comments/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { apiFetch } from "@/lib/api/client";
+import { readSessionCookie, SESSION_COOKIE } from "@/features/auth/session";
+
+// Comment server actions for the article detail page (#18).
+//
+// postComment returns a discriminated result so CommentForm can
+// render inline validation errors (API 422) without bubbling a
+// generic exception. deleteComment throws on failure — the client
+// component treats any error as "stay put, show the row", which is
+// the right UX for a trash-icon click that fails.
+
+const cookieHeader = async (): Promise<string | undefined> => {
+  const token = await readSessionCookie();
+  return token ? `${SESSION_COOKIE}=${token}` : undefined;
+};
+
+const requireSession = async (): Promise<string> => {
+  const cookie = await cookieHeader();
+  if (!cookie) {
+    throw new Error("unauthenticated");
+  }
+  return cookie;
+};
+
+export type PostCommentResult =
+  | { ok: true }
+  | { ok: false; errors: string[] };
+
+export const postCommentAction = async (
+  slug: string,
+  _prev: PostCommentResult | null,
+  formData: FormData,
+): Promise<PostCommentResult> => {
+  const raw = formData.get("body");
+  const body = typeof raw === "string" ? raw.trim() : "";
+  if (body.length === 0) {
+    return { ok: false, errors: ["Comment body can't be empty"] };
+  }
+
+  const cookie = await requireSession();
+  const res = await apiFetch<unknown>(
+    `/api/articles/${encodeURIComponent(slug)}/comments`,
+    {
+      method: "POST",
+      cookie,
+      body: JSON.stringify({ comment: { body } }),
+    },
+  );
+  if (!res.ok) {
+    const errs = (res.data as { errors?: Record<string, string[]> })?.errors;
+    const flat = errs
+      ? Object.entries(errs).flatMap(([k, msgs]) => msgs.map((m) => `${k} ${m}`))
+      : ["Failed to post comment"];
+    return { ok: false, errors: flat };
+  }
+
+  revalidatePath(`/article/[slug]`, "page");
+  return { ok: true };
+};
+
+export const deleteComment = async (
+  slug: string,
+  id: number,
+): Promise<void> => {
+  const cookie = await requireSession();
+  const res = await apiFetch(
+    `/api/articles/${encodeURIComponent(slug)}/comments/${id}`,
+    { method: "DELETE", cookie },
+  );
+  if (!res.ok) {
+    throw new Error(`deleteComment failed: ${res.status}`);
+  }
+  revalidatePath(`/article/[slug]`, "page");
+};

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+
+// Markdown pipeline for article bodies.
+//
+// Adapted from yukicountry/realworld-nextjs-rsc @ f455599f
+// (MIT, attributed in ADR 000 §12). The yukicountry chain is
+// unified → remark-parse → remark-rehype → rehype-stringify.
+// We add **rehype-sanitize** in the middle — the upstream omits it,
+// and without it `<script>` / `<iframe>` / event-handler attributes
+// ride the article body straight into the DOM (XSS). Deliberate
+// redesign vs upstream; non-negotiable per ADR 000 §12.
+//
+// Server-only so the (moderately heavy) ESM-only pipeline never
+// leaks into the client bundle — renders happen during the article
+// page's RSC pass.
+
+// Start from rehype-sanitize's default schema (GitHub-style — the
+// same safe subset rehype-sanitize README recommends) and re-allow
+// the two attributes our article body actually uses: `className`
+// (the remark-rehype output carries it for syntax blocks) and
+// `target` / `rel` on anchor tags (so external links open in a new
+// tab with noopener, the a11y-friendly default).
+const sanitizeSchema: typeof defaultSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes?.code ?? []), "className"],
+    a: [
+      ...(defaultSchema.attributes?.a ?? []),
+      ["target", "_blank"],
+      ["rel", "noopener", "noreferrer"],
+    ],
+  },
+};
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype, { allowDangerousHtml: false })
+  .use(rehypeSanitize, sanitizeSchema)
+  .use(rehypeStringify);
+
+export const renderMarkdown = async (body: string): Promise<string> => {
+  const file = await processor.process(body);
+  return String(file);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 8.49.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -96,6 +96,24 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      rehype-sanitize:
+        specifier: 6.0.0
+        version: 6.0.0
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
+      remark-gfm:
+        specifier: 4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: 11.1.2
+        version: 11.1.2
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -1647,11 +1665,17 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1664,6 +1688,9 @@ packages:
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1687,6 +1714,9 @@ packages:
 
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -1746,6 +1776,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.49.0':
     resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2070,6 +2103,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2163,6 +2199,9 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai-string@1.6.0:
     resolution: {integrity: sha512-sXV7whDmpax+8H++YaZelgin7aur1LGf9ZhjZa3ojETFJ0uPVuS4XEXuIagpZ/c8uVOtsSh4MwOjy5CBLjJSXA==}
     peerDependencies:
@@ -2183,6 +2222,15 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   chardet@2.0.0:
     resolution: {integrity: sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==}
@@ -2250,6 +2298,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -2337,6 +2388,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decomment@0.9.5:
     resolution: {integrity: sha512-h0TZ8t6Dp49duwyDHo3iw67mnh9/UpFiSSiOb5gDK1sqoXzrfX/SQxIUQd2R2QEiSnqib0KF2fnKnGfAhAs6lg==}
     engines: {node: '>=6.4', npm: '>=2.15'}
@@ -2383,6 +2437,10 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
@@ -2395,6 +2453,9 @@ packages:
 
   dev-null@0.1.1:
     resolution: {integrity: sha512-nMNZG0zfMgmdv8S5O0TM5cpwNbGKRGPCxVsr0SmA3NZZy9CYBbuNLL0PD3Acx9e5LIUgwONXtM9kM6RlawPxEQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2517,6 +2578,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -2936,6 +3001,15 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -2945,6 +3019,9 @@ packages:
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -3099,6 +3176,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -3416,6 +3497,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3444,9 +3528,48 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3454,6 +3577,90 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3916,6 +4123,9 @@ packages:
   property-expr@2.0.6:
     resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
@@ -3998,6 +4208,24 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   remeda@2.33.4:
     resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
@@ -4183,6 +4411,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -4241,6 +4472,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -4361,6 +4595,12 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4440,6 +4680,24 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -4494,6 +4752,12 @@ packages:
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4702,6 +4966,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6467,9 +6734,17 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
@@ -6481,6 +6756,10 @@ snapshots:
       '@types/node': 22.18.2
 
   '@types/lodash@4.17.24': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
 
@@ -6507,6 +6786,8 @@ snapshots:
   '@types/react@19.2.2':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -6598,6 +6879,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.49.0
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -7006,6 +7289,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -7097,6 +7382,8 @@ snapshots:
 
   caseless@0.12.0: {}
 
+  ccount@2.0.1: {}
+
   chai-string@1.6.0(chai@4.5.0):
     dependencies:
       chai: 4.5.0
@@ -7128,6 +7415,12 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
 
   chardet@2.0.0: {}
 
@@ -7210,6 +7503,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  comma-separated-tokens@2.0.3: {}
+
   commander@11.1.0: {}
 
   commander@8.3.0: {}
@@ -7282,6 +7577,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decomment@0.9.5:
     dependencies:
       esprima: 4.0.1
@@ -7322,6 +7621,8 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dequal@2.0.3: {}
+
   des.js@1.1.0:
     dependencies:
       inherits: 2.0.4
@@ -7332,6 +7633,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   dev-null@0.1.1: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -7540,6 +7845,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -8041,6 +8348,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -8048,6 +8379,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hono@4.12.15: {}
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -8209,6 +8542,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
@@ -8512,6 +8847,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8541,11 +8878,318 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -9087,6 +9731,8 @@ snapshots:
 
   property-expr@2.0.6: {}
 
+  property-information@7.1.0: {}
+
   protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -9193,6 +9839,51 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   remeda@2.33.4: {}
 
@@ -9435,6 +10126,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0: {}
 
   sqlstring@2.3.3: {}
@@ -9523,6 +10216,11 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -9613,6 +10311,10 @@ snapshots:
       tldts: 7.0.29
 
   tr46@0.0.3: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -9706,6 +10408,39 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.2.0: {}
 
   universalify@2.0.1: {}
@@ -9773,6 +10508,16 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite-node@3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -9810,7 +10555,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -9836,6 +10581,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@22.18.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.13
       '@types/node': 22.18.2
     transitivePeerDependencies:
       - jiti
@@ -9990,3 +10736,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/tests/e2e/specs/15-web-layout-shell.spec.ts
+++ b/tests/e2e/specs/15-web-layout-shell.spec.ts
@@ -3,14 +3,17 @@ import { mkdir } from "node:fs/promises";
 
 const SCREENSHOT_DIR = "tests/e2e/screenshots/15";
 const AUTH_COOKIE_NAME = "conduit-user";
+// `/article/[slug]` and `/profile/[username]` are excluded from this
+// always-200 list because they reflect real data after #18 / #20: a
+// non-existent slug/username returns 404 with a helpful "not found"
+// page instead of a ComingSoon stub. Layout-shell coverage for those
+// routes lives in 18-web-article-detail.spec.ts and the profile spec.
 const PROTECTED_ROUTES = [
   "/",
   "/login",
   "/register",
   "/settings",
   "/editor",
-  "/article/sample-slug",
-  "/profile/sample-user",
 ];
 
 test.beforeAll(async () => {

--- a/tests/e2e/specs/18-web-article-detail.spec.ts
+++ b/tests/e2e/specs/18-web-article-detail.spec.ts
@@ -1,0 +1,324 @@
+import { expect, request, test, type BrowserContext } from "@playwright/test";
+
+// BDD coverage for issue #18: article detail page with markdown,
+// comments, follow/favorite, author delete, and graceful 404.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Each test uses its own ApiRequestContext so we can set the
+// per-user auth cookie without bleed between scenarios.
+type ApiCtx = Awaited<ReturnType<typeof request.newContext>>;
+const apiContext = () => request.newContext({ baseURL: API_URL });
+
+const registerUser = async (api: ApiCtx, username: string): Promise<string> => {
+  const res = await api.post("/api/users", {
+    data: {
+      user: {
+        username,
+        email: `${username}@jake.jake`,
+        password: "jakejake",
+      },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const setCookie = res.headers()["set-cookie"] ?? "";
+  const match = setCookie.match(/conduit_session=([^;]+)/);
+  if (!match) throw new Error("expected conduit_session cookie from register");
+  return match[1];
+};
+
+type CreateArticleOpts = { title?: string; body?: string; tagList?: string[] };
+const createArticle = async (
+  api: ApiCtx,
+  opts: CreateArticleOpts = {},
+): Promise<{ slug: string; title: string }> => {
+  const title = opts.title ?? `Title ${uniq()}`;
+  const res = await api.post("/api/articles", {
+    data: {
+      article: {
+        title,
+        description: "d",
+        body: opts.body ?? "body",
+        tagList: opts.tagList ?? [],
+      },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const payload = (await res.json()) as { article: { slug: string } };
+  return { slug: payload.article.slug, title };
+};
+
+const primeSession = async (
+  context: BrowserContext,
+  session: string,
+  username: string,
+): Promise<void> => {
+  const webOrigin = new URL(WEB_URL);
+  await context.addCookies([
+    {
+      name: "conduit_session",
+      value: session,
+      domain: webOrigin.hostname,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+    {
+      name: "conduit-user",
+      value: encodeURIComponent(JSON.stringify({ username, image: null })),
+      domain: webOrigin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+};
+
+test.describe("issue #18 — article detail page", () => {
+  test("Scenario 1: anonymous view renders article + comments, compose box gated", async ({
+    page,
+  }) => {
+    const jakeApi = await apiContext();
+    await registerUser(jakeApi, `jake-${uniq()}`);
+    const { slug, title } = await createArticle(jakeApi, {
+      title: `Anon View ${uniq()}`,
+      body: "Hello body.",
+      tagList: ["anon"],
+    });
+
+    const res = await page.goto(`${WEB_URL}/article/${slug}`);
+    expect(res?.status()).toBe(200);
+
+    await expect(page.locator(".banner h1")).toHaveText(title);
+    await expect(page.getByTestId("article-body")).toContainText("Hello body.");
+    await expect(page.locator(".tag-list")).toContainText("anon");
+
+    // Compose box is replaced with a sign-in/register prompt.
+    await expect(page.locator('[aria-label="Comments"]')).toContainText(
+      "add comments",
+    );
+    await expect(
+      page.locator('textarea[name="body"]'),
+    ).toHaveCount(0);
+    // Follow + favorite buttons link to login rather than posting.
+    const banner = page.locator(".banner");
+    await expect(banner.getByRole("link", { name: /Follow/ })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+    await expect(
+      banner.getByRole("link", { name: /Favorite Article/ }),
+    ).toHaveAttribute("href", "/login");
+  });
+
+  test("Scenario 2: authed follow + favorite toggle persist through refresh", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    await registerUser(jakeApi, jake);
+    const danSession = await registerUser(danApi, dan);
+    const { slug } = await createArticle(jakeApi, { title: `Follow ${id}` });
+    await primeSession(context, danSession, dan);
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+
+    // The page renders ArticleMeta twice (banner + footer) per the
+    // RealWorld UI spec, so there are two copies of each button —
+    // scope to the banner's first instance when clicking.
+    const followBtn = page
+      .getByRole("button", { name: `Follow ${jake}` })
+      .first();
+    await expect(followBtn).toBeVisible();
+    await followBtn.click();
+    await expect(
+      page.getByRole("button", { name: `Unfollow ${jake}` }).first(),
+    ).toBeVisible();
+
+    const favBtn = page
+      .getByRole("button", { name: /Favorite Article \(0\)/ })
+      .first();
+    await favBtn.click();
+    await expect(
+      page.getByRole("button", { name: /Unfavorite Article \(1\)/ }).first(),
+    ).toBeVisible();
+
+    // Refresh: persisted server state should render the same labels.
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: `Unfollow ${jake}` }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Unfavorite Article \(1\)/ }).first(),
+    ).toBeVisible();
+  });
+
+  test("Scenario 3: markdown is rendered and sanitised", async ({ page }) => {
+    const jakeApi = await apiContext();
+    await registerUser(jakeApi, `jake-${uniq()}`);
+    const body = "# Heading\n\n**bold** text and a <script>alert(1)</script>";
+    const { slug } = await createArticle(jakeApi, {
+      title: `Markdown ${uniq()}`,
+      body,
+    });
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+
+    const bodyRegion = page.getByTestId("article-body");
+    await expect(bodyRegion.locator("h1")).toHaveText("Heading");
+    await expect(bodyRegion.locator("strong")).toHaveText("bold");
+    // rehype-sanitize must strip <script>. Scoped to the body region so
+    // the app's own script tags (Next runtime) are not counted.
+    await expect(bodyRegion.locator("script")).toHaveCount(0);
+    const html = await bodyRegion.innerHTML();
+    expect(html).not.toContain("<script>");
+  });
+
+  test("Scenario 4: author sees Edit + Delete, delete redirects home", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const jakeSession = await registerUser(jakeApi, jake);
+    const { slug } = await createArticle(jakeApi, { title: `Own ${id}` });
+    await primeSession(context, jakeSession, jake);
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+
+    await expect(
+      page.getByRole("link", { name: /Edit Article/ }).first(),
+    ).toHaveAttribute("href", `/editor/${slug}`);
+    // Follow/favorite must NOT appear on my own article.
+    await expect(
+      page.getByRole("button", { name: /Follow/ }),
+    ).toHaveCount(0);
+
+    // Auto-confirm the delete dialog, then click.
+    page.once("dialog", (d) => d.accept());
+    await page.getByRole("button", { name: /Delete Article/ }).first().click();
+
+    await page.waitForURL(`${WEB_URL}/`);
+    expect(page.url().replace(/\/$/, "")).toBe(WEB_URL);
+
+    // The article is gone: direct revisit yields 404.
+    const revisit = await page.goto(`${WEB_URL}/article/${slug}`);
+    expect(revisit?.status()).toBe(404);
+  });
+
+  test("Scenario 5: existing comments list renders newest-first", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jakeApi = await apiContext();
+    const jake = `jake-${id}`;
+    await registerUser(jakeApi, jake);
+    const { slug } = await createArticle(jakeApi, { title: `Comments ${id}` });
+
+    const first = await jakeApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: `first ${id}` } },
+    });
+    expect(first.status()).toBe(201);
+    // Tiny gap so the createdAt timestamps differ deterministically.
+    await new Promise((r) => setTimeout(r, 1100));
+    const second = await jakeApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: `second ${id}` } },
+    });
+    expect(second.status()).toBe(201);
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+    const bodies = await page
+      .getByTestId("comment-list")
+      .locator(".card-text")
+      .allTextContents();
+    expect(bodies.length).toBe(2);
+    expect(bodies[0]).toContain(`second ${id}`);
+    expect(bodies[1]).toContain(`first ${id}`);
+  });
+
+  test("Scenario 6: authenticated user posts a comment, it appears without full reload", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    await registerUser(jakeApi, jake);
+    const danSession = await registerUser(danApi, dan);
+    const { slug } = await createArticle(jakeApi, { title: `Post ${id}` });
+    await primeSession(context, danSession, dan);
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+    await page
+      .locator('textarea[name="body"]')
+      .fill(`a new comment ${id}`);
+    await page.getByRole("button", { name: "Post Comment" }).click();
+
+    await expect(
+      page.getByTestId("comment-list").locator(".card-text").first(),
+    ).toContainText(`a new comment ${id}`);
+  });
+
+  test("Scenario 7: comment author sees delete only on their own rows", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    await registerUser(jakeApi, jake);
+    const danSession = await registerUser(danApi, dan);
+    const { slug } = await createArticle(jakeApi, { title: `Trash ${id}` });
+
+    // Jake posts one comment, dan posts another.
+    const jRes = await jakeApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: `from-jake ${id}` } },
+    });
+    expect(jRes.status()).toBe(201);
+    const dRes = await danApi.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: `from-dan ${id}` } },
+    });
+    expect(dRes.status()).toBe(201);
+    const danCommentId = ((await dRes.json()) as { comment: { id: number } })
+      .comment.id;
+
+    await primeSession(context, danSession, dan);
+    await page.goto(`${WEB_URL}/article/${slug}`);
+
+    // Exactly one delete button visible — on dan's own row.
+    const deleteButtons = page.getByRole("button", { name: "Delete comment" });
+    await expect(deleteButtons).toHaveCount(1);
+
+    await deleteButtons.click();
+    await expect(
+      page.getByTestId(`comment-${danCommentId}`),
+    ).toHaveCount(0);
+    // Jake's comment still there.
+    await expect(page.getByTestId("comment-list")).toContainText(
+      `from-jake ${id}`,
+    );
+  });
+
+  test("Scenario 8: non-existent slug returns 404 with a helpful message", async ({
+    page,
+  }) => {
+    const res = await page.goto(`${WEB_URL}/article/no-such-slug-${uniq()}`);
+    expect(res?.status()).toBe(404);
+    await expect(page.locator("body")).toContainText("Article not found");
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #18.

## User Intent

A visitor lands on `/article/[slug]` and sees the full article — banner, author info, sanitised markdown body, tag pills, comment thread — in the initial server render. Authenticated viewers can follow the author, favorite the article, delete their own article or comments, and post new comments. An unknown slug yields a helpful 404 rather than a stub.

## What ships

- **RSC detail page** (`apps/web/src/app/article/[slug]/page.tsx`) — parallel-fetches article + comments + viewer state, calls `notFound()` on 404, renders banner meta + markdown body + tag list + comments region. `ArticleMeta` is rendered twice per RealWorld's canonical UI (banner + footer).
- **Markdown pipeline** (`apps/web/src/lib/markdown.ts`) — `unified → remark-parse → remark-gfm → remark-rehype → rehype-sanitize → rehype-stringify`. **`rehype-sanitize` is the deliberate redesign vs upstream** (`yukicountry/realworld-nextjs-rsc` omits it); without it any `<script>` / event-handler / `javascript:` URL in an article body would land straight in the DOM.
- **Server actions**:
  - `features/articles/actions.ts` — `followAuthor`, `unfollowAuthor`, `favoriteArticle`, `unfavoriteArticle`, `deleteArticle` (the last redirects to `/`).
  - `features/comments/actions.ts` — `postCommentAction` (returns discriminated result for inline form errors), `deleteComment`.
- **Client components**:
  - `FollowButton`, `FavoriteButton`, `DeleteArticleButton` — `useOptimistic` for instant label flips; `useTransition` for pending state.
  - `CommentForm` — `useActionState`, form resets on success, inline error list on 422.
  - `DeleteCommentButton` — trash icon, only renders on the viewer's own rows via the `CommentItem` `viewerUsername` check.
- **Query helpers** (`features/articles/queries.ts`) — `getArticle(slug)` returns `null` on 404 (for `notFound()`), `listComments(slug)` returns `[]`. Non-404 errors still throw so the 500 boundary catches them.
- **Session helper** — new `readCurrentUsername()` in `features/auth/session.ts` reads the presentation-only `conduit-user` cookie for the author/viewer comparison.
- **404 page** (`app/article/[slug]/not-found.tsx`) — "Article not found" + link home, per AC scenario 8.
- **Playwright spec** (`tests/e2e/specs/18-web-article-detail.spec.ts`) — 8 tests matching the 8 AC scenarios. Seeds users + articles + comments via the API context (no UI round-trips for setup), primes browser cookies for authed scenarios.
- **Spec 15 update** — `/article/[slug]` and `/profile/[username]` removed from the always-200 route list, because a non-existent slug/username now correctly returns 404. Behavior-change side-effect, not a scope cross.

## Reuse decisions honoured

Per ADR 000 §12:
- **Absorb verbatim**: the unified markdown chain shape.
- **Adapt**: button + form component composition from yukicountry.
- **Redesign**: `rehype-sanitize` added — non-negotiable XSS guard.

## Evidence

- **Local Playwright against compose** (`docker compose up -d --build`, then run against `:3100` / `:3101`):
  ```
  Running 8 tests using 1 worker
  … 8 passed (6.5s)
  ```
- **Regression sweep** (`15-web-layout-shell`, `16-web-auth-register-login`, `17-web-homepage`, `18-web-article-detail`): **26 passed**.
- `pnpm lint` ✓ (zero warnings), `pnpm typecheck` ✓, `pnpm --filter @conduit/web build` ✓.
- **XSS check** (scenario 3): the sanitize pipeline strips `<script>alert(1)</script>` — the Playwright spec asserts `page.getByTestId("article-body").locator("script")` returns 0 and the raw HTML contains no `<script>` substring.
- **Portability grep**: no hardcoded secrets, absolute paths, region/account ids. `localhost:3101` / `:3100` appear only as env-var defaults, matching the existing spec + lib pattern.

## Test plan

- [x] All 8 AC scenarios as Playwright tests, each mapped 1:1
- [x] Anonymous + authenticated rendering paths both exercised
- [x] Markdown + XSS sanitization verified against live compose
- [x] Delete flow reaches `notFound()` on revisit after delete
- [x] Comments: list ordering, post, author-only delete
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build`
- [x] Regression sweep of existing web specs (15, 16, 17) — all green
- [ ] CI smoke stays green on this PR (existing smoke.sh `/healthz` mismatch is a pre-existing issue on `latest`, not introduced here)
