### PR TITLE
fix(api): register duplicate username/email returns 409 Conflict (#66)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -56,6 +56,10 @@ const registerRoute = createRoute({
       description: "Created",
       content: { "application/json": { schema: UserResponseSchema } },
     },
+    409: {
+      description: "Conflict — username or email already taken",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
     422: {
       description: "Unprocessable entity",
       content: { "application/json": { schema: ErrorResponseSchema } },
@@ -145,7 +149,14 @@ export const registerAuthRoutes = (app: OpenAPIHono<AppEnv>): void => {
       c.header("Authorization", `Token ${envelope.token}`);
       return c.json({ user: envelope }, 201);
     } catch (err) {
-      if (err instanceof AuthError) {
+      // registerUser today only throws 409 (duplicate). Narrow the
+      // switch so the OpenAPI route's response union (201 | 409 |
+      // 422) stays exact — any future 401-throwing path would be a
+      // bug in the register handler anyway.
+      if (err instanceof AuthError && err.status === 409) {
+        return c.json(jsonError(err.field, err.detail), 409);
+      }
+      if (err instanceof AuthError && err.status === 422) {
         return c.json(jsonError(err.field, err.detail), 422);
       }
       throw err;

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -25,7 +25,7 @@ export class AuthError extends Error {
   constructor(
     public readonly field: string,
     public readonly detail: string,
-    public readonly status: 401 | 422,
+    public readonly status: 401 | 409 | 422,
   ) {
     super(`${field}: ${detail}`);
     this.name = "AuthError";
@@ -98,10 +98,16 @@ export const registerUser = async (input: RegisterInput): Promise<UserEnvelope> 
     select: { email: true, username: true },
   });
   if (existing) {
+    // Duplicate on register is a state conflict — the client's intent
+    // can never succeed without re-choosing an identifier. 409 per
+    // RealWorld spec / canonical Bruno `errors-auth/05` + `06`.
+    // Update-user clashes (line ~170) stay 422 because there the
+    // caller is already authenticated and the payload is a field
+    // validation, not a registration attempt.
     if (existing.email === input.email) {
-      throw new AuthError("email", "has already been taken", 422);
+      throw new AuthError("email", "has already been taken", 409);
     }
-    throw new AuthError("username", "has already been taken", 422);
+    throw new AuthError("username", "has already been taken", 409);
   }
 
   const passwordHash = await bcrypt.hash(input.password, config.bcryptCost);

--- a/apps/web/src/features/auth/actions.ts
+++ b/apps/web/src/features/auth/actions.ts
@@ -28,11 +28,12 @@ type UserEnvelope = {
 
 type ApiErrors = { errors?: Record<string, string[]> };
 
-// Map the API's 422 `{ errors: { email: ["has already been taken"] } }`
-// into conform-to's `{ field: [msg] }` shape, keying every error under
-// the form's canonical field name so the inline error element renders
-// next to the right input. Unknown keys (e.g. the API's generic "body"
-// validation failures) surface on the form root.
+// Map the API's field-keyed error envelope (422 for validation, 409
+// for duplicate on register) into conform-to's `{ field: [msg] }`
+// shape, keying every error under the form's canonical field name so
+// the inline error element renders next to the right input. Unknown
+// keys (e.g. the API's generic "body" validation failures) surface
+// on the form root.
 const mergeApiErrors = (
   api: ApiErrors,
   knownFields: readonly string[],
@@ -66,7 +67,10 @@ export const registerAction = async (
   });
 
   if (!res.ok) {
-    if (res.status === 422) {
+    // 409 = duplicate username/email (per #66), 422 = other field
+    // validation. Both carry the same `{errors:{field:[msg]}}` shape
+    // so the field-error mapping is identical.
+    if (res.status === 409 || res.status === 422) {
       return submission.reply({
         fieldErrors: mergeApiErrors(res.data, ["username", "email", "password"]),
       });

--- a/tests/api/bruno-baseline.json
+++ b/tests/api/bruno-baseline.json
@@ -10,19 +10,17 @@
     { "path": "errors-articles/11-create-article-empty-body.bru", "cluster": "article-create-empty-field-validation", "followUpIssue": "#67" },
     { "path": "errors-auth/02-register-empty-email.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" },
     { "path": "errors-auth/03-register-empty-password.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" },
-    { "path": "errors-auth/05-register-duplicate-username.bru", "cluster": "duplicate-user-status-409", "followUpIssue": "#66" },
-    { "path": "errors-auth/06-register-duplicate-email.bru", "cluster": "duplicate-user-status-409", "followUpIssue": "#66" },
     { "path": "errors-auth/07-login-empty-email.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" }
   ],
   "clusters": {
     "taglist-empty-array-semantics": "Upstream treats `{taglist: []}` on article PUT as 'clear all tags'. Our API rejects it with 422; decide semantics + fix update handler.",
     "article-create-empty-field-validation": "Create article accepts empty description/body (201). Spec requires 422 when description or body is empty. Tighten zod schema in apps/api/src/routes/articles.ts.",
-    "validation-cant-be-blank-ordering": "Empty-string inputs surface format errors ('is not a valid email', 'is too short') before the blank check. Upstream expects 'can't be blank' first.",
-    "duplicate-user-status-409": "Register duplicate username/email returns 422; upstream expects 409 Conflict. Swap status in apps/api/src/routes/auth.ts register handler."
+    "validation-cant-be-blank-ordering": "Empty-string inputs surface format errors ('is not a valid email', 'is too short') before the blank check. Upstream expects 'can't be blank' first."
   },
   "resolvedClusters": {
     "401-body-shape": "Resolved by #62 (2026-04-29) — 13 paths across errors-articles/ errors-auth/ errors-comments/ errors-profiles/ now emit the canonical `{errors:{token:[\"is missing\"]}}` envelope; wrong-password emits `{errors:{credentials:[\"invalid\"]}}` per upstream.",
     "list-views-include-body": "Resolved by #63 (2026-04-29) — `GET /api/articles`, `GET /api/articles/feed`, and `favorited`-filtered list now omit `body` per spec. 9 paths removed from knownFailing.",
-    "empty-string-nullable-normalization": "Resolved by #64 (2026-04-29) — PUT /api/user with `bio:\"\"` or `image:\"\"` now coerces to null via a z.preprocess layer on UpdateUserRequestSchema. 4 paths removed from knownFailing."
+    "empty-string-nullable-normalization": "Resolved by #64 (2026-04-29) — PUT /api/user with `bio:\"\"` or `image:\"\"` now coerces to null via a z.preprocess layer on UpdateUserRequestSchema. 4 paths removed from knownFailing.",
+    "duplicate-user-status-409": "Resolved by #66 (2026-04-29) — registerUser throws AuthError at status 409 on duplicate username/email (was 422). Update-user clashes stay 422 per the field-validation semantics there."
   }
 }

--- a/tests/e2e/specs/4-api-auth-register-login.spec.ts
+++ b/tests/e2e/specs/4-api-auth-register-login.spec.ts
@@ -49,7 +49,7 @@ test.describe("issue #4 — API auth (register / login / current-user)", () => {
     await mkdir(dirname(`${SCREENSHOT_DIR}/_keep`), { recursive: true });
   });
 
-  test("Scenario 2: duplicate email returns 422 with spec-shaped error", async () => {
+  test("Scenario 2: duplicate email returns 409 with spec-shaped error", async () => {
     const id = uniq();
     const api = await request.newContext({ baseURL: API_URL });
     const email = `dupe-${id}@jake.jake`;
@@ -61,7 +61,8 @@ test.describe("issue #4 — API auth (register / login / current-user)", () => {
     const dup = await api.post("/api/users", {
       data: { user: { username: `two-${id}`, email, password: "jakejake" } },
     });
-    expect(dup.status()).toBe(422);
+    // Spec: duplicate on register is a state conflict → 409. Per #66.
+    expect(dup.status()).toBe(409);
     const body = (await dup.json()) as { errors: { email?: string[] } };
     expect(body.errors.email).toEqual(["has already been taken"]);
   });


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #66.

## User Intent

`POST /api/users` with a username or email already in the DB returns `409 Conflict` (not 422) — matching the RealWorld spec's "state conflict" semantics and the canonical Bruno assertions in `errors-auth/05-register-duplicate-username.bru` + `06-register-duplicate-email.bru`. Authenticated PUT `/api/user` clashes (line ~170 in `auth.service.ts`) deliberately stay at 422 because there the caller is already authed and the clash is field-validation.

## What changes

**`apps/api/src/services/auth.service.ts`**
- `AuthError.status` union widens from `401 | 422` to `401 | 409 | 422`.
- `registerUser` now throws `AuthError("email", "has already been taken", 409)` and `AuthError("username", "has already been taken", 409)` on duplicate.
- `updateUser` duplicate-field throws stay at 422 (unchanged).

**`apps/api/src/routes/auth.ts`**
- Register route's OpenAPI `responses` block adds `409` next to `422`.
- Register handler's catch branch narrows: `err.status === 409` → `c.json(..., 409)`; `err.status === 422` → `c.json(..., 422)`. This keeps the typed-response union exact — the OpenAPI router's `RouteConfigToTypedResponse` infers from the declared `responses`, so a single `c.json(..., err.status)` with a wider union doesn't typecheck.

**`apps/web/src/features/auth/actions.ts`**
- Register action treats 409 the same as 422 for duplicate-field error mapping (both carry `{errors:{field:[msg]}}`). Comment refreshed.

**`tests/e2e/specs/4-api-auth-register-login.spec.ts`**
- Scenario 2 expectation: 422 → 409. Body shape unchanged.

**`tests/api/bruno-baseline.json`**
- 2 `duplicate-user-status-409` entries removed; cluster description moved to `resolvedClusters`.

## Evidence

- **Live curl spot-check** (local compose):
  ```
  # seed
  $ POST /api/users {username:"t66a",email:"t66@x.com",…}  → 201
  # duplicate email
  $ POST /api/users {username:"t66b",email:"t66@x.com",…}
    → 409 {"errors":{"email":["has already been taken"]}}     ✓
  # duplicate username
  $ POST /api/users {username:"t66a",email:"other@x.com",…}
    → 409 {"errors":{"username":["has already been taken"]}}  ✓
  ```
- **Bruno gate**:
  ```
  [baseline] total requests: 149
  [baseline] failing now: 20
  [baseline] baseline size: 20
  [baseline] new regressions: 0
  [baseline] newly passing (baseline stale): 0
  [baseline] OK — failures match baseline exactly.
  ```
- **Playwright**: 92 pass on first run, spec 18 Scenario 2 (the #69 article-detail "follow + favorite refresh persist" scenario) flaked once then passed on a rerun (8/8) — pre-existing timing flake in the optimistic-update UI, unrelated to this PR's server-side shape change.
- `pnpm lint` ✓, `pnpm typecheck` ✓.

## Test plan

- [x] Duplicate email → 409 with `{errors:{email:["has already been taken"]}}`
- [x] Duplicate username → 409 with `{errors:{username:["has already been taken"]}}`
- [x] Fresh email + username → 201 (happy path unchanged)
- [x] PUT /api/user duplicate email still → 422 (update-user clash unaffected)
- [x] Web register form still renders inline error on duplicate-email attempt
- [x] Bruno baseline: 2 paths removed, clean match
- [x] `pnpm lint`, `pnpm typecheck`
- [ ] CI green on this PR
