### PR TITLE
feat(web): settings page — update profile + change password + logout (#21)

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,11 +1,29 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import { redirect } from "next/navigation";
+import { SettingsForm } from "@/features/auth/SettingsForm";
+import { getCurrentUser } from "@/features/auth/session";
 
 export const metadata = { title: "Settings — Conduit" };
 
-export default function SettingsPage() {
+// RSC settings page (#21). Fetches the current user via GET /api/user
+// so the form defaults always reflect the committed DB state (not the
+// stale `conduit-user` presentation cookie). Anon viewers get a 307
+// redirect to /login?redirect=/settings per AC scenario 6.
+export default async function SettingsPage() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    redirect("/login?redirect=/settings");
+  }
+
   return (
-    <ComingSoon title="Settings">
-      <p>Update profile, change password, logout — issue #21.</p>
-    </ComingSoon>
+    <div className="settings-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Your Settings</h1>
+            <SettingsForm currentUser={currentUser} />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/features/auth/SettingsForm.tsx
+++ b/apps/web/src/features/auth/SettingsForm.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useActionState } from "react";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { logoutAction, updateUserAction } from "./actions";
+import { settingsSchema } from "./schema";
+
+type LastResult = {
+  initialValue?: Record<string, string | string[] | undefined>;
+} | null;
+
+const echoed = (lastResult: LastResult, field: string, fallback: string): string => {
+  const raw = lastResult?.initialValue?.[field];
+  if (typeof raw === "string") return raw;
+  return fallback;
+};
+
+export type CurrentUser = {
+  email: string;
+  username: string;
+  bio: string | null;
+  image: string | null;
+};
+
+type Props = { currentUser: CurrentUser };
+
+// Authenticated settings form (#21). Pattern parallels LoginForm /
+// RegisterForm — useActionState + conform-to — with prefilled fields
+// from the server-rendered current user envelope. Logout is a sibling
+// plain <form action={logoutAction}> below the update button so the
+// browser POSTs the server action directly (no JS needed).
+export const SettingsForm = ({ currentUser }: Props) => {
+  const [lastResult, action] = useActionState(updateUserAction, null);
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate: ({ formData }) =>
+      parseWithZod(formData, { schema: settingsSchema }),
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
+
+  const formErrors = form.errors ?? [];
+  const fieldErrors = {
+    image: fields.image.errors ?? [],
+    username: fields.username.errors ?? [],
+    bio: fields.bio.errors ?? [],
+    email: fields.email.errors ?? [],
+    password: fields.password.errors ?? [],
+  };
+  const allErrors = [
+    ...formErrors,
+    ...fieldErrors.image,
+    ...fieldErrors.username,
+    ...fieldErrors.bio,
+    ...fieldErrors.email,
+    ...fieldErrors.password,
+  ];
+
+  const typed = lastResult as LastResult;
+  // Remount inputs when the action replied with echoed values so
+  // conform-to repopulates the defaults; matches the LoginForm pattern.
+  const remountKey = typed?.initialValue
+    ? `echo-${echoed(typed, "username", currentUser.username)}`
+    : `initial-${currentUser.username}`;
+
+  return (
+    <>
+      <form
+        id={form.id}
+        action={action}
+        onSubmit={form.onSubmit}
+        noValidate
+        aria-label="Settings"
+      >
+        {allErrors.length > 0 ? (
+          <ul className="error-messages">
+            {allErrors.map((msg) => (
+              <li key={msg}>{msg}</li>
+            ))}
+          </ul>
+        ) : null}
+        <fieldset>
+          <fieldset className="form-group">
+            <input
+              key={`image-${remountKey}`}
+              id={fields.image.id}
+              form={fields.image.formId}
+              type="text"
+              name={fields.image.name}
+              defaultValue={echoed(typed, "image", currentUser.image ?? "")}
+              className="form-control"
+              placeholder="URL of profile picture"
+              aria-invalid={fieldErrors.image.length > 0 || undefined}
+            />
+          </fieldset>
+          <fieldset className="form-group">
+            <input
+              key={`username-${remountKey}`}
+              id={fields.username.id}
+              form={fields.username.formId}
+              type="text"
+              name={fields.username.name}
+              defaultValue={echoed(typed, "username", currentUser.username)}
+              className="form-control form-control-lg"
+              placeholder="Your Name"
+              aria-invalid={fieldErrors.username.length > 0 || undefined}
+            />
+          </fieldset>
+          <fieldset className="form-group">
+            <textarea
+              key={`bio-${remountKey}`}
+              id={fields.bio.id}
+              form={fields.bio.formId}
+              name={fields.bio.name}
+              defaultValue={echoed(typed, "bio", currentUser.bio ?? "")}
+              rows={8}
+              className="form-control form-control-lg"
+              placeholder="Short bio about you"
+              aria-invalid={fieldErrors.bio.length > 0 || undefined}
+            />
+          </fieldset>
+          <fieldset className="form-group">
+            <input
+              key={`email-${remountKey}`}
+              id={fields.email.id}
+              form={fields.email.formId}
+              type="email"
+              name={fields.email.name}
+              defaultValue={echoed(typed, "email", currentUser.email)}
+              className="form-control form-control-lg"
+              placeholder="Email"
+              aria-invalid={fieldErrors.email.length > 0 || undefined}
+            />
+          </fieldset>
+          <fieldset className="form-group">
+            <input
+              key={`password-${remountKey}`}
+              id={fields.password.id}
+              form={fields.password.formId}
+              type="password"
+              name={fields.password.name}
+              className="form-control form-control-lg"
+              placeholder="New Password"
+              autoComplete="new-password"
+              aria-invalid={fieldErrors.password.length > 0 || undefined}
+            />
+          </fieldset>
+          <button
+            type="submit"
+            className="btn btn-lg btn-primary pull-xs-right"
+          >
+            Update Settings
+          </button>
+        </fieldset>
+      </form>
+
+      <hr />
+
+      {/* Logout is a separate form so it doesn't inherit SettingsForm's
+          updateUserAction. Plain server-action POST — no JS required. */}
+      <form action={logoutAction}>
+        <button
+          type="submit"
+          className="btn btn-outline-danger"
+        >
+          Or click here to logout.
+        </button>
+      </form>
+    </>
+  );
+};

--- a/apps/web/src/features/auth/actions.ts
+++ b/apps/web/src/features/auth/actions.ts
@@ -1,10 +1,16 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { parseWithZod } from "@conform-to/zod/v4";
 import { apiFetch } from "@/lib/api/client";
-import { loginSchema, registerSchema } from "./schema";
-import { writeSession } from "./session";
+import { loginSchema, registerSchema, settingsSchema } from "./schema";
+import {
+  SESSION_COOKIE,
+  USER_COOKIE,
+  readSessionCookie,
+  writeSession,
+} from "./session";
 
 // Pattern adapted from yukicountry/realworld-nextjs-rsc @ f455599f
 // (`src/modules/features/auth/actions.ts`, MIT). The shape — Server
@@ -87,6 +93,7 @@ export const registerAction = async (
   redirect("/");
 };
 
+// (loginAction follows)
 export const loginAction = async (
   _prev: unknown,
   formData: FormData,
@@ -126,5 +133,75 @@ export const loginAction = async (
     username: res.data.user.username,
     image: res.data.user.image,
   });
+  redirect("/");
+};
+
+// Settings update (#21). On success the API returns a fresh UserEnvelope
+// + Set-Cookie (the token rotates whenever password changes and stays
+// stable otherwise — either way we re-write the session cookie so the
+// browser carries the latest). Success redirects to the user's profile.
+export const updateUserAction = async (
+  _prev: unknown,
+  formData: FormData,
+) => {
+  const submission = parseWithZod(formData, { schema: settingsSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+  const v = submission.value;
+
+  // Strip empty strings on optional fields so the API update is a
+  // proper partial — blank image/bio/password stay omitted (no change)
+  // rather than sent as "" and routed through the #64 empty-string
+  // coerce. Explicit clears are a different UX not exposed today.
+  const cookie = await readSessionCookie();
+  if (!cookie) {
+    redirect("/login?redirect=/settings");
+  }
+  const payload: Record<string, string> = {
+    username: v.username,
+    email: v.email,
+  };
+  if (v.image && v.image.length > 0) payload.image = v.image;
+  if (v.bio && v.bio.length > 0) payload.bio = v.bio;
+  if (v.password && v.password.length > 0) payload.password = v.password;
+
+  const res = await apiFetch<UserEnvelope>("/api/user", {
+    method: "PUT",
+    cookie: `${SESSION_COOKIE}=${cookie}`,
+    body: JSON.stringify({ user: payload }),
+  });
+  if (!res.ok) {
+    if (res.status === 422) {
+      return submission.reply({
+        fieldErrors: mergeApiErrors(res.data, [
+          "username",
+          "email",
+          "password",
+          "bio",
+          "image",
+        ]),
+      });
+    }
+    return submission.reply({
+      formErrors: ["server error — please try again"],
+    });
+  }
+
+  // API rotated the token (always new jti, fresh on password change).
+  // writeSession refreshes both cookies so the authed chrome + any
+  // downstream API calls carry the new credential.
+  await writeSession(res.setCookie, {
+    username: res.data.user.username,
+    image: res.data.user.image,
+  });
+  redirect(`/profile/${encodeURIComponent(res.data.user.username)}`);
+};
+
+// Logout (#21 scenario 5). Clears both cookies and redirects home.
+export const logoutAction = async (): Promise<never> => {
+  const jar = await cookies();
+  jar.delete(SESSION_COOKIE);
+  jar.delete(USER_COOKIE);
   redirect("/");
 };

--- a/apps/web/src/features/auth/schema.ts
+++ b/apps/web/src/features/auth/schema.ts
@@ -32,5 +32,30 @@ export const loginSchema = z.object({
     .min(1, "password can't be blank"),
 });
 
+// Settings (#21). Required fields keep their non-blank guard; image/
+// bio/password are optional and empty strings are treated below in
+// the action as "don't send this field" so the API update is a proper
+// partial. Password gets a length check when provided.
+export const settingsSchema = z.object({
+  image: z.string().optional(),
+  username: z
+    .string({ message: "username can't be blank" })
+    .min(1, "username can't be blank")
+    .max(100, "username is too long (maximum is 100 characters)"),
+  bio: z.string().optional(),
+  email: z
+    .string({ message: "email can't be blank" })
+    .min(1, "email can't be blank")
+    .email("email must be a valid email"),
+  password: z
+    .string()
+    .optional()
+    .refine(
+      (v) => v === undefined || v === "" || v.length >= 8,
+      "password is too short (minimum is 8 characters)",
+    ),
+});
+
 export type RegisterInput = z.infer<typeof registerSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
+export type SettingsInput = z.infer<typeof settingsSchema>;

--- a/apps/web/src/features/auth/session.ts
+++ b/apps/web/src/features/auth/session.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cookies } from "next/headers";
+import { apiFetch } from "@/lib/api/client";
 
 // Server-only session helpers.
 //
@@ -96,6 +97,29 @@ export const isAuthenticated = async (): Promise<boolean> => {
   // Either cookie is enough to treat the viewer as authed for redirect
   // purposes; the API will reject forged tokens on its own.
   return Boolean(jar.get(SESSION_COOKIE)?.value || jar.get(USER_COOKIE)?.value);
+};
+
+export type CurrentUser = {
+  email: string;
+  username: string;
+  bio: string | null;
+  image: string | null;
+};
+
+// Server-only fetch of the full current-user envelope via GET /api/user
+// — used by the settings page (#21) to prefill the form with every
+// editable field. Returns null when the session cookie is missing or
+// rejected; the caller redirects to /login in that case.
+export const getCurrentUser = async (): Promise<CurrentUser | null> => {
+  const token = await readSessionCookie();
+  if (!token) return null;
+  const res = await apiFetch<{ user: CurrentUser & { token: string } }>(
+    "/api/user",
+    { cookie: `${SESSION_COOKIE}=${token}` },
+  );
+  if (!res.ok) return null;
+  const { email, username, bio, image } = res.data.user;
+  return { email, username, bio, image };
 };
 
 // Presentation-only hint: who is the viewer, per the readable user

--- a/tests/e2e/specs/21-web-settings.spec.ts
+++ b/tests/e2e/specs/21-web-settings.spec.ts
@@ -1,0 +1,207 @@
+import {
+  expect,
+  request,
+  test,
+  type BrowserContext,
+} from "@playwright/test";
+
+// BDD coverage for issue #21: settings page (#21).
+// Six scenarios matching the AC block.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+type ApiCtx = Awaited<ReturnType<typeof request.newContext>>;
+const apiContext = () => request.newContext({ baseURL: API_URL });
+
+const registerUser = async (api: ApiCtx, username: string): Promise<string> => {
+  const res = await api.post("/api/users", {
+    data: {
+      user: {
+        username,
+        email: `${username}@jake.jake`,
+        password: "jakejake",
+      },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const setCookie = res.headers()["set-cookie"] ?? "";
+  const match = setCookie.match(/conduit_session=([^;]+)/);
+  if (!match) throw new Error("expected conduit_session cookie from register");
+  return match[1];
+};
+
+const primeSession = async (
+  context: BrowserContext,
+  session: string,
+  username: string,
+): Promise<void> => {
+  const webOrigin = new URL(WEB_URL);
+  await context.addCookies([
+    {
+      name: "conduit_session",
+      value: session,
+      domain: webOrigin.hostname,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+    {
+      name: "conduit-user",
+      value: encodeURIComponent(JSON.stringify({ username, image: null })),
+      domain: webOrigin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+};
+
+test.describe("issue #21 — settings page", () => {
+  test("Scenario 1: populate form with current user", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/settings`);
+    const form = page.getByRole("form", { name: "Settings" });
+    await expect(form).toBeVisible();
+
+    // Image + bio empty on a fresh user; username + email reflect registration.
+    await expect(form.getByPlaceholder("URL of profile picture")).toHaveValue("");
+    await expect(form.getByPlaceholder("Your Name")).toHaveValue(jake);
+    await expect(form.getByPlaceholder("Short bio about you")).toHaveValue("");
+    await expect(form.getByPlaceholder("Email")).toHaveValue(`${jake}@jake.jake`);
+    await expect(form.getByPlaceholder("New Password")).toHaveValue("");
+  });
+
+  test("Scenario 2: update bio succeeds and redirects to profile", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/settings`);
+    const form = page.getByRole("form", { name: "Settings" });
+    await form.getByPlaceholder("Short bio about you").fill("I like cats");
+    await form.getByRole("button", { name: "Update Settings" }).click();
+
+    await page.waitForURL(`${WEB_URL}/profile/${jake}`);
+
+    // Persisted via API.
+    const me = await jakeApi.get("/api/user");
+    expect(me.status()).toBe(200);
+    const body = (await me.json()) as { user: { bio: string | null } };
+    expect(body.user.bio).toBe("I like cats");
+  });
+
+  test("Scenario 3: duplicate email shows inline error and preserves inputs", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    const jakeSession = await registerUser(jakeApi, jake);
+    await registerUser(danApi, dan);
+    await primeSession(context, jakeSession, jake);
+
+    await page.goto(`${WEB_URL}/settings`);
+    const form = page.getByRole("form", { name: "Settings" });
+    const email = form.getByPlaceholder("Email");
+    await email.fill(`${dan}@jake.jake`);
+    await form.getByRole("button", { name: "Update Settings" }).click();
+
+    // Stays on /settings, inline error renders.
+    await expect(page).toHaveURL(/\/settings/);
+    await expect(page.locator(".error-messages")).toContainText(
+      "email has already been taken",
+    );
+    // The attempted (duplicate) email is preserved in the field.
+    await expect(email).toHaveValue(`${dan}@jake.jake`);
+  });
+
+  test("Scenario 4: password update issues fresh cookie and keeps user authed", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/settings`);
+    const form = page.getByRole("form", { name: "Settings" });
+    await form.getByPlaceholder("New Password").fill("newpassword");
+    await form.getByRole("button", { name: "Update Settings" }).click();
+
+    await page.waitForURL(`${WEB_URL}/profile/${jake}`);
+
+    // Verify no 401 on the next authed page — if the rotated token
+    // wasn't written back, the navbar (which reads conduit-user) would
+    // flip to signed-out chrome.
+    const settingsRes = await page.goto(`${WEB_URL}/settings`);
+    expect(settingsRes?.status()).toBe(200);
+    // Cookie was rotated.
+    const jar = await context.cookies(WEB_URL);
+    const session2 = jar.find((c) => c.name === "conduit_session")?.value;
+    expect(session2).toBeTruthy();
+    expect(session2).not.toBe(session);
+  });
+
+  test("Scenario 5: logout clears cookies and lands on /", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/settings`);
+    await page
+      .getByRole("button", { name: /Or click here to logout/ })
+      .click();
+
+    await page.waitForURL(`${WEB_URL}/`);
+
+    // conduit_session + conduit-user cleared from the jar.
+    const jar = await context.cookies(WEB_URL);
+    expect(jar.find((c) => c.name === "conduit_session")).toBeUndefined();
+    expect(jar.find((c) => c.name === "conduit-user")).toBeUndefined();
+
+    // Navbar now shows anon chrome.
+    const nav = page.locator("nav");
+    await expect(nav.getByRole("link", { name: "Sign in" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Sign up" })).toBeVisible();
+  });
+
+  test("Scenario 6: /settings requires auth, redirects to /login?redirect=/settings", async ({
+    page,
+  }) => {
+    const res = await page.goto(`${WEB_URL}/settings`);
+    // Next follows redirects client-side, so the final URL is /login
+    // with the original path preserved as `?redirect=/settings`.
+    await expect(page).toHaveURL(/\/login\?redirect=(%2F|\/)settings$/);
+    // Final status after redirect is 200 (the login page).
+    expect(res?.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #21.

## User Intent

Logged-in users hit `/settings`, see every editable field prefilled with their current values, change what they want (including optionally a new password), click Update Settings, and land on their profile page with the change committed. Logout clears cookies and lands back on `/`. Anon viewers hitting `/settings` get redirected to `/login?redirect=/settings`.

## What ships

- **RSC page** `apps/web/src/app/settings/page.tsx` — calls `getCurrentUser()`; redirects to `/login?redirect=/settings` when unauthenticated.
- **Session helpers** — `getCurrentUser()` in `features/auth/session.ts` (GET `/api/user`, returns `CurrentUser | null`). Existing `readSessionCookie` / `writeSession` reused.
- **Schema** — `settingsSchema` in `features/auth/schema.ts`: required non-blank `username` + valid `email`; optional `image`, `bio`, `password` (with length ≥ 8 when provided).
- **Actions** (`features/auth/actions.ts`):
  - `updateUserAction` — parseWithZod, strip-empty on optional fields so the PUT is a proper partial, `writeSession(res.setCookie, ...)` on success to rotate the cookie, `redirect(/profile/<username>)`.
  - `logoutAction` — clears both cookies via `cookies().delete(...)`, redirects to `/`.
- **Client component** `features/auth/SettingsForm.tsx` — conform-to form with prefilled defaults, inline error list, remount-on-echo pattern matching LoginForm/RegisterForm. Logout is a sibling `<form action={logoutAction}>` so it works without JS.
- **Playwright spec** `tests/e2e/specs/21-web-settings.spec.ts` — 6/6 scenarios pass:
  ```
  ✓ Scenario 1: populate form with current user
  ✓ Scenario 2: update bio succeeds and redirects to profile
  ✓ Scenario 3: duplicate email shows inline error and preserves inputs
  ✓ Scenario 4: password update issues fresh cookie and keeps user authed
  ✓ Scenario 5: logout clears cookies and lands on /
  ✓ Scenario 6: /settings requires auth, redirects to /login?redirect=/settings
  ```

## Evidence

- Local Playwright against compose: 6/6 scenarios pass (above).
- Full Playwright suite: **99 passed**.
- `pnpm lint` ✓, `pnpm typecheck` ✓, `pnpm --filter @conduit/web build` ✓.

## Notes

- AC scenario 4 (password rotation) verifies the rotated cookie directly — subsequent `/settings` load returns 200, and `context.cookies()` shows a fresh `conduit_session` distinct from the seeded one.
- Honoring `?redirect=...` after successful login is a *separate* feature (not in #21's AC). The redirect parameter is set on the /login URL per scenario 6 but the login action still sends the user to `/` on success; if/when we want to follow the redirect query, that's a small additional change.

## Test plan

- [x] Form prefilled with image / username / bio / email / password defaults
- [x] Update bio → redirects to `/profile/<username>`, persisted in DB
- [x] Update to duplicate email → inline error on form, input preserved
- [x] New password → fresh cookie, next authed navigation stays 200
- [x] Logout → cookies cleared, navbar shows anon chrome
- [x] Anon GET `/settings` → redirect to `/login?redirect=/settings`
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm --filter @conduit/web build`
- [x] Full Playwright 99/99
- [ ] CI green on this PR
