### PR TITLE
fix(api): article create rejects empty description/body with 422 (#67)

### DIFF
--- a/apps/api/src/schemas/article.ts
+++ b/apps/api/src/schemas/article.ts
@@ -52,8 +52,11 @@ export const CreateArticleRequestSchema = z
   .object({
     article: z.object({
       title: z.string().min(1, "can't be blank").max(300),
-      description: z.string().max(1000),
-      body: z.string().max(50_000),
+      // description + body are required on create per RealWorld spec —
+      // the upstream Bruno errors-articles/10 + 11 assert 422 with
+      // `"can't be blank"` when either is empty. See #67.
+      description: z.string().min(1, "can't be blank").max(1000),
+      body: z.string().min(1, "can't be blank").max(50_000),
       tagList: z.array(z.string().min(1).max(50)).max(20).optional(),
     }),
   })

--- a/tests/api/bruno-baseline.json
+++ b/tests/api/bruno-baseline.json
@@ -6,21 +6,20 @@
   "knownFailing": [
     { "path": "articles/13-update-article-remove-all-tags-with-empty-array.bru", "cluster": "taglist-empty-array-semantics", "followUpIssue": "#68" },
     { "path": "articles/14-verify-tags-were-actually-removed.bru", "cluster": "taglist-empty-array-semantics", "followUpIssue": "#68" },
-    { "path": "errors-articles/10-create-article-empty-description.bru", "cluster": "article-create-empty-field-validation", "followUpIssue": "#67" },
-    { "path": "errors-articles/11-create-article-empty-body.bru", "cluster": "article-create-empty-field-validation", "followUpIssue": "#67" },
     { "path": "errors-auth/02-register-empty-email.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" },
     { "path": "errors-auth/03-register-empty-password.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" },
     { "path": "errors-auth/07-login-empty-email.bru", "cluster": "validation-cant-be-blank-ordering", "followUpIssue": "#65" }
   ],
   "clusters": {
     "taglist-empty-array-semantics": "Upstream treats `{taglist: []}` on article PUT as 'clear all tags'. Our API rejects it with 422; decide semantics + fix update handler.",
-    "article-create-empty-field-validation": "Create article accepts empty description/body (201). Spec requires 422 when description or body is empty. Tighten zod schema in apps/api/src/routes/articles.ts.",
-    "validation-cant-be-blank-ordering": "Empty-string inputs surface format errors ('is not a valid email', 'is too short') before the blank check. Upstream expects 'can't be blank' first."
+    "validation-cant-be-blank-ordering": "Empty-string inputs surface format errors ('is not a valid email', 'is too short') before the blank check. Upstream expects 'can't be blank' first.",
+    "duplicate-user-status-409": "Register duplicate username/email returns 422; upstream expects 409 Conflict. Swap status in apps/api/src/routes/auth.ts register handler."
   },
   "resolvedClusters": {
     "401-body-shape": "Resolved by #62 (2026-04-29) — 13 paths across errors-articles/ errors-auth/ errors-comments/ errors-profiles/ now emit the canonical `{errors:{token:[\"is missing\"]}}` envelope; wrong-password emits `{errors:{credentials:[\"invalid\"]}}` per upstream.",
     "list-views-include-body": "Resolved by #63 (2026-04-29) — `GET /api/articles`, `GET /api/articles/feed`, and `favorited`-filtered list now omit `body` per spec. 9 paths removed from knownFailing.",
     "empty-string-nullable-normalization": "Resolved by #64 (2026-04-29) — PUT /api/user with `bio:\"\"` or `image:\"\"` now coerces to null via a z.preprocess layer on UpdateUserRequestSchema. 4 paths removed from knownFailing.",
-    "duplicate-user-status-409": "Resolved by #66 (2026-04-29) — registerUser throws AuthError at status 409 on duplicate username/email (was 422). Update-user clashes stay 422 per the field-validation semantics there."
+    "duplicate-user-status-409": "Resolved by #66 (2026-04-29) — registerUser throws AuthError at status 409 on duplicate username/email (was 422). Update-user clashes stay 422 per the field-validation semantics there.",
+    "article-create-empty-field-validation": "Resolved by #67 (2026-04-29) — CreateArticleRequestSchema tightens description + body to .min(1, \"can't be blank\"). Create with empty description or body now returns 422 with the canonical envelope. 2 paths removed from knownFailing."
   }
 }


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #67.

## User Intent

`POST /api/articles` with `"description": ""` or `"body": ""` returns `422 Unprocessable Entity` and `{"errors":{<field>:["can't be blank"]}}`, matching the canonical RealWorld Bruno assertions in `errors-articles/10-create-article-empty-description.bru` + `11-create-article-empty-body.bru`. No more slug-reserving empty articles.

## What changes

One file. `apps/api/src/schemas/article.ts` — `CreateArticleRequestSchema` tightens `description` and `body` from `.max(...)` only to `.min(1, "can't be blank").max(...)`. The existing `spec422Hook` in `app.ts` already converts zod issues into `{errors:{<path>:["<message>"]}}`, so no error-handler changes needed.

`UpdateArticleRequestSchema` deliberately unchanged — partial updates with explicit `""` are a different UX (the refine already blocks the all-empty case), and #67's scope is creation only.

Baseline shrinks 13 → 11; cluster moved to `resolvedClusters`.

## Evidence

- **Live curl spot-check** (local compose, authenticated):
  ```
  # empty description
  POST /api/articles {"title":"Hello","description":"","body":"content"}
    → 422 {"errors":{"description":["can't be blank"]}}  ✓

  # empty body
  POST /api/articles {"title":"Hello","description":"A","body":""}
    → 422 {"errors":{"body":["can't be blank"]}}  ✓

  # happy path — unchanged
  POST /api/articles {"title":"Hello","description":"A","body":"content"}
    → 201 (slug hello-ax18)  ✓
  ```
- **Bruno gate**:
  ```
  [baseline] total requests: 149
  [baseline] failing now: 11
  [baseline] baseline size: 11
  [baseline] new regressions: 0
  [baseline] newly passing (baseline stale): 0
  [baseline] OK — failures match baseline exactly.
  ```
- **Playwright**: 92/93 — one flake in `18-web-article-detail.spec.ts:120` (Scenario 2, the useOptimistic/revalidate race) which is **pre-existing** on `latest` (PR #78 in flight addresses it; unrelated to this PR's server-side validation change).
- `pnpm lint` ✓, `pnpm typecheck` ✓.

## Test plan

- [x] Empty description → 422 with `errors.description = ["can't be blank"]`
- [x] Empty body → 422 with `errors.body = ["can't be blank"]`
- [x] Empty title still → 422 (behaviour unchanged, pre-existing `.min(1)`)
- [x] Non-empty happy path still → 201
- [x] Bruno baseline: 2 paths removed, clean match
- [x] Lint + typecheck clean
- [ ] CI green on this PR
