### PR TITLE
feat(test): axe-playwright dynamic a11y gate across page specs (#87)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -15,7 +15,10 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <Navbar />
-        {children}
+        {/* Every page's content sits inside <main> so axe's
+            landmark-one-main + region rules are satisfied globally
+            (see tests/e2e/axe-config.ts + #87). */}
+        <main>{children}</main>
         <Footer />
       </body>
     </html>

--- a/apps/web/src/components/article/ArticleMeta.tsx
+++ b/apps/web/src/components/article/ArticleMeta.tsx
@@ -30,15 +30,18 @@ export const ArticleMeta = ({ article, viewerUsername, authed }: Props) => {
 
   return (
     <div className="article-meta">
-      <Link href={profileHref}>
-        {article.author.image ? (
-          // Remote user-supplied avatar URLs don't belong in next/image's
-          // domains allowlist; the bitmap is tiny (32–64 px) and cached
-          // by the browser. Matches the pattern in Navbar / ArticlePreview.
-          // eslint-disable-next-line @next/next/no-img-element
+      {article.author.image ? (
+        <Link
+          href={profileHref}
+          aria-label={`${article.author.username} profile`}
+        >
+          {/* Remote user-supplied avatar URLs don't belong in next/image's
+              domains allowlist; the bitmap is tiny (32–64 px) and cached
+              by the browser. Matches the pattern in Navbar / ArticlePreview. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={article.author.image} alt={`${article.author.username} avatar`} />
-        ) : null}
-      </Link>
+        </Link>
+      ) : null}
       <div className="info">
         <Link href={profileHref} className="author">
           {article.author.username}

--- a/apps/web/src/components/comment/CommentItem.tsx
+++ b/apps/web/src/components/comment/CommentItem.tsx
@@ -26,21 +26,22 @@ export const CommentItem = ({ slug, comment, viewerUsername }: Props) => {
         <p className="card-text">{comment.body}</p>
       </div>
       <div className="card-footer">
-        <a
-          href={`/profile/${encodeURIComponent(comment.author.username)}`}
-          className="comment-author"
-        >
-          {comment.author.image ? (
-            // Tiny comment-author avatar; see established pattern in
-            // Navbar / ArticlePreview for plain <img> vs next/image.
-            // eslint-disable-next-line @next/next/no-img-element
+        {comment.author.image ? (
+          <a
+            href={`/profile/${encodeURIComponent(comment.author.username)}`}
+            className="comment-author"
+            aria-label={`${comment.author.username} profile`}
+          >
+            {/* Tiny comment-author avatar; see established pattern in
+                Navbar / ArticlePreview for plain <img> vs next/image. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={comment.author.image}
               alt={`${comment.author.username} avatar`}
               className="comment-author-img"
             />
-          ) : null}
-        </a>
+          </a>
+        ) : null}
         &nbsp;
         <a
           href={`/profile/${encodeURIComponent(comment.author.username)}`}

--- a/docs/quality-gates-axe.md
+++ b/docs/quality-gates-axe.md
@@ -1,0 +1,59 @@
+# axe-playwright dynamic a11y gate (#87)
+
+The Playwright suite's page-level specs run axe-core against the rendered DOM. Zero `critical` or `serious` violations block merge. `moderate` and `minor` are signal-only.
+
+Companion doc to `docs/quality-gates.md` (the size-limit + LHCI gates
+from PR #88 — once that lands, merge this section into that file).
+
+## What's measured
+
+| Spec | URL(s) under gate |
+|---|---|
+| 15 layout-shell | `/`, `/login`, `/register`, `/settings`, `/editor` |
+| 16 auth | `/login`, `/register` |
+| 17 homepage (anon) | `/` |
+| 18 article-detail | `/article/<seeded>` |
+| 19 editor (authed) | `/editor` |
+| 20 profile | `/profile/<seeded>` |
+| 21 settings (authed) | `/settings` |
+| 56 home favorite | `/` with a seeded article |
+
+Each page-level spec calls `await runAxe(page)` (from `tests/e2e/axe-config.ts`) at least once. The helper injects axe-core then calls `checkA11y` with:
+
+- **Fail on**: `critical` + `serious` impacts.
+- **Rule overrides**: documented per-rule in `sharedRuleOverrides` at the top of the helper. Each entry carries a one-line `why:` citing the issue / PR that tracks the fix.
+
+## Current overrides
+
+| Rule | Why | Tracked |
+|---|---|---|
+| `color-contrast` | RealWorld canonical palette (brand green `#5cb85c`, muted grey `#b3b3b3`, white-on-green banner) below AA on every shared chrome surface — 10–11 nodes per page, all from Navbar / banner / footer. Fix requires a palette tune that touches visual parity with the RealWorld reference. | **#90** |
+
+Any new override must land with a `type/bug` follow-up issue. The gate never silently suppresses a violation.
+
+## Adding the gate to a new spec
+
+```ts
+import { runAxe } from "../axe-config";
+
+test("axe a11y gate on <page> (#87)", async ({ page }) => {
+  await page.goto(`${WEB_URL}/the-page`);
+  await runAxe(page);
+});
+```
+
+Authed pages seed a session via the existing `registerUser` + `primeSession` helpers, then call `runAxe`.
+
+## Triaging a new violation
+
+1. **If trivial** (missing `aria-label`, empty anchor, semantic HTML): fix inline in the PR.
+2. **If it requires a component rewrite or visual redesign**: file a `type/bug` issue with rule id + spec name + first-failing URL, then add an override in `sharedRuleOverrides` with a `why:` that points to the issue.
+3. **Never** silent-suppress. The rule override shape (`Record<id, { enabled: false; why: string }>`) enforces the discipline at code-review time.
+
+## What #87 landed with
+
+- Canonical `color-contrast` violations tracked in #90 and allowlisted.
+- Trivial empty-anchor violations (empty author avatar links on `/article/[slug]` + `CommentItem`) fixed inline — avatars now only render when an image is present, and the ghost-anchor fallback is gone.
+- `landmark-one-main` + `region` (moderate; signal-only but free) fixed by wrapping `{children}` in a `<main>` element in `apps/web/src/app/layout.tsx`.
+
+All 8 page-level specs pass `runAxe(page)` against the current walking-skeleton compose stack.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@playwright/test": "1.59.1",
     "@size-limit/file": "12.1.0",
     "@usebruno/cli": "3.3.0",
+    "axe-core": "4.11.4",
+    "axe-playwright": "2.2.2",
     "newman": "6.2.2",
     "size-limit": "12.1.0",
     "typescript": "5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@usebruno/cli':
         specifier: 3.3.0
         version: 3.3.0
+      axe-core:
+        specifier: 4.11.4
+        version: 4.11.4
+      axe-playwright:
+        specifier: 2.2.2
+        version: 2.2.2(playwright@1.59.1)
       newman:
         specifier: 6.2.2
         version: 6.2.2
@@ -1758,6 +1764,9 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
+  '@types/junit-report-builder@3.0.2':
+    resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
+
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
@@ -2194,9 +2203,20 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axe-core@4.11.3:
-    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
+
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
+
+  axe-playwright@2.2.2:
+    resolution: {integrity: sha512-h350/grzDCPgpuWV7eEOqr/f61Xn07Gi9f9B3Ew4rW6/nFtpdEJYW6jgRATorgAGXjEAYFTnaY3sEys39wDw4A==}
+    peerDependencies:
+      playwright: '>1.0.0'
 
   axios-ntlm@1.4.6:
     resolution: {integrity: sha512-4nR5cbVEBfPMTFkd77FEDpDuaR205JKibmrkaQyNwGcCx0szWNpRZaL0jZyMx4+mVY2PXHjRHuJafv9Oipl0Kg==}
@@ -3780,6 +3800,10 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  junit-report-builder@5.1.2:
+    resolution: {integrity: sha512-HzvLbEQcoqN2LmGnloShxu2hLadi/rkOTU3zt61UeMICLS0wGDvbf8neIi6+bGkxMnAePIcFMFnbqV+r6YvwxA==}
+    engines: {node: '>=16'}
+
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
@@ -4220,6 +4244,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
@@ -7704,6 +7732,8 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 22.18.2
 
+  '@types/junit-report-builder@3.0.2': {}
+
   '@types/lodash@4.17.24': {}
 
   '@types/mdast@4.0.4':
@@ -8245,7 +8275,21 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axe-core@4.11.3: {}
+  axe-core@4.11.4: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.11.4):
+    dependencies:
+      axe-core: 4.11.4
+      mustache: 4.2.0
+
+  axe-playwright@2.2.2(playwright@1.59.1):
+    dependencies:
+      '@types/junit-report-builder': 3.0.2
+      axe-core: 4.11.4
+      axe-html-reporter: 2.2.11(axe-core@4.11.4)
+      junit-report-builder: 5.1.2
+      picocolors: 1.1.1
+      playwright: 1.59.1
 
   axios-ntlm@1.4.6(debug@4.4.3):
     dependencies:
@@ -9112,7 +9156,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.11.3
+      axe-core: 4.11.4
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
@@ -10082,6 +10126,12 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  junit-report-builder@5.1.2:
+    dependencies:
+      lodash: 4.18.1
+      make-dir: 3.1.0
+      xmlbuilder: 15.1.1
+
   jwa@1.4.2:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -10147,7 +10197,7 @@ snapshots:
     dependencies:
       '@paulirish/trace_engine': 0.0.53
       '@sentry/node': 7.120.4
-      axe-core: 4.11.3
+      axe-core: 4.11.4
       chrome-launcher: 1.2.1
       configstore: 5.0.1
       csp_evaluator: 1.1.5
@@ -10685,6 +10735,8 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mute-stream@0.0.7: {}
 

--- a/tests/e2e/axe-config.ts
+++ b/tests/e2e/axe-config.ts
@@ -1,0 +1,112 @@
+import { injectAxe, checkA11y } from "axe-playwright";
+import type { Page } from "@playwright/test";
+
+// Shared axe-playwright gate for every page-level E2E spec. Issue #87.
+//
+// Usage inside a test:
+//
+//   import { runAxe } from "../axe-config";
+//   ...
+//   await page.goto(`${WEB_URL}/login`);
+//   await runAxe(page);
+//
+// Design choices:
+//   - Block on `critical` and `serious` violations; surface `moderate`
+//     and `minor` as non-blocking warnings. The spec's AC is explicit
+//     that critical / serious → fail; moderate / minor are
+//     signal-only.
+//   - `axe-core` is injected once per page navigation; repeat calls
+//     after navigation are safe (axe-playwright detects the stale
+//     injection and re-injects).
+//   - The rule disable-list is intentionally empty at the outset.
+//     Any rule disabled here MUST carry a one-line `why` comment
+//     citing the upstream issue / documented false-positive, per
+//     #87's AC scenario 2. Initial violations surface without a
+//     safety net; fixes land inline or as `type/bug` follow-ups.
+
+type AxeViolationNode = {
+  target: string[];
+  html: string;
+  failureSummary?: string;
+};
+
+type AxeViolation = {
+  id: string;
+  impact: "critical" | "serious" | "moderate" | "minor" | null;
+  help: string;
+  helpUrl: string;
+  nodes: AxeViolationNode[];
+};
+
+export type RunAxeOptions = {
+  // Severity levels that fail the test. Default: critical + serious.
+  // Tests that need to allow moderate / minor temporarily can relax
+  // this, but the call site must include a justification comment.
+  failOn?: Array<AxeViolation["impact"]>;
+  // CSS selectors to exclude from analysis. Use sparingly and
+  // document why — any exclusion is a per-spec allowlist.
+  exclude?: string[];
+};
+
+/**
+ * Rule overrides shared across every spec. Each entry is a known
+ * false positive or a documented exception with a short `why`.
+ *
+ * Empty today. Populated as initial violations surface during
+ * CI — each new entry needs:
+ *   - the rule id (from axe-core),
+ *   - a one-line `why:` explaining the override,
+ *   - a link to the spec / PR / upstream issue.
+ */
+const sharedRuleOverrides: Record<
+  string,
+  { enabled: false; why: string }
+> = {
+  // Canonical RealWorld palette (navbar green #5cb85c, muted nav-link
+  // grey #b3b3b3, white-on-green banner) fails WCAG AA contrast on
+  // every page surface — 10–11 violations per page from shared chrome.
+  // Tracked in #90; allowlist while the palette gets tuned to an
+  // AA-compliant variant without breaking visual parity with the
+  // RealWorld reference. Remove this entry once #90 lands.
+  "color-contrast": {
+    enabled: false,
+    why: "Tracked in #90 — RealWorld canonical palette below AA",
+  },
+};
+
+/**
+ * Inject axe-core into the current page and run the check. Throws if
+ * any violation at the configured severity appears, failing the test.
+ *
+ * The call site is one line per spec; the configuration lives here so
+ * tuning (rule overrides, severity thresholds) is done in one place
+ * and reviewed together.
+ */
+export const runAxe = async (
+  page: Page,
+  options: RunAxeOptions = {},
+): Promise<void> => {
+  const failOn = options.failOn ?? ["critical", "serious"];
+
+  await injectAxe(page);
+
+  // axe-playwright's `checkA11y` throws on violation. Pass:
+  //   - includedImpacts: which severities should count as a failure,
+  //   - axeOptions.rules: our shared overrides,
+  //   - detailedReport + detailedReportOptions.html: so the failure
+  //     message in CI carries the offending HTML, not just a rule id,
+  //     which dramatically speeds diagnosis.
+  await checkA11y(page, options.exclude ? { exclude: options.exclude } : undefined, {
+    includedImpacts: failOn.filter((i): i is NonNullable<typeof i> => i !== null),
+    axeOptions: {
+      rules: Object.fromEntries(
+        Object.entries(sharedRuleOverrides).map(([id, cfg]) => [
+          id,
+          { enabled: cfg.enabled },
+        ]),
+      ),
+    },
+    detailedReport: true,
+    detailedReportOptions: { html: true },
+  });
+};

--- a/tests/e2e/specs/15-web-layout-shell.spec.ts
+++ b/tests/e2e/specs/15-web-layout-shell.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { mkdir } from "node:fs/promises";
+import { runAxe } from "../axe-config";
 
 const SCREENSHOT_DIR = "tests/e2e/screenshots/15";
 const AUTH_COOKIE_NAME = "conduit-user";
@@ -131,4 +132,11 @@ test("canonical RealWorld styling — Source Sans Pro + green navbar + banner", 
   expect(bannerBg).toBe("rgb(92, 184, 92)");
 
   await page.screenshot({ path: `${SCREENSHOT_DIR}/scenario-5-styling.png` });
+});
+
+test("axe a11y gate on layout-shell anon routes (#87)", async ({ page }) => {
+  for (const path of PROTECTED_ROUTES) {
+    await page.goto(path);
+    await runAxe(page);
+  }
 });

--- a/tests/e2e/specs/16-web-auth-register-login.spec.ts
+++ b/tests/e2e/specs/16-web-auth-register-login.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { runAxe } from "../axe-config";
 import { mkdir } from "node:fs/promises";
 
 // BDD coverage for issue #16: register + login pages backed by Next.js
@@ -245,4 +246,11 @@ test.describe("issue #16 — web register / login", () => {
       path: `${SCREENSHOT_DIR}/scenario-7-already-authed.png`,
     });
   });
+});
+
+test("axe a11y gate on auth routes (#87)", async ({ page }) => {
+  for (const path of ["/login", "/register"]) {
+    await page.goto(path);
+    await runAxe(page);
+  }
 });

--- a/tests/e2e/specs/17-web-homepage.spec.ts
+++ b/tests/e2e/specs/17-web-homepage.spec.ts
@@ -1,4 +1,5 @@
 import { expect, request, test } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #17 (rescoped by Audit E.1, 2026-04-29):
 // static RSC homepage — banner, feed tabs, article preview cards,
@@ -275,4 +276,9 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
       "No articles are here... yet.",
     );
   });
+});
+
+test("axe a11y gate on homepage (#87)", async ({ page }) => {
+  await page.goto(`${WEB_URL}/`);
+  await runAxe(page);
 });

--- a/tests/e2e/specs/18-web-article-detail.spec.ts
+++ b/tests/e2e/specs/18-web-article-detail.spec.ts
@@ -1,4 +1,5 @@
 import { expect, request, test, type BrowserContext } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #18: article detail page with markdown,
 // comments, follow/favorite, author delete, and graceful 404.
@@ -321,4 +322,15 @@ test.describe("issue #18 — article detail page", () => {
     expect(res?.status()).toBe(404);
     await expect(page.locator("body")).toContainText("Article not found");
   });
+});
+
+test("axe a11y gate on article detail (#87)", async ({ page }) => {
+  const jakeApi = await apiContext();
+  await registerUser(jakeApi, `jake-${uniq()}`);
+  const { slug } = await createArticle(jakeApi, {
+    title: `Axe ${uniq()}`,
+    body: "Hello body.",
+  });
+  await page.goto(`${WEB_URL}/article/${slug}`);
+  await runAxe(page);
 });

--- a/tests/e2e/specs/19-web-editor.spec.ts
+++ b/tests/e2e/specs/19-web-editor.spec.ts
@@ -4,6 +4,7 @@ import {
   test,
   type BrowserContext,
 } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #19: editor page (create + edit).
 
@@ -250,4 +251,14 @@ test.describe("issue #19 — editor", () => {
     await expect(page).toHaveURL(/\/login\?redirect=(%2F|\/)editor$/);
     expect(res?.status()).toBe(200);
   });
+});
+
+test("axe a11y gate on editor page (#87)", async ({ page, context }) => {
+  const id = uniq();
+  const jake = `jake-${id}`;
+  const api = await apiContext();
+  const session = await registerUser(api, jake);
+  await primeSession(context, session, jake);
+  await page.goto(`${WEB_URL}/editor`);
+  await runAxe(page);
 });

--- a/tests/e2e/specs/20-web-profile-page.spec.ts
+++ b/tests/e2e/specs/20-web-profile-page.spec.ts
@@ -4,6 +4,7 @@ import {
   test,
   type BrowserContext,
 } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #20: profile page.
 // Five AC scenarios.
@@ -197,4 +198,13 @@ test.describe("issue #20 — profile page", () => {
       "No articles are here... yet.",
     );
   });
+});
+
+test("axe a11y gate on profile page (#87)", async ({ page }) => {
+  const id = uniq();
+  const jake = `jake-${id}`;
+  const api = await apiContext();
+  await registerUser(api, jake);
+  await page.goto(`${WEB_URL}/profile/${jake}`);
+  await runAxe(page);
 });

--- a/tests/e2e/specs/21-web-settings.spec.ts
+++ b/tests/e2e/specs/21-web-settings.spec.ts
@@ -4,6 +4,7 @@ import {
   test,
   type BrowserContext,
 } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #21: settings page (#21).
 // Six scenarios matching the AC block.
@@ -204,4 +205,14 @@ test.describe("issue #21 — settings page", () => {
     // Final status after redirect is 200 (the login page).
     expect(res?.status()).toBe(200);
   });
+});
+
+test("axe a11y gate on settings page (#87)", async ({ page, context }) => {
+  const id = uniq();
+  const jake = `jake-${id}`;
+  const api = await apiContext();
+  const session = await registerUser(api, jake);
+  await primeSession(context, session, jake);
+  await page.goto(`${WEB_URL}/settings`);
+  await runAxe(page);
 });

--- a/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
+++ b/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
@@ -4,6 +4,7 @@ import {
   test,
   type BrowserContext,
 } from "@playwright/test";
+import { runAxe } from "../axe-config";
 
 // BDD coverage for issue #56: interactive favorite toggle on the
 // homepage ArticlePreview card. Four scenarios from the issue body.
@@ -232,4 +233,13 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     );
     expect(favPostSeen).toBe(false);
   });
+});
+
+test("axe a11y gate on homepage with articles (#87)", async ({ page }) => {
+  const id = uniq();
+  const jakeApi = await apiContext();
+  await registerUser(jakeApi, `jake-${id}`);
+  await createArticle(jakeApi, `Axe ${id}`);
+  await page.goto(`${WEB_URL}/`);
+  await runAxe(page);
 });


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #87.

## User Intent

Every page-level Playwright spec now runs axe-core against the rendered DOM. Zero `critical` or `serious` a11y violations block merge.

## What ships

- **`tests/e2e/axe-config.ts`** — shared `runAxe(page, options?)` helper. Injects axe-core, calls `checkA11y` with `critical | serious` as failing impacts, surfaces a detailed report with the offending HTML on failure. `sharedRuleOverrides` is the one-file allowlist; every entry requires a `why:` comment citing the follow-up issue.
- **Integration across 8 specs** — 15 layout-shell, 16 auth, 17 homepage, 18 article-detail, 19 editor, 20 profile, 21 settings, 56 home-favorite-toggle. Each gets an `axe a11y gate on <surface> (#87)` test that navigates to the relevant URL and calls `runAxe(page)`.
- **Inline fixes** for trivial violations surfaced during integration:
  - `apps/web/src/app/layout.tsx` — wraps `{children}` in `<main>` so `landmark-one-main` + `region` (moderate) pass globally.
  - `apps/web/src/components/article/ArticleMeta.tsx` — the profile avatar `<Link>` only renders when `author.image` is present, so the previous empty-anchor (serious `link-name` violation) is gone.
  - `apps/web/src/components/comment/CommentItem.tsx` — same pattern; the avatar-link wrapper is gated on `comment.author.image`.
- **Follow-up issue #90** — RealWorld canonical palette (`#5cb85c` brand green, `#b3b3b3` muted nav-links, white-on-green banner) fails WCAG AA contrast on every page surface. 10–11 `color-contrast` nodes per page, all from shared chrome. Fixing requires a palette tune that touches visual parity with the RealWorld reference — filed as a design-decision issue, allowlisted in this PR's `sharedRuleOverrides` with a `why:` pointer to #90.
- **`docs/quality-gates-axe.md`** — companion to the `docs/quality-gates.md` that phase-1 PR #88 introduces. Once #88 merges, the axe section folds into that file.

## Evidence

- **axe gate tests alone**: 8/8 pass (`pnpm playwright test --grep "axe a11y gate"`).
- **Full Playwright suite**: **123 passed (1.3m)** — no regressions.
- `pnpm lint` ✓, `pnpm typecheck` ✓.

## How the allowlist works

```ts
const sharedRuleOverrides: Record<string, { enabled: false; why: string }> = {
  "color-contrast": {
    enabled: false,
    why: "Tracked in #90 — RealWorld canonical palette below AA",
  },
};
```

The type shape enforces a `why:` at the code-review level — you can't add an override without attaching a justification.

## Test plan

- [x] `runAxe(page)` fails on critical/serious, passes moderate/minor
- [x] Every page-level spec has at least one axe gate test
- [x] Empty author-avatar anchors fixed (ArticleMeta + CommentItem)
- [x] `<main>` landmark added (layout.tsx)
- [x] Color-contrast violations allowlisted with #90 pointer
- [x] Full Playwright 123/123
- [ ] CI green on this PR
