### PR TITLE
feat(web): editor — create + edit article with tag-pill input (#19)

### DIFF
--- a/apps/web/src/app/editor/[slug]/page.tsx
+++ b/apps/web/src/app/editor/[slug]/page.tsx
@@ -1,16 +1,61 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import { notFound, redirect } from "next/navigation";
+import { EditorForm } from "@/components/editor/EditorForm";
+import { getArticle } from "@/features/articles/queries";
+import {
+  isAuthenticated,
+  readCurrentUsername,
+} from "@/features/auth/session";
 
 export const metadata = { title: "Edit Article — Conduit" };
 
+// Edit-article editor (#19). Auth-gated like the create route; also
+// rejects non-author edits by redirecting to the article detail page
+// (AC scenario 5) so the user sees the content they can't modify
+// rather than a blank 403.
 export default async function EditArticlePage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
+  const authed = await isAuthenticated();
+  if (!authed) {
+    redirect(
+      `/login?redirect=${encodeURIComponent(`/editor/${slug}`)}`,
+    );
+  }
+
+  const [article, viewer] = await Promise.all([
+    getArticle(slug),
+    readCurrentUsername(),
+  ]);
+  if (!article) {
+    notFound();
+  }
+  if (viewer !== article.author.username) {
+    // Not the author — bounce to the read-only article page. The
+    // detail page handles the rest; no flash copy here, the redirect
+    // itself is the UX signal.
+    redirect(`/article/${encodeURIComponent(slug)}`);
+  }
+
   return (
-    <ComingSoon title="Edit Article">
-      <p>Editing article <code>{slug}</code> — issue #19.</p>
-    </ComingSoon>
+    <div className="editor-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-10 offset-md-1 col-xs-12">
+            <EditorForm
+              initial={{
+                slug: article.slug,
+                title: article.title,
+                description: article.description,
+                body: article.body,
+                tagList: article.tagList,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/editor/page.tsx
+++ b/apps/web/src/app/editor/page.tsx
@@ -1,11 +1,24 @@
-import { ComingSoon } from "@/components/ComingSoon";
+import { redirect } from "next/navigation";
+import { EditorForm } from "@/components/editor/EditorForm";
+import { isAuthenticated } from "@/features/auth/session";
 
 export const metadata = { title: "New Article — Conduit" };
 
-export default function EditorPage() {
+// Create-article editor (#19). Anon viewers → /login?redirect=/editor.
+export default async function NewEditorPage() {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    redirect("/login?redirect=/editor");
+  }
   return (
-    <ComingSoon title="New Article">
-      <p>The article editor with tag-pill input lands in issue #19.</p>
-    </ComingSoon>
+    <div className="editor-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-10 offset-md-1 col-xs-12">
+            <EditorForm />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/editor/EditorForm.tsx
+++ b/apps/web/src/components/editor/EditorForm.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useActionState } from "react";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import {
+  createArticleAction,
+  updateArticleAction,
+} from "@/features/articles/actions";
+import { editorSchema } from "@/features/articles/schema";
+import { TagInput } from "./TagInput";
+
+type LastResult = {
+  initialValue?: Record<string, string | string[] | undefined>;
+} | null;
+
+const echoed = (
+  lastResult: LastResult,
+  field: string,
+  fallback: string,
+): string => {
+  const raw = lastResult?.initialValue?.[field];
+  if (typeof raw === "string") return raw;
+  return fallback;
+};
+
+export type EditorInitial = {
+  slug?: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+};
+
+type Props = { initial?: EditorInitial };
+
+// Editor form (#19). On create (no `initial`) wires createArticleAction;
+// on edit (initial.slug defined) wires updateArticleAction bound to the
+// existing slug. Validation mirrors the API so most errors surface
+// inline before the POST; API-origin errors (422 / 403) land via
+// mergeEditorErrors in the action.
+export const EditorForm = ({ initial }: Props) => {
+  const isEdit = Boolean(initial?.slug);
+  const boundAction = isEdit
+    ? updateArticleAction.bind(null, initial!.slug!)
+    : createArticleAction;
+
+  const [lastResult, action] = useActionState(boundAction, null);
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate: ({ formData }) =>
+      parseWithZod(formData, { schema: editorSchema }),
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
+
+  const formErrors = form.errors ?? [];
+  const fieldErrors = {
+    title: fields.title.errors ?? [],
+    description: fields.description.errors ?? [],
+    body: fields.body.errors ?? [],
+  };
+  const allErrors = [
+    ...formErrors,
+    ...fieldErrors.title,
+    ...fieldErrors.description,
+    ...fieldErrors.body,
+  ];
+
+  const typed = lastResult as LastResult;
+  const fallback = {
+    title: initial?.title ?? "",
+    description: initial?.description ?? "",
+    body: initial?.body ?? "",
+  };
+  const remountKey = typed?.initialValue
+    ? `echo-${echoed(typed, "title", fallback.title)}`
+    : `initial-${initial?.slug ?? "new"}`;
+
+  return (
+    <form
+      id={form.id}
+      action={action}
+      onSubmit={form.onSubmit}
+      noValidate
+      aria-label="Editor"
+    >
+      {allErrors.length > 0 ? (
+        <ul className="error-messages">
+          {allErrors.map((msg) => (
+            <li key={msg}>{msg}</li>
+          ))}
+        </ul>
+      ) : null}
+      <fieldset>
+        <fieldset className="form-group">
+          <input
+            key={`title-${remountKey}`}
+            id={fields.title.id}
+            form={fields.title.formId}
+            type="text"
+            name={fields.title.name}
+            defaultValue={echoed(typed, "title", fallback.title)}
+            className="form-control form-control-lg"
+            placeholder="Article Title"
+            aria-invalid={fieldErrors.title.length > 0 || undefined}
+          />
+        </fieldset>
+        <fieldset className="form-group">
+          <input
+            key={`description-${remountKey}`}
+            id={fields.description.id}
+            form={fields.description.formId}
+            type="text"
+            name={fields.description.name}
+            defaultValue={echoed(typed, "description", fallback.description)}
+            className="form-control"
+            placeholder="What's this article about?"
+            aria-invalid={fieldErrors.description.length > 0 || undefined}
+          />
+        </fieldset>
+        <fieldset className="form-group">
+          <textarea
+            key={`body-${remountKey}`}
+            id={fields.body.id}
+            form={fields.body.formId}
+            name={fields.body.name}
+            defaultValue={echoed(typed, "body", fallback.body)}
+            rows={8}
+            className="form-control"
+            placeholder="Write your article (in markdown)"
+            aria-invalid={fieldErrors.body.length > 0 || undefined}
+          />
+        </fieldset>
+        <TagInput
+          name={fields.tagList.name}
+          initialTags={initial?.tagList ?? []}
+        />
+        <button
+          type="submit"
+          className="btn btn-lg pull-xs-right btn-primary"
+        >
+          Publish Article
+        </button>
+      </fieldset>
+    </form>
+  );
+};

--- a/apps/web/src/components/editor/TagInput.tsx
+++ b/apps/web/src/components/editor/TagInput.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, type KeyboardEvent, type ChangeEvent } from "react";
+
+type Props = {
+  // The form reads tags from a hidden input with this name so the
+  // server action sees them alongside the rest of the editor form.
+  name: string;
+  initialTags?: string[];
+};
+
+// Controlled tag input for the editor (#19). Enter or comma commits
+// the current input as a pill; pills show a × button to remove. Empty
+// and duplicate tags are rejected silently — the spec doesn't call
+// them out as errors, and the rejection keeps the list tidy without
+// surprising the user.
+export const TagInput = ({ name, initialTags = [] }: Props) => {
+  const [tags, setTags] = useState<string[]>(initialTags);
+  const [draft, setDraft] = useState("");
+
+  const commit = (raw: string) => {
+    const next = raw.trim();
+    if (next.length === 0) return;
+    setTags((prev) => (prev.includes(next) ? prev : [...prev, next]));
+    setDraft("");
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === ",") {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === "Backspace" && draft === "" && tags.length > 0) {
+      // Backspace on an empty draft pops the last pill — matches the
+      // idiom used by most chip inputs (Material, react-tag-input).
+      setTags((prev) => prev.slice(0, -1));
+    }
+  };
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    // If the user pastes / types a comma in the middle of text, commit
+    // everything up to the comma as a pill and keep the remainder.
+    if (raw.includes(",")) {
+      const parts = raw.split(",");
+      for (let i = 0; i < parts.length - 1; i++) {
+        commit(parts[i]);
+      }
+      setDraft(parts[parts.length - 1]);
+    } else {
+      setDraft(raw);
+    }
+  };
+
+  const remove = (tag: string) =>
+    setTags((prev) => prev.filter((t) => t !== tag));
+
+  return (
+    <fieldset className="form-group">
+      <input
+        type="text"
+        className="form-control"
+        placeholder="Enter tags"
+        value={draft}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onBlur={() => draft.trim() && commit(draft)}
+        aria-label="Enter tags"
+      />
+      <div className="tag-list" data-testid="tag-list">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="tag-default tag-pill"
+            data-testid={`tag-pill-${tag}`}
+          >
+            <button
+              type="button"
+              className="ion-close-round"
+              aria-label={`Remove tag ${tag}`}
+              onClick={() => remove(tag)}
+            >
+              ×
+            </button>{" "}
+            {tag}
+          </span>
+        ))}
+      </div>
+      {/* Hidden input ferries the committed pill list to the server
+          action as a JSON string; the schema transform decodes it. */}
+      <input type="hidden" name={name} value={JSON.stringify(tags)} />
+    </fieldset>
+  );
+};

--- a/apps/web/src/features/articles/actions.ts
+++ b/apps/web/src/features/articles/actions.ts
@@ -96,3 +96,130 @@ export const deleteArticle = async (slug: string): Promise<void> => {
   // homepage re-fetches on navigation so no revalidation needed.
   redirect("/");
 };
+
+// ------------------------------------------------------------------
+// Editor actions (#19)
+// ------------------------------------------------------------------
+
+// Editor create + update share the same form shape. Both use
+// @conform-to/zod for validation and map API field errors back into
+// the form's fieldErrors on 422. On success both redirect to the
+// article detail page for the (possibly new) slug.
+
+import { parseWithZod } from "@conform-to/zod/v4";
+import { editorSchema } from "./schema";
+
+type ArticleEnvelope = {
+  article: {
+    slug: string;
+    title: string;
+    description: string;
+    body: string;
+    tagList: string[];
+  };
+};
+
+type ApiErrors = { errors?: Record<string, string[]> };
+
+const mergeEditorErrors = (
+  api: ApiErrors,
+): Record<string, string[]> => {
+  const fields = ["title", "description", "body", "tagList"] as const;
+  const out: Record<string, string[]> = {};
+  for (const [field, msgs] of Object.entries(api.errors ?? {})) {
+    if ((fields as readonly string[]).includes(field)) {
+      out[field] = msgs.map((m) => `${field} ${m}`);
+    } else {
+      out[""] = [...(out[""] ?? []), ...msgs.map((m) => `${field} ${m}`)];
+    }
+  }
+  if (Object.keys(out).length === 0) {
+    out[""] = ["something went wrong — please try again"];
+  }
+  return out;
+};
+
+export const createArticleAction = async (
+  _prev: unknown,
+  formData: FormData,
+) => {
+  const submission = parseWithZod(formData, { schema: editorSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+  const cookie = await cookieHeader();
+  if (!cookie) {
+    redirect("/login?redirect=/editor");
+  }
+  const v = submission.value;
+  const res = await apiFetch<ArticleEnvelope>("/api/articles", {
+    method: "POST",
+    cookie,
+    body: JSON.stringify({
+      article: {
+        title: v.title,
+        description: v.description,
+        body: v.body,
+        tagList: v.tagList,
+      },
+    }),
+  });
+  if (!res.ok) {
+    if (res.status === 422) {
+      return submission.reply({
+        fieldErrors: mergeEditorErrors(res.data),
+      });
+    }
+    return submission.reply({
+      formErrors: ["server error — please try again"],
+    });
+  }
+  redirect(`/article/${encodeURIComponent(res.data.article.slug)}`);
+};
+
+export const updateArticleAction = async (
+  slug: string,
+  _prev: unknown,
+  formData: FormData,
+) => {
+  const submission = parseWithZod(formData, { schema: editorSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+  const cookie = await cookieHeader();
+  if (!cookie) {
+    redirect("/login?redirect=/editor");
+  }
+  const v = submission.value;
+  const res = await apiFetch<ArticleEnvelope>(
+    `/api/articles/${encodeURIComponent(slug)}`,
+    {
+      method: "PUT",
+      cookie,
+      body: JSON.stringify({
+        article: {
+          title: v.title,
+          description: v.description,
+          body: v.body,
+          tagList: v.tagList,
+        },
+      }),
+    },
+  );
+  if (!res.ok) {
+    if (res.status === 422) {
+      return submission.reply({
+        fieldErrors: mergeEditorErrors(res.data),
+      });
+    }
+    if (res.status === 403) {
+      return submission.reply({
+        formErrors: ["you cannot edit another author's article"],
+      });
+    }
+    return submission.reply({
+      formErrors: ["server error — please try again"],
+    });
+  }
+  redirect(`/article/${encodeURIComponent(res.data.article.slug)}`);
+};

--- a/apps/web/src/features/articles/schema.ts
+++ b/apps/web/src/features/articles/schema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+// Mirrors the API's CreateArticleRequestSchema field-for-field — the
+// editor submits the same shape whether creating or updating (the
+// update case sends a partial, but the required fields still have to
+// pass client-side on "Publish" so we don't round-trip a 422).
+export const editorSchema = z.object({
+  title: z
+    .string({ message: "title can't be blank" })
+    .min(1, "title can't be blank")
+    .max(300, "title is too long (maximum is 300 characters)"),
+  description: z
+    .string({ message: "description can't be blank" })
+    .min(1, "description can't be blank")
+    .max(1000, "description is too long (maximum is 1000 characters)"),
+  body: z
+    .string({ message: "body can't be blank" })
+    .min(1, "body can't be blank")
+    .max(50_000, "body is too long (maximum is 50000 characters)"),
+  // tagList rides as a hidden JSON-encoded input from the TagInput
+  // component. We decode + validate array shape here.
+  tagList: z
+    .string()
+    .optional()
+    .transform((s) => {
+      if (!s) return [] as string[];
+      try {
+        const parsed = JSON.parse(s) as unknown;
+        if (!Array.isArray(parsed)) return [] as string[];
+        return parsed.filter((t): t is string => typeof t === "string");
+      } catch {
+        return [] as string[];
+      }
+    }),
+});
+
+export type EditorInput = z.infer<typeof editorSchema>;

--- a/tests/e2e/specs/19-web-editor.spec.ts
+++ b/tests/e2e/specs/19-web-editor.spec.ts
@@ -1,0 +1,253 @@
+import {
+  expect,
+  request,
+  test,
+  type BrowserContext,
+} from "@playwright/test";
+
+// BDD coverage for issue #19: editor page (create + edit).
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+type ApiCtx = Awaited<ReturnType<typeof request.newContext>>;
+const apiContext = () => request.newContext({ baseURL: API_URL });
+
+const registerUser = async (api: ApiCtx, username: string): Promise<string> => {
+  const res = await api.post("/api/users", {
+    data: {
+      user: {
+        username,
+        email: `${username}@jake.jake`,
+        password: "jakejake",
+      },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const setCookie = res.headers()["set-cookie"] ?? "";
+  const match = setCookie.match(/conduit_session=([^;]+)/);
+  if (!match) throw new Error("expected conduit_session cookie from register");
+  return match[1];
+};
+
+const createArticle = async (
+  api: ApiCtx,
+  title: string,
+  tagList: string[] = [],
+): Promise<string> => {
+  const res = await api.post("/api/articles", {
+    data: {
+      article: { title, description: "d", body: "b", tagList },
+    },
+  });
+  expect(res.status()).toBe(201);
+  return ((await res.json()) as { article: { slug: string } }).article.slug;
+};
+
+const primeSession = async (
+  context: BrowserContext,
+  session: string,
+  username: string,
+): Promise<void> => {
+  const webOrigin = new URL(WEB_URL);
+  await context.addCookies([
+    {
+      name: "conduit_session",
+      value: session,
+      domain: webOrigin.hostname,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+    {
+      name: "conduit-user",
+      value: encodeURIComponent(JSON.stringify({ username, image: null })),
+      domain: webOrigin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+};
+
+test.describe("issue #19 — editor", () => {
+  test("Scenario 1: create a new article end-to-end", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/editor`);
+    const form = page.getByRole("form", { name: "Editor" });
+    await form
+      .getByPlaceholder("Article Title")
+      .fill(`Did you train your dragon? ${id}`);
+    await form
+      .getByPlaceholder("What's this article about?")
+      .fill("Ever wonder?");
+    await form
+      .getByPlaceholder("Write your article (in markdown)")
+      .fill("You have to believe");
+    // Tag input accepts two comma-delimited tags.
+    const tagInput = form.getByLabel("Enter tags");
+    await tagInput.fill("dragons");
+    await tagInput.press("Enter");
+    await tagInput.fill("training");
+    await tagInput.press("Enter");
+
+    await Promise.all([
+      page.waitForURL(/\/article\/did-you-train-your-dragon-/),
+      form.getByRole("button", { name: "Publish Article" }).click(),
+    ]);
+
+    // Article detail renders the just-saved content.
+    await expect(page.locator(".banner h1")).toHaveText(
+      `Did you train your dragon? ${id}`,
+    );
+    await expect(page.getByTestId("article-body")).toContainText(
+      "You have to believe",
+    );
+    await expect(page.locator(".tag-list")).toContainText("dragons");
+    await expect(page.locator(".tag-list")).toContainText("training");
+  });
+
+  test("Scenario 2: tag input accepts comma / enter separated pills with × remove", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/editor`);
+    const form = page.getByRole("form", { name: "Editor" });
+    const tagInput = form.getByLabel("Enter tags");
+
+    await tagInput.fill("one");
+    await tagInput.press("Enter");
+    await expect(form.getByTestId("tag-pill-one")).toBeVisible();
+    await expect(tagInput).toHaveValue("");
+
+    // Comma commits too (typed as part of the value).
+    await tagInput.fill("two,");
+    await expect(form.getByTestId("tag-pill-two")).toBeVisible();
+    await expect(tagInput).toHaveValue("");
+
+    // × removes a pill.
+    await form.getByRole("button", { name: "Remove tag one" }).click();
+    await expect(form.getByTestId("tag-pill-one")).toHaveCount(0);
+    await expect(form.getByTestId("tag-pill-two")).toBeVisible();
+  });
+
+  test("Scenario 3: validation errors render at top of form and preserve other values", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    await page.goto(`${WEB_URL}/editor`);
+    const form = page.getByRole("form", { name: "Editor" });
+
+    // Fill description/body/tag; leave title blank.
+    await form.getByPlaceholder("What's this article about?").fill(`desc ${id}`);
+    await form
+      .getByPlaceholder("Write your article (in markdown)")
+      .fill(`body ${id}`);
+    const tagInput = form.getByLabel("Enter tags");
+    await tagInput.fill("keeper");
+    await tagInput.press("Enter");
+
+    await form.getByRole("button", { name: "Publish Article" }).click();
+
+    await expect(page).toHaveURL(/\/editor$/);
+    await expect(form.locator(".error-messages")).toContainText(
+      "title can't be blank",
+    );
+    // Preserved values.
+    await expect(
+      form.getByPlaceholder("What's this article about?"),
+    ).toHaveValue(`desc ${id}`);
+    await expect(
+      form.getByPlaceholder("Write your article (in markdown)"),
+    ).toHaveValue(`body ${id}`);
+  });
+
+  test("Scenario 4: edit existing own article re-posts and lands on the new slug", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const jakeApi = await apiContext();
+    const session = await registerUser(jakeApi, jake);
+    await primeSession(context, session, jake);
+
+    const slug = await createArticle(jakeApi, `How to train ${id}`, [
+      "dragons",
+    ]);
+
+    await page.goto(`${WEB_URL}/editor/${slug}`);
+    const form = page.getByRole("form", { name: "Editor" });
+
+    // Prefilled.
+    await expect(form.getByPlaceholder("Article Title")).toHaveValue(
+      `How to train ${id}`,
+    );
+    await expect(form.getByPlaceholder("What's this article about?")).toHaveValue("d");
+
+    // Rename.
+    const newTitle = `How to train dragons — revised ${id}`;
+    await form.getByPlaceholder("Article Title").fill(newTitle);
+    await Promise.all([
+      page.waitForURL(/\/article\/how-to-train-dragons-revised-/),
+      form.getByRole("button", { name: "Publish Article" }).click(),
+    ]);
+    await expect(page.locator(".banner h1")).toHaveText(newTitle);
+  });
+
+  test("Scenario 5: editing someone else's article redirects to the detail page", async ({
+    page,
+    context,
+  }) => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const dan = `dan-${id}`;
+    const jakeApi = await apiContext();
+    const danApi = await apiContext();
+    await registerUser(jakeApi, jake);
+    const danSession = await registerUser(danApi, dan);
+    await primeSession(context, danSession, dan);
+
+    const slug = await createArticle(jakeApi, `Jake's secret ${id}`);
+
+    await page.goto(`${WEB_URL}/editor/${slug}`);
+    await page.waitForURL(new RegExp(`/article/${slug}`));
+    // No editor form on the destination page.
+    await expect(
+      page.getByRole("form", { name: "Editor" }),
+    ).toHaveCount(0);
+  });
+
+  test("Scenario 6: /editor requires auth, redirects to /login?redirect=/editor", async ({
+    page,
+  }) => {
+    const res = await page.goto(`${WEB_URL}/editor`);
+    await expect(page).toHaveURL(/\/login\?redirect=(%2F|\/)editor$/);
+    expect(res?.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #19.

## User Intent

Logged-in users create articles at `/editor` and edit their own at `/editor/[slug]`. Title / description / body / tags all validate inline. Tags are a pill-input: Enter or comma commits, × removes, backspace-on-empty pops. Submit → `/article/<slug>`. Anon → login. Non-author edit → detail page.

## What ships

- **Routes**
  - `apps/web/src/app/editor/page.tsx` — create route, auth-gated.
  - `apps/web/src/app/editor/[slug]/page.tsx` — edit route; fetches existing article RSC-side for prefill; `notFound()` on unknown slug; redirects non-authors to `/article/<slug>`.
- **Schema** `apps/web/src/features/articles/schema.ts` — mirrors the API's `CreateArticleRequestSchema` + decodes JSON-encoded tagList hidden field.
- **Actions** (appended to `features/articles/actions.ts`)
  - `createArticleAction` — POST `/api/articles`, maps 422 to field errors, redirects to the new slug.
  - `updateArticleAction` — PUT `/api/articles/:slug`, maps 422 + 403, redirects to the (possibly new) slug.
- **Client components**
  - `components/editor/EditorForm.tsx` — conform-to + useActionState, shared between create + edit (passes `initial` for prefill), remount-on-echo.
  - `components/editor/TagInput.tsx` — controlled pill list: Enter / comma to commit, `×` button to remove, backspace-on-empty pops, onBlur commits any remaining draft. Hidden JSON input ferries the list to the action.
- **Playwright spec** `tests/e2e/specs/19-web-editor.spec.ts` — 6/6 scenarios pass:
  ```
  ✓ Scenario 1: create end-to-end
  ✓ Scenario 2: tag input comma/enter pills + × remove
  ✓ Scenario 3: blank title → error at top, other values preserved
  ✓ Scenario 4: edit own — prefilled, rename, redirect to new slug
  ✓ Scenario 5: edit another's → redirect to /article/<slug>
  ✓ Scenario 6: anon /editor → /login?redirect=/editor
  ```

## Evidence

- Spec 19 isolated: **6/6 passed (4.0s)**.
- Full Playwright suite: **109 passed**.
- `pnpm lint` ✓, `pnpm typecheck` ✓, `pnpm --filter @conduit/web build` ✓.

## Notes

- The tagList transport is a hidden JSON-encoded input (`[]`-wrapped string). The editor schema decodes it and defends against non-array payloads — safer than the classic "comma-split at submit" pattern and means the TagInput can live as a pure React component without a form-schema quirk.
- The edit route's non-author check runs at render time (based on the `conduit-user` cookie vs `article.author.username`). The API independently enforces 403 on `PUT` (#9) so a forged cookie still gets blocked server-side; the 403 branch in `updateArticleAction` surfaces the right form-level error if a user reaches it.

## Test plan

- [x] Create happy path (title + desc + body + tags) → new article page
- [x] Tag input: Enter commits, comma commits, × removes, draft cleared
- [x] Blank title → inline error at top, other fields preserved
- [x] Edit own article → prefilled, rename → new slug lands
- [x] Edit other's article → redirect to `/article/<slug>` (no form shown)
- [x] Anon `/editor` → `/login?redirect=/editor`
- [x] `pnpm lint` + `pnpm typecheck` + `pnpm build`
- [x] Full Playwright 109/109
- [ ] CI green on this PR
