### PR TITLE
fix(api): coerce empty-string bio/image to null on user update (#64)

### DIFF
--- a/apps/api/src/schemas/user.ts
+++ b/apps/api/src/schemas/user.ts
@@ -33,6 +33,16 @@ export const LoginRequestSchema = z
   })
   .openapi("LoginRequest");
 
+// Empty string → null coercion for nullable user-update fields.
+// Spec treats `{"bio":""}` / `{"image":""}` as "clear this field"
+// and expects the response to echo `null` + persist null (see #64).
+// Apply to the bio + image branches only — email/username/password
+// stay required-string shaped because the spec rejects empty strings
+// there (see #65 / errors-auth/12-update-email-to-empty-string-
+// should-reject.bru).
+const emptyToNull = <T extends z.ZodType<string, unknown>>(inner: T) =>
+  z.preprocess((v) => (v === "" ? null : v), inner.nullable());
+
 export const UpdateUserRequestSchema = z
   .object({
     user: z
@@ -44,8 +54,8 @@ export const UpdateUserRequestSchema = z
           .min(8, "is too short (minimum is 8 characters)")
           .max(200)
           .optional(),
-        bio: z.string().max(2000).nullable().optional(),
-        image: z.string().url("is not a valid url").nullable().optional(),
+        bio: emptyToNull(z.string().max(2000)).optional(),
+        image: emptyToNull(z.string().url("is not a valid url")).optional(),
       })
       .refine(
         (u) => Object.values(u).some((v) => v !== undefined),

--- a/tests/api/bruno-baseline.json
+++ b/tests/api/bruno-baseline.json
@@ -1,15 +1,11 @@
 {
   "_comment": "Known Bruno conformance drift against our API. The gate fails when the set of failing request paths is not a subset of knownFailing — i.e. any new failure is a regression, and any baseline item that now passes must be removed here to tighten the gate. Follow-up issues track the clusters so they can be driven to 100% over time.",
   "collectionSha": "e75fef39",
-  "capturedAt": "2026-04-29T09:10Z",
+  "capturedAt": "2026-04-29T09:38Z",
   "totalRequests": 149,
   "knownFailing": [
     { "path": "articles/13-update-article-remove-all-tags-with-empty-array.bru", "cluster": "taglist-empty-array-semantics", "followUpIssue": "#68" },
     { "path": "articles/14-verify-tags-were-actually-removed.bru", "cluster": "taglist-empty-array-semantics", "followUpIssue": "#68" },
-    { "path": "auth/06-update-user-bio-to-empty-string-should-normalize-to-null.bru", "cluster": "empty-string-nullable-normalization", "followUpIssue": "#64" },
-    { "path": "auth/07-verify-empty-string-normalization-persisted.bru", "cluster": "empty-string-nullable-normalization", "followUpIssue": "#64" },
-    { "path": "auth/14-update-image-to-empty-string-should-normalize-to-null.bru", "cluster": "empty-string-nullable-normalization", "followUpIssue": "#64" },
-    { "path": "auth/15-verify-image-empty-string-normalization-persisted.bru", "cluster": "empty-string-nullable-normalization", "followUpIssue": "#64" },
     { "path": "errors-articles/10-create-article-empty-description.bru", "cluster": "article-create-empty-field-validation", "followUpIssue": "#67" },
     { "path": "errors-articles/11-create-article-empty-body.bru", "cluster": "article-create-empty-field-validation", "followUpIssue": "#67" },
     { "path": "errors-auth/02-register-empty-email.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" },
@@ -20,13 +16,13 @@
   ],
   "clusters": {
     "taglist-empty-array-semantics": "Upstream treats `{taglist: []}` on article PUT as 'clear all tags'. Our API rejects it with 422; decide semantics + fix update handler.",
-    "empty-string-nullable-normalization": "User PUT with `bio: \"\"` or `image: \"\"` is expected to normalize to null. Our API rejects empty strings outright (422). Add a coerce layer in user update schema.",
     "article-create-empty-field-validation": "Create article accepts empty description/body (201). Spec requires 422 when description or body is empty. Tighten zod schema in apps/api/src/routes/articles.ts.",
     "validation-cant-be-blank-ordering": "Empty-string inputs surface format errors ('is not a valid email', 'is too short') before the blank check. Upstream expects 'can't be blank' first.",
     "duplicate-user-status-409": "Register duplicate username/email returns 422; upstream expects 409 Conflict. Swap status in apps/api/src/routes/auth.ts register handler."
   },
   "resolvedClusters": {
     "401-body-shape": "Resolved by #62 (2026-04-29) — 13 paths across errors-articles/ errors-auth/ errors-comments/ errors-profiles/ now emit the canonical `{errors:{token:[\"is missing\"]}}` envelope; wrong-password emits `{errors:{credentials:[\"invalid\"]}}` per upstream.",
-    "list-views-include-body": "Resolved by #63 (2026-04-29) — `GET /api/articles`, `GET /api/articles/feed`, and `favorited`-filtered list now omit `body` per spec. 9 paths removed from knownFailing."
+    "list-views-include-body": "Resolved by #63 (2026-04-29) — `GET /api/articles`, `GET /api/articles/feed`, and `favorited`-filtered list now omit `body` per spec. 9 paths removed from knownFailing.",
+    "empty-string-nullable-normalization": "Resolved by #64 (2026-04-29) — PUT /api/user with `bio:\"\"` or `image:\"\"` now coerces to null via a z.preprocess layer on UpdateUserRequestSchema. 4 paths removed from knownFailing."
   }
 }


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #64.

## User Intent

PUT `/api/user` with `{"user":{"bio":""}}` or `{"user":{"image":""}}` normalizes the field to `null` in the response, the DB, and every subsequent GET. No more 422 on a "clear-my-bio" intent.

## What changes

One schema file. `apps/api/src/schemas/user.ts` adds a small `emptyToNull` preprocess helper and applies it to the `bio` + `image` branches of `UpdateUserRequestSchema`:

```ts
const emptyToNull = <T extends z.ZodType<string, unknown>>(inner: T) =>
  z.preprocess((v) => (v === "" ? null : v), inner.nullable());

// …inside the PUT schema
bio: emptyToNull(z.string().max(2000)).optional(),
image: emptyToNull(z.string().url("is not a valid url")).optional(),
```

Scope is intentionally narrow — only the nullable fields on user update. `email`, `username`, `password` stay required-string shaped because the spec rejects empty strings on those (see `errors-auth/12-update-email-to-empty-string-should-reject.bru` — still in baseline under `validation-cant-be-blank-ordering`, closes with #65).

Baseline shrinks from 35 → 31 — four `empty-string-nullable-normalization` paths resolved, cluster description removed.

## Evidence

- **Live curl spot-check** (local compose, fresh user):
  ```
  $ PUT /api/user {"bio":"hello"}  → .user.bio = "hello"
  $ PUT /api/user {"bio":""}        → .user.bio = null      ✓
  $ PUT /api/user {"image":"https://example.com/a.png"}  → .user.image = "…"
  $ PUT /api/user {"image":""}       → .user.image = null    ✓
  ```
- **Bruno gate**:
  ```
  [baseline] total requests: 149
  [baseline] failing now: 31
  [baseline] baseline size: 31
  [baseline] new regressions: 0
  [baseline] newly passing (baseline stale): 0
  [baseline] OK — failures match baseline exactly.
  ```
- **Full Playwright suite**: 93 passed (picks up #69's article-detail scenarios that merged to `latest`).
- `pnpm lint` ✓, `pnpm typecheck` ✓.

## Test plan

- [x] `bio: ""` coerces to `null` on response and persists as `null`
- [x] `image: ""` coerces to `null` on response and persists as `null`
- [x] `email: ""`, `username: ""`, `password: ""` still rejected (unchanged)
- [x] Valid non-empty values still validate normally (url check on image, max length on bio)
- [x] Bruno baseline passes (4 paths removed, clean match)
- [x] Full Playwright suite: 93/93
- [x] Lint + typecheck clean
- [ ] CI green on this PR
