### PR TITLE
fix(test): harden spec 14 tags-ordering against DB pollution (#72)

### DIFF
--- a/tests/e2e/specs/14-api-tags-list.spec.ts
+++ b/tests/e2e/specs/14-api-tags-list.spec.ts
@@ -40,16 +40,29 @@ test.describe("issue #14 — API GET /api/tags", () => {
     const api = await request.newContext({ baseURL: API_URL });
     await registerUser(api, jake);
 
-    // Namespace tags with `${id}` so the counts are deterministic even
-    // alongside other suites' articles. Three tags with 3/2/1 articles
-    // each — AC scenario 1's shape literally.
+    // Namespace tags with `${id}` so the counts stay comparable to
+    // other suites' seeds. All three tags need enough articles that
+    // they cannot be evicted from `/api/tags`'s top-20 slice by
+    // more-popular tags from prior spec runs — #72 fixed a
+    // regression where `t1` (1 article) fell out of the slice on a
+    // polluted DB. Counts: t3=7, t2=5, t1=3. Relative ordering
+    // (the AC's assertion) is unchanged.
     const t3 = `dragons-${id}`;
     const t2 = `training-${id}`;
     const t1 = `programming-${id}`;
 
-    await createArticleWithTags(api, `A1 ${id}`, [t3, t2, t1]);
-    await createArticleWithTags(api, `A2 ${id}`, [t3, t2]);
-    await createArticleWithTags(api, `A3 ${id}`, [t3]);
+    // t3 articles (count=7)
+    for (let i = 0; i < 7; i++) {
+      await createArticleWithTags(api, `A3-${i} ${id}`, [t3]);
+    }
+    // t2 articles (count=5)
+    for (let i = 0; i < 5; i++) {
+      await createArticleWithTags(api, `A2-${i} ${id}`, [t2]);
+    }
+    // t1 articles (count=3)
+    for (let i = 0; i < 3; i++) {
+      await createArticleWithTags(api, `A1-${i} ${id}`, [t1]);
+    }
 
     const anon = await request.newContext({ baseURL: API_URL });
     const res = await anon.get("/api/tags");


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #72.

## User Intent

Spec 14 (`tests/e2e/specs/14-api-tags-list.spec.ts`) Scenario 1 passes deterministically regardless of how much tag data the compose DB has accumulated from prior test runs. The evaluator's T2 regression cadence stops flagging spec 14 as red.

## Root cause (restated)

Scenario 1 seeded three tags with counts 3 / 2 / 1 and asserted relative ordering after filtering to `*-${id}`. `/api/tags` returns the top-20 by count, so once the DB accumulated 20+ other tags with count > 1, the 1-article `programming-${id}` tag was evicted from the slice — the filter returned only two entries, and `toEqual([t3, t2, t1])` broke.

## Fix

Bump seed counts to 7 / 5 / 3 so all three tags land in the top-20 regardless of DB pollution. Relative ordering — the actual AC — is unchanged. Went with the evaluator's option 1 (harden the spec) over option 2 (DB reset) because option 2 would blow up any other spec running in the same process.

```diff
-    await createArticleWithTags(api, `A1 ${id}`, [t3, t2, t1]);
-    await createArticleWithTags(api, `A2 ${id}`, [t3, t2]);
-    await createArticleWithTags(api, `A3 ${id}`, [t3]);
+    for (let i = 0; i < 7; i++) { ... [t3] }
+    for (let i = 0; i < 5; i++) { ... [t2] }
+    for (let i = 0; i < 3; i++) { ... [t1] }
```

## Evidence

Exact repro loop: compose up → full Playwright run (seeds DB) → run spec 14 alone.

**Before** (on current `latest` `a4fdd2f`):
```
× Scenario 1: expected [dragons-X, training-X] to equal [dragons-X, training-X, programming-X]
```

**After** (this PR):
```
$ # full Playwright run to pollute the DB
$ playwright test …
85 passed

$ # spec 14 alone on polluted DB
$ playwright test … specs/14-api-tags-list.spec.ts
Running 4 tests using 1 worker
  ✓ 1 Scenario 1: tags ordered by usage count descending (340ms)
  ✓ 2 Scenario 2: tags list accessible without a cookie (16ms)
  ✓ 3 Scenario 3: response shape is an array of strings (151ms)
  ✓ 4 Scenario 4: endpoint returns the documented envelope key `tags` (8ms)
4 passed

$ # and: full Playwright run again, end-to-end on doubly-polluted DB
$ playwright test …
85 passed
```

`pnpm lint` ✓, `pnpm typecheck` ✓.

## Test plan

- [x] Spec 14 passes on a fresh compose DB
- [x] Spec 14 passes after the full Playwright suite has seeded the DB
- [x] Full Playwright suite passes end-to-end on double-polluted DB (85/85)
- [x] Relative-ordering AC preserved (t3 > t2 > t1 still holds)
- [x] Lint + typecheck clean
- [ ] CI green on this PR
