### PR TITLE
fix(test): spec 56 cold-start flake — await transition before persistence check (#89)

### DIFF
--- a/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
+++ b/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
@@ -85,6 +85,23 @@ const cardFor = (page: Parameters<typeof test>[1] extends (args: {
   page.locator(`.article-preview:has(a[href="/article/${slug}"])`);
 
 test.describe("issue #56 — homepage favorite toggle", () => {
+  // Cold-start warmup (#89). A fresh `docker compose up --build` leaves
+  // Next's first-compile window open for a few seconds after the web
+  // container reports healthy — the useOptimistic + router.refresh()
+  // dance in FavoriteButton can land its optimistic flip against a
+  // not-yet-warmed bundle and get overwritten when the refresh's
+  // freshly-compiled props arrive. One goto + networkidle here closes
+  // that window before Scenario 1 runs, without changing runtime
+  // behaviour.
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(`${WEB_URL}/`, { waitUntil: "networkidle" });
+    } finally {
+      await page.close();
+    }
+  });
+
   test("Scenario 1: authed favorite on a preview card — optimistic flip + persists", async ({
     page,
     context,
@@ -117,6 +134,12 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     // should still be 1 after the client's router.refresh() cycle.
     await expect(btn).toHaveAttribute("aria-pressed", "true");
     await expect(btn).toContainText("1");
+    // Wait for the server action's transition to complete (aria-busy
+    // clears when router.refresh() has returned + props landed). The
+    // earlier aria-pressed check satisfies the optimistic path; this
+    // guarantees the DB write committed before the independent-fetch
+    // persistence check below — closes the cold-start race in #89.
+    await expect(btn).not.toHaveAttribute("aria-busy", "true");
 
     // Persistence: independent API fetch confirms the DB write landed.
     const check = await danApi.get(`/api/articles/${slug}`);
@@ -154,6 +177,9 @@ test.describe("issue #56 — homepage favorite toggle", () => {
 
     await expect(btn).toHaveAttribute("aria-pressed", "false");
     await expect(btn).toContainText("0");
+    // Wait for the transition to commit before the independent-fetch
+    // persistence check — see Scenario 1 note and #89.
+    await expect(btn).not.toHaveAttribute("aria-busy", "true");
 
     const check = await danApi.get(`/api/articles/${slug}`);
     expect(check.status()).toBe(200);


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #89.

## Diagnosis differs from the original hypothesis

The evaluator's ticket framed this as a Next first-compile window race — optimistic flip landing before the bundle was warm. On first cold-start repro (fresh `compose down -v && compose up --build`), the failure surfaced at **`expect(body.article.favorited).toBe(true)`** (Scenario 1 line 144) — not at the optimistic UI assertion. The UI correctly showed `aria-pressed=true` + count `1`; the **independent API fetch** reported `favorited=false`.

That's a different race:

1. `btn.click()` fires the React click handler.
2. `setOptimistic({ favorited: true })` — optimistic UI flips instantly.
3. Playwright's `toHaveAttribute("aria-pressed", "true")` + `toContainText("1")` assertions pass immediately (optimistic state is enough).
4. Playwright proceeds to `danApi.get(`/api/articles/${slug}`)`.
5. The server action's POST is **still in flight** — the DB write hasn't committed yet.
6. API check returns `favorited=false`, test fails.

The warm-run stress tests in #78 passed because the 2nd run of each scenario found the action already committed from a previous click; cold runs don't have that luck.

## Fix

Wait for `aria-busy="true"` to clear on the button before the persistence check. `aria-busy` is set by `useTransition`'s `isPending` flag; it clears exactly when the transition resolves — meaning both the server action's POST returned **and** `router.refresh()` completed. After that, the DB write is guaranteed committed and the independent API fetch will observe it.

```ts
await btn.click();
await expect(btn).toHaveAttribute("aria-pressed", "true");
await expect(btn).toContainText("1");
// New: wait for the transition to complete before touching the API.
await expect(btn).not.toHaveAttribute("aria-busy", "true");
const check = await danApi.get(`/api/articles/${slug}`);
```

Also added `test.beforeAll` warmup (evaluator's option 1) as a secondary guard — it goes to `/` with `waitUntil: "networkidle"` so Next's first-compile window closes before Scenario 1 runs. The aria-busy wait is the load-bearing fix; the warmup covers edge cases where the compile-while-clicking interaction might still produce a millisecond-race.

Applied to both Scenario 1 (favorite) and Scenario 2 (unfavorite) — same shape, same race.

## Evidence

- 4 consecutive **cold-start** runs (full `compose down -v` + `up --build` before each) all pass 4/4:
  ```
  === run 1 ===  4 passed (4.5s)
  === run 2 ===  4 passed (4.4s)
  === run 3 ===  4 passed (4.5s)
  === initial cold === 4 passed (4.7s)
  ```
- `pnpm lint` ✓, `pnpm typecheck` ✓.

## Test plan

- [x] Fresh compose + spec 56 first — Scenarios 1 & 2 pass deterministically
- [x] 4 consecutive cold runs, all 4/4 pass
- [x] `test.beforeAll` warmup added as secondary guard
- [x] aria-busy wait eliminates the race before persistence check
- [x] Lint + typecheck clean
- [ ] CI green on this PR
