### PR TITLE
fix(infra): smoke.sh asserts /healthz shape, not legacy literal (#61)

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -33,7 +33,12 @@ fi
 
 echo "[smoke] GET ${API_URL_HOST}/healthz"
 api_body=$(curl -fsS "${API_URL_HOST}/healthz")
-if [[ "$api_body" != '{"ok":true}' ]]; then
+# /healthz returns { ok, checks: { db } } per #25's observability floor.
+# Use a shape assertion (ok=true AND checks.db=ok) rather than literal
+# equality so the smoke catches db-fail (`checks.db=fail` → 503) the
+# same way it catches api-down, and so additive extensions to the
+# envelope (future `checks.queue`, `checks.cache`) don't break smoke.
+if ! printf '%s' "$api_body" | jq -e '.ok == true and .checks.db == "ok"' >/dev/null; then
   echo "[smoke] unexpected api body: $api_body" >&2
   exit 1
 fi


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #61.

## User Intent

Every PR's CI `compose up + smoke both services` job turns green again. The smoke check is no longer wedged on the pre-#25 `/healthz` body literal — it asserts the real shape and also catches a db-fail envelope the way #25 promised.

## What changes

One file. `scripts/smoke.sh` swaps the literal equality against `'{"ok":true}'` for a `jq -e '.ok == true and .checks.db == "ok"'` shape assertion. Rationale:

- Matches `apps/api/src/routes/healthz.ts`'s committed response `{ ok, checks: { db } }` (the shape `25-api-observability-floor.spec.ts` scenario 3a already asserts as correct).
- Fails the smoke when `checks.db == "fail"` — which is exactly the condition #49's deferred 503 side-stack spec will eventually drive, and a regression the old literal would *also* have caught (by not matching), but by accident.
- Tolerant of additive extensions (`checks.queue`, `checks.cache`) so future health probes land without another smoke update.

`jq` is already in the harness `scripts/*` toolkit (`eval-affected-scopes.sh`, `oss-discover.sh`) and preinstalled on `ubuntu-latest`, so no new CI dependency.

## Evidence

- Current `/healthz` body (local compose on `:3101`):
  ```
  {"ok":true,"checks":{"db":"ok"}}
  ```
- `bash scripts/smoke.sh` now exits 0:
  ```
  [smoke] postgres health
  [smoke] GET http://localhost:3101/healthz
  [smoke] GET http://localhost:3100/
  [smoke] all checks passed
  ```
- Shape-assertion sanity table (stdin → exit):
  | body | expected | actual |
  |---|---|---|
  | `{"ok":true,"checks":{"db":"ok"}}` | 0 | 0 |
  | `{"ok":true,"checks":{"db":"fail"}}` | 1 | 1 |
  | `{"ok":false,"checks":{"db":"fail"}}` | 1 | 1 |
  | `{"ok":true,"checks":{"db":"ok"},"checks_added_later":{"queue":"ok"}}` | 0 | 0 |

## Test plan

- [x] `bash scripts/smoke.sh` passes against current `latest` compose stack
- [x] Shape assertion rejects `ok=false`, `db=fail`
- [x] Shape assertion accepts additive envelope extensions
- [ ] CI `compose up + smoke both services` turns green on this PR
- [ ] Subsequent PRs (including my own #59 #60 #69) re-run CI and surface whatever latent issues were previously masked by the `smoke.sh` hard-fail
