### PR TITLE
fix(test): spec 25b compose-up retry on transient failure (#106)

### DIFF
--- a/tests/e2e/specs/25b-api-healthz-db-down.spec.ts
+++ b/tests/e2e/specs/25b-api-healthz-db-down.spec.ts
@@ -117,7 +117,25 @@ test.describe.serial("issue #49 — /healthz 503 side-stack spec", () => {
       ].join("\n") + "\n",
     );
 
-    compose(["up", "-d", "--build"], { stdio: "inherit" });
+    // `compose up -d --build` occasionally fails with a transient
+    // non-zero exit on a cold docker image cache (#106). Retry up to
+    // 3 times with 1s backoff before letting the test fail — the
+    // command is idempotent, so retrying after a partial start is
+    // safe.
+    let lastErr: unknown = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        compose(["up", "-d", "--build"], { stdio: "inherit" });
+        lastErr = null;
+        break;
+      } catch (err) {
+        lastErr = err;
+        if (attempt < 3) {
+          await new Promise((r) => setTimeout(r, 1000));
+        }
+      }
+    }
+    if (lastErr) throw lastErr;
 
     apiContainerName = resolveContainer("api");
     pgContainerName = resolveContainer("postgres");


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #106.

## User Intent

Spec 25b's side-stack `beforeAll` occasionally fails at
`docker compose up -d --build` before the test body runs. The
command is transiently unreliable on a cold image cache and a
retry-only solution (`--retries=1` at the Playwright level) masks
the problem without fixing the root cause of lost wall-clock.

## Fix

Per evaluator's Option 1 on #106 — wrap the compose-up call in a
small retry loop (3 attempts, 1s backoff):

```ts
let lastErr: unknown = null;
for (let attempt = 1; attempt <= 3; attempt++) {
  try {
    compose(["up", "-d", "--build"], { stdio: "inherit" });
    lastErr = null;
    break;
  } catch (err) {
    lastErr = err;
    if (attempt < 3) {
      await new Promise((r) => setTimeout(r, 1000));
    }
  }
}
if (lastErr) throw lastErr;
```

`compose up -d` is idempotent, so retrying after a partial start
doesn't leave a broken-state stack — the subsequent
`resolveContainer` + `waitHealthy` confirm the stack is actually
up before any test probes it.

## Why not Option 2

Option 2 (split `compose up` from `waitHealthy`) would make the
control flow read more cleanly but costs ~15 lines of
restructuring vs. 19 lines added inline. The retry is a small
local fix to a known-flaky class; keeping it scoped to the one
call site is the minimal blast radius.

## Verification

```
$ pnpm lint && pnpm typecheck           → ✓
$ npx playwright test specs/25b-api-healthz-db-down.spec.ts
  1 passed (30.4s)
```

Happy path unchanged: the retry only fires on exception, so warm
runs pay zero extra time.

## Related

- #49 — original side-stack spec design.
- #76 / #92 — same cold-start class, one layer up.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] Spec 25b in isolation: 1/1 in 30.4s
- [x] Retry scope: only covers the compose invocation, not the
      `waitHealthy` poll (which already has its own 60×500ms retry)
- [ ] CI green on this PR
