### PR TITLE
feat(test): /healthz 503 side-stack spec (#49)

### DIFF
--- a/tests/e2e/specs/25b-api-healthz-db-down.spec.ts
+++ b/tests/e2e/specs/25b-api-healthz-db-down.spec.ts
@@ -1,0 +1,208 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, request, test } from "@playwright/test";
+
+// Deferred-from-#25 scenario 3b: assert /healthz returns 503 when the
+// database is unreachable. We can't pause postgres in the main
+// `conduit` compose project without starving every other spec, so
+// this spec spins up its *own* side-stack with a distinct project
+// name + distinct host ports, pauses / unpauses postgres there, and
+// tears the stack down when done.
+
+const PROJECT =
+  process.env.CONDUIT_HEALTHZ_TEST_PROJECT ?? "conduit-healthz-test";
+const API_HOST_PORT =
+  process.env.CONDUIT_HEALTHZ_TEST_API_PORT ?? "3121";
+const WEB_HOST_PORT =
+  process.env.CONDUIT_HEALTHZ_TEST_WEB_PORT ?? "3120";
+const POSTGRES_HOST_PORT =
+  process.env.CONDUIT_HEALTHZ_TEST_POSTGRES_PORT ?? "5454";
+
+const COMPOSE_FILE = "infra/docker-compose.yml";
+
+let envFilePath = "";
+let apiContainerName = "";
+let pgContainerName = "";
+
+// All shell-outs go through execFileSync with explicit arg arrays —
+// no string interpolation into a shell, so there's no injection
+// surface even though every value here is hard-coded or env-derived.
+const run = (
+  bin: string,
+  args: string[],
+  opts: { stdio?: "pipe" | "inherit" } = {},
+): string => {
+  const out = execFileSync(bin, args, {
+    stdio: opts.stdio === "inherit" ? "inherit" : "pipe",
+    timeout: 5 * 60 * 1000,
+  });
+  return opts.stdio === "inherit" ? "" : out.toString();
+};
+
+const compose = (args: string[], opts: { stdio?: "pipe" | "inherit" } = {}) =>
+  run(
+    "docker",
+    [
+      "compose",
+      "-p",
+      PROJECT,
+      "-f",
+      COMPOSE_FILE,
+      "--env-file",
+      envFilePath,
+      ...args,
+    ],
+    opts,
+  );
+
+// Compose-derived container name, for pause / unpause / logs. We
+// query `compose ps -q` + `docker inspect` so the spec keeps working
+// if the compose naming convention ever changes.
+const resolveContainer = (service: string): string => {
+  const ids = compose(["ps", "-q", service]).trim();
+  if (!ids) throw new Error(`compose ps returned no container for ${service}`);
+  const id = ids.split("\n")[0];
+  return run("docker", ["inspect", "--format", "{{.Name}}", id])
+    .trim()
+    .replace(/^\//, "");
+};
+
+const waitHealthy = async (container: string, tries = 60): Promise<boolean> => {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const state = run("docker", [
+        "inspect",
+        "--format",
+        "{{.State.Health.Status}}",
+        container,
+      ]).trim();
+      if (state === "healthy") return true;
+    } catch {
+      // container may not exist yet on the first few tries.
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+};
+
+test.describe.serial("issue #49 — /healthz 503 side-stack spec", () => {
+  test.beforeAll(async () => {
+    // Throwaway .env with non-colliding ports + a random password so
+    // the side-stack can't be reused across runs.
+    const dir = mkdtempSync(join(tmpdir(), "conduit-healthz-test-"));
+    envFilePath = join(dir, ".env");
+    const pw = `p${Date.now()}`;
+    writeFileSync(
+      envFilePath,
+      [
+        "NODE_ENV=development",
+        "LOG_LEVEL=warn",
+        "POSTGRES_USER=conduit",
+        `POSTGRES_PASSWORD=${pw}`,
+        "POSTGRES_DB=conduit",
+        `POSTGRES_HOST_PORT=${POSTGRES_HOST_PORT}`,
+        "API_PORT=3001",
+        `API_HOST_PORT=${API_HOST_PORT}`,
+        "API_URL_INTERNAL=http://api:3001",
+        "WEB_PORT=3000",
+        `WEB_HOST_PORT=${WEB_HOST_PORT}`,
+        `WEB_URL=http://localhost:${WEB_HOST_PORT}`,
+        `NEXT_PUBLIC_API_URL=http://localhost:${API_HOST_PORT}`,
+        `JWT_SECRET=${pw}${pw}`,
+        "JWT_TTL_SECONDS=604800",
+        "COOKIE_DOMAIN=localhost",
+        "COOKIE_SECURE=false",
+      ].join("\n") + "\n",
+    );
+
+    compose(["up", "-d", "--build"], { stdio: "inherit" });
+
+    apiContainerName = resolveContainer("api");
+    pgContainerName = resolveContainer("postgres");
+    const apiUp = await waitHealthy(apiContainerName);
+    if (!apiUp) {
+      throw new Error(
+        `side-stack api never became healthy (container=${apiContainerName})`,
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    // Always run a clean teardown — `down -v` drops the project's
+    // containers + networks + volumes so the next run starts clean
+    // and `docker ps -a --filter name=...` returns empty (AC 2).
+    if (pgContainerName) {
+      try {
+        run("docker", ["unpause", pgContainerName]);
+      } catch {
+        // container may already be unpaused / gone — ignore.
+      }
+    }
+    const res = spawnSync(
+      "docker",
+      [
+        "compose",
+        "-p",
+        PROJECT,
+        "-f",
+        COMPOSE_FILE,
+        "--env-file",
+        envFilePath,
+        "down",
+        "-v",
+      ],
+      { stdio: "inherit", timeout: 60_000 },
+    );
+    if (res.status !== 0) {
+      throw new Error(`side-stack down returned ${res.status}`);
+    }
+    if (envFilePath) {
+      rmSync(envFilePath, { force: true });
+    }
+
+    const remaining = run("docker", [
+      "ps",
+      "-a",
+      "--filter",
+      `name=${PROJECT}`,
+      "--format",
+      "{{.Names}}",
+    ]).trim();
+    expect(remaining, "side-stack teardown should leave no containers").toBe(
+      "",
+    );
+  });
+
+  test("Scenario 1: /healthz returns 503 when postgres is paused", async () => {
+    const api = await request.newContext({
+      baseURL: `http://localhost:${API_HOST_PORT}`,
+    });
+
+    // Baseline: before pausing, /healthz should return 200 (confirms
+    // the side-stack is up and the probe path works).
+    const before = await api.get("/healthz");
+    expect(before.status()).toBe(200);
+
+    run("docker", ["pause", pgContainerName]);
+
+    try {
+      // Probe may take up to `HEALTHCHECK_DB_TIMEOUT_MS` (2s default)
+      // to time out; single request is enough since the code path is
+      // deterministic once paused.
+      const res = await api.get("/healthz", { timeout: 5000 });
+      expect(res.status()).toBe(503);
+      const body = (await res.json()) as {
+        ok: boolean;
+        checks: { db: string };
+      };
+      expect(body.ok).toBe(false);
+      expect(body.checks.db).toBe("fail");
+    } finally {
+      run("docker", ["unpause", pgContainerName]);
+      const ok = await waitHealthy(pgContainerName, 20);
+      expect(ok, "postgres should unpause cleanly").toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #49.

## User Intent

The `/healthz` 503 branch (already live in `apps/api/src/routes/healthz.ts`) now has a live runtime test: a Playwright spec that pauses postgres and asserts the API returns `503 {ok:false, checks:{db:"fail"}}`. Completes scenario 3b that was deferred from #25.

## What ships

- **One new spec** `tests/e2e/specs/25b-api-healthz-db-down.spec.ts`:
  - **beforeAll**: writes a throwaway `.env` to `tmpdir()` with distinct ports (API 3121, Web 3120, Postgres 5454) + a random password, then spins up a side-stack via `docker compose -p conduit-healthz-test -f infra/docker-compose.yml --env-file <tmpenv> up -d --build`. Waits for the api container to be healthy before running assertions.
  - **Scenario 1** — confirms `/healthz` = 200 as baseline, `docker pause`s postgres, re-probes (up to 5s), asserts `503` + `{ok:false, checks:{db:"fail"}}`, `docker unpause`s. Assertion happens inside a `try/finally` so the unpause runs even on a failure, avoiding a paused container stuck across runs.
  - **afterAll**: best-effort `docker unpause` + `docker compose ... down -v`, then asserts `docker ps -a --filter name=<project>` is empty (AC scenario 2 — clean teardown).
- Project name + ports parameterized via env (`CONDUIT_HEALTHZ_TEST_PROJECT`, `..._API_PORT`, `..._WEB_PORT`, `..._POSTGRES_PORT`) so the evaluator worktree can override when running under a different port pool.

## Design notes

- **Isolation** — The side-stack is a separate compose project (distinct name + distinct ports + distinct volumes). Pausing postgres there does not affect the main `conduit` test stack running other specs in the same Playwright invocation. Verified by running spec 22 (healthz smoke on main), spec 25 (observability floor), and spec 25b together: all 11 tests pass (32.7s).
- **Injection surface** — Every shell-out uses `execFileSync(bin, [arg, arg, ...])` (no string interpolation into a shell). Project name + ports are env-derived or hard-coded, but the discipline keeps the spec safe from future changes that might wire in untrusted input.
- **Container name resolution** — Rather than hardcoding `<project>-api-1`, the spec calls `compose ps -q <service>` and `docker inspect --format {{.Name}}` so it keeps working if compose's naming convention ever shifts. (Same lesson as #58.)
- **Clean teardown** — The spec's afterAll runs regardless of test outcome (Playwright hook semantics). The final `docker ps` assertion guards against any future regression that leaves containers dangling.

## Evidence

- Spec 25b isolated: **1 passed (1.5m)** — full build-and-teardown cycle on a cold image cache.
- Combined with spec 22 + 25: **11 passed (32.7s)** (warm cache) — cross-spec isolation confirmed.
- `pnpm lint` ✓, `pnpm typecheck` ✓.
- Teardown verified: `docker ps -a --filter name=conduit-healthz-test` returns empty after the spec.

## Test plan

- [x] Side-stack comes up on isolated ports + project name
- [x] `/healthz` returns 200 pre-pause (baseline)
- [x] `docker pause` postgres, `/healthz` returns 503 with correct body
- [x] `docker unpause` restores postgres health
- [x] `afterAll` runs `compose down -v`, no container leak
- [x] Runs alongside spec 22 + 25 without cross-contamination
- [x] `pnpm lint`, `pnpm typecheck`
- [ ] CI green on this PR
