### PR TITLE
feat(test): articles API client POP (#96 Phase 2 of #35)

### DIFF
--- a/tests/e2e/page-objects/articles.ts
+++ b/tests/e2e/page-objects/articles.ts
@@ -1,0 +1,201 @@
+import { expect, request, type APIRequestContext } from "@playwright/test";
+
+// API-client page object for `/api/articles` + friends.
+//
+// #96 (Phase 2 of #35). The four articles-family specs (8, 9, 10, 11)
+// are API-only (Playwright `request.newContext()` → Hono API). The
+// traditional browser-DOM POP pattern doesn't map, but the same
+// motivation applies: semantic methods for reusable API journeys
+// instead of every spec re-implementing `registerUser` +
+// `createArticle` helpers locally. Previous PRs (#103 auth) kept
+// API-only specs untouched; this PR consolidates the duplicated
+// helpers into one module so future API specs don't keep growing
+// the copy-paste surface.
+//
+// Adapted from mutoe/vue3-realworld-example-app @ dd34ba90 (MIT) —
+// the Vue ref uses axios clients with similar semantic names
+// (`createArticle`, `getArticles`, `favorite`). Our naming matches.
+
+const DEFAULT_API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+export type Article = {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+  createdAt: string;
+  updatedAt: string;
+  favorited: boolean;
+  favoritesCount: number;
+  author: {
+    username: string;
+    bio: string | null;
+    image: string | null;
+    following: boolean;
+  };
+};
+
+export type ArticlesEnvelope = {
+  articles: Article[];
+  articlesCount: number;
+};
+
+export type ArticleInput = {
+  title: string;
+  description?: string;
+  body?: string;
+  tagList?: string[];
+};
+
+export type ArticleUpdate = Partial<{
+  title: string;
+  description: string;
+  body: string;
+}>;
+
+export type ListFilters = Partial<{
+  author: string;
+  tag: string;
+  favorited: string;
+  limit: number;
+  offset: number;
+}>;
+
+export class ArticlesApi {
+  constructor(
+    public readonly api: APIRequestContext,
+    private readonly baseURL: string = DEFAULT_API_URL,
+  ) {}
+
+  static async newContext(baseURL = DEFAULT_API_URL): Promise<ArticlesApi> {
+    const ctx = await request.newContext({ baseURL });
+    return new ArticlesApi(ctx, baseURL);
+  }
+
+  // ─── User helpers (auth prerequisite for article ops) ────────
+
+  async registerUser(username: string): Promise<void> {
+    const res = await this.api.post("/api/users", {
+      data: {
+        user: {
+          username,
+          email: `${username}@jake.jake`,
+          password: "jakejake",
+        },
+      },
+    });
+    expect(res.status()).toBe(201);
+  }
+
+  // ─── Articles CRUD ───────────────────────────────────────────
+
+  async createArticle(input: ArticleInput): Promise<Article> {
+    const res = await this.api.post("/api/articles", {
+      data: {
+        article: {
+          title: input.title,
+          description: input.description ?? "d",
+          body: input.body ?? "b",
+          tagList: input.tagList ?? [],
+        },
+      },
+    });
+    expect(res.status()).toBe(201);
+    const body = (await res.json()) as { article: Article };
+    return body.article;
+  }
+
+  // Convenience: every spec under #96 historically only cares about
+  // the slug after creation. Wraps `createArticle` for that shape.
+  async createArticleReturnSlug(input: ArticleInput): Promise<string> {
+    const article = await this.createArticle(input);
+    return article.slug;
+  }
+
+  async readBySlug(slug: string): Promise<Article> {
+    const res = await this.api.get(`/api/articles/${slug}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: Article };
+    return body.article;
+  }
+
+  async updateArticle(slug: string, update: ArticleUpdate): Promise<Article> {
+    const res = await this.api.put(`/api/articles/${slug}`, {
+      data: { article: update },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: Article };
+    return body.article;
+  }
+
+  async deleteArticle(slug: string): Promise<void> {
+    const res = await this.api.delete(`/api/articles/${slug}`);
+    expect(res.status()).toBe(204);
+  }
+
+  // ─── List + feed ─────────────────────────────────────────────
+
+  async listArticles(filters: ListFilters = {}): Promise<ArticlesEnvelope> {
+    const params = new URLSearchParams();
+    if (filters.author) params.set("author", filters.author);
+    if (filters.tag) params.set("tag", filters.tag);
+    if (filters.favorited) params.set("favorited", filters.favorited);
+    if (filters.limit !== undefined) params.set("limit", String(filters.limit));
+    if (filters.offset !== undefined) {
+      params.set("offset", String(filters.offset));
+    }
+    const qs = params.toString();
+    const path = qs ? `/api/articles?${qs}` : "/api/articles";
+    const res = await this.api.get(path);
+    expect(res.status()).toBe(200);
+    return (await res.json()) as ArticlesEnvelope;
+  }
+
+  async feedArticles(
+    filters: Pick<ListFilters, "limit" | "offset"> = {},
+  ): Promise<ArticlesEnvelope> {
+    const res = await this.feedRaw(filters);
+    expect(res.status()).toBe(200);
+    return (await res.json()) as ArticlesEnvelope;
+  }
+
+  // Raw feed call — some scenarios need the Response object to
+  // assert 401 without auth, not just the envelope.
+  async feedRaw(
+    filters: Pick<ListFilters, "limit" | "offset"> = {},
+  ): Promise<Awaited<ReturnType<APIRequestContext["get"]>>> {
+    const params = new URLSearchParams();
+    if (filters.limit !== undefined) params.set("limit", String(filters.limit));
+    if (filters.offset !== undefined) {
+      params.set("offset", String(filters.offset));
+    }
+    const qs = params.toString();
+    const path = qs ? `/api/articles/feed?${qs}` : "/api/articles/feed";
+    return this.api.get(path);
+  }
+
+  // ─── Favorite / follow relationship shortcuts ────────────────
+
+  async favorite(slug: string): Promise<Article> {
+    const res = await this.api.post(`/api/articles/${slug}/favorite`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: Article };
+    return body.article;
+  }
+
+  async unfavorite(slug: string): Promise<Article> {
+    const res = await this.api.delete(`/api/articles/${slug}/favorite`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: Article };
+    return body.article;
+  }
+
+  async follow(username: string): Promise<void> {
+    const res = await this.api.post(`/api/profiles/${username}/follow`);
+    expect(res.status()).toBe(200);
+  }
+}

--- a/tests/e2e/specs/10-api-articles-list.spec.ts
+++ b/tests/e2e/specs/10-api-articles-list.spec.ts
@@ -1,8 +1,12 @@
 import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
 
 // BDD coverage for issue #10: GET /api/articles with filters + pagination.
 // Seven AC scenarios. Each test seeds distinctly-named users / tags /
 // titles so it can run alongside other specs without cross-contamination.
+//
+// #96 Phase 2 refactor: API helpers live in `ArticlesApi` now (each
+// spec previously had its own local `registerUser` / `createArticle`).
 
 const API_URL =
   process.env.API_URL ??
@@ -11,48 +15,20 @@ const API_URL =
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
-const createArticle = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  title: string,
-  tagList: string[] = [],
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b", tagList } },
-  });
-  expect(res.status()).toBe(201);
-  const body = (await res.json()) as { article: { slug: string } };
-  return body.article.slug;
-};
-
 test.describe("issue #10 — API GET /api/articles", () => {
   test("Scenario 1: default list returns newest first + articlesCount", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
-    const s1 = await createArticle(api, `A1 ${id}`);
+    const s1 = await api.createArticleReturnSlug({ title: `A1 ${id}` });
     await new Promise((r) => setTimeout(r, 20));
-    const s2 = await createArticle(api, `A2 ${id}`);
+    const s2 = await api.createArticleReturnSlug({ title: `A2 ${id}` });
     await new Promise((r) => setTimeout(r, 20));
-    const s3 = await createArticle(api, `A3 ${id}`);
+    const s3 = await api.createArticleReturnSlug({ title: `A3 ${id}` });
 
-    const res = await api.get(`/api/articles?author=${jake}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ slug: string; createdAt: string }>;
-      articlesCount: number;
-    };
+    const body = await api.listArticles({ author: jake });
     expect(body.articlesCount).toBe(3);
     expect(body.articles.map((a) => a.slug)).toEqual([s3, s2, s1]);
     expect(Date.parse(body.articles[0].createdAt)).toBeGreaterThan(
@@ -66,22 +42,26 @@ test.describe("issue #10 — API GET /api/articles", () => {
   test("Scenario 2: filter by tag returns only articles carrying that tag", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
     const dragons = `dragons-${id}`;
     const training = `training-${id}`;
 
-    const slugA = await createArticle(api, `A ${id}`, [dragons]);
-    await createArticle(api, `B ${id}`, [training]);
-    const slugC = await createArticle(api, `C ${id}`, [dragons, training]);
+    const slugA = await api.createArticleReturnSlug({
+      title: `A ${id}`,
+      tagList: [dragons],
+    });
+    await api.createArticleReturnSlug({
+      title: `B ${id}`,
+      tagList: [training],
+    });
+    const slugC = await api.createArticleReturnSlug({
+      title: `C ${id}`,
+      tagList: [dragons, training],
+    });
 
-    const res = await api.get(`/api/articles?tag=${dragons}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ slug: string }>;
-      articlesCount: number;
-    };
+    const body = await api.listArticles({ tag: dragons });
     expect(body.articlesCount).toBe(2);
     expect(body.articles.map((a) => a.slug).sort()).toEqual([slugA, slugC].sort());
   });
@@ -90,21 +70,16 @@ test.describe("issue #10 — API GET /api/articles", () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
 
-    await createArticle(jakeApi, `J1 ${id}`);
-    await createArticle(jakeApi, `J2 ${id}`);
-    await createArticle(danApi, `D1 ${id}`);
+    await jakeApi.createArticleReturnSlug({ title: `J1 ${id}` });
+    await jakeApi.createArticleReturnSlug({ title: `J2 ${id}` });
+    await danApi.createArticleReturnSlug({ title: `D1 ${id}` });
 
-    const res = await jakeApi.get(`/api/articles?author=${jake}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ author: { username: string } }>;
-      articlesCount: number;
-    };
+    const body = await jakeApi.listArticles({ author: jake });
     expect(body.articlesCount).toBe(2);
     for (const a of body.articles) {
       expect(a.author.username).toBe(jake);
@@ -115,23 +90,17 @@ test.describe("issue #10 — API GET /api/articles", () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
 
-    const slugA = await createArticle(jakeApi, `Fav-A ${id}`);
-    await createArticle(jakeApi, `Fav-B ${id}`);
+    const slugA = await jakeApi.createArticleReturnSlug({ title: `Fav-A ${id}` });
+    await jakeApi.createArticleReturnSlug({ title: `Fav-B ${id}` });
 
-    const fav = await danApi.post(`/api/articles/${slugA}/favorite`);
-    expect(fav.status()).toBe(200);
+    await danApi.favorite(slugA);
 
-    const res = await jakeApi.get(`/api/articles?favorited=${dan}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ slug: string }>;
-      articlesCount: number;
-    };
+    const body = await jakeApi.listArticles({ favorited: dan });
     expect(body.articlesCount).toBe(1);
     expect(body.articles[0].slug).toBe(slugA);
   });
@@ -139,21 +108,18 @@ test.describe("issue #10 — API GET /api/articles", () => {
   test("Scenario 5: pagination respects limit + offset", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
     // Seed 25 articles. Author filter isolates this spec from others
     // running in parallel against the same stack.
     for (let i = 0; i < 25; i += 1) {
-      await createArticle(api, `P${i.toString().padStart(2, "0")} ${id}`);
+      await api.createArticleReturnSlug({
+        title: `P${i.toString().padStart(2, "0")} ${id}`,
+      });
     }
 
-    const res = await api.get(`/api/articles?author=${jake}&limit=10&offset=10`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ title: string }>;
-      articlesCount: number;
-    };
+    const body = await api.listArticles({ author: jake, limit: 10, offset: 10 });
     expect(body.articles.length).toBe(10);
     expect(body.articlesCount).toBe(25);
     // Offset 10 in a newest-first 25-article list = items 14 through 5
@@ -167,25 +133,16 @@ test.describe("issue #10 — API GET /api/articles", () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
 
-    const slugA = await createArticle(jakeApi, `S6 ${id}`);
-    await danApi.post(`/api/articles/${slugA}/favorite`);
-    await danApi.post(`/api/profiles/${jake}/follow`);
+    const slugA = await jakeApi.createArticleReturnSlug({ title: `S6 ${id}` });
+    await danApi.favorite(slugA);
+    await danApi.follow(jake);
 
-    const res = await danApi.get(`/api/articles?author=${jake}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{
-        slug: string;
-        favorited: boolean;
-        favoritesCount: number;
-        author: { following: boolean };
-      }>;
-    };
+    const body = await danApi.listArticles({ author: jake });
     const a = body.articles.find((x) => x.slug === slugA);
     expect(a, "article A should be in the response").toBeDefined();
     expect(a!.favorited).toBe(true);
@@ -194,6 +151,8 @@ test.describe("issue #10 — API GET /api/articles", () => {
   });
 
   test("Scenario 7: invalid limit is rejected with 422", async () => {
+    // Raw request — we want the 422 response body, not the POP's
+    // wrapped assertion.
     const anon = await request.newContext({ baseURL: API_URL });
     const res = await anon.get(`/api/articles?limit=999`);
     expect(res.status()).toBe(422);

--- a/tests/e2e/specs/11-api-articles-feed.spec.ts
+++ b/tests/e2e/specs/11-api-articles-feed.spec.ts
@@ -1,37 +1,13 @@
-import { expect, request, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
 
 // BDD coverage for issue #11: GET /api/articles/feed.
 // Four AC scenarios — tests seed per-id authors / articles so parallel
 // suites don't tread on each other.
-
-const API_URL =
-  process.env.API_URL ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:3101";
+//
+// #96 Phase 2 refactor: API helpers via `ArticlesApi`.
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
-const createArticle = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  title: string,
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b" } },
-  });
-  expect(res.status()).toBe(201);
-  const body = (await res.json()) as { article: { slug: string } };
-  return body.article.slug;
-};
 
 test.describe("issue #11 — API GET /api/articles/feed", () => {
   test("Scenario 1: feed contains only articles from followed users", async () => {
@@ -39,30 +15,21 @@ test.describe("issue #11 — API GET /api/articles/feed", () => {
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
     const alice = `alice-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    const aliceApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    await registerUser(aliceApi, alice);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    const aliceApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    await aliceApi.registerUser(alice);
 
-    const j1 = await createArticle(jakeApi, `J1 ${id}`);
-    const j2 = await createArticle(jakeApi, `J2 ${id}`);
-    await createArticle(aliceApi, `A1 ${id}`);
-    await createArticle(aliceApi, `A2 ${id}`);
+    const j1 = await jakeApi.createArticleReturnSlug({ title: `J1 ${id}` });
+    const j2 = await jakeApi.createArticleReturnSlug({ title: `J2 ${id}` });
+    await aliceApi.createArticleReturnSlug({ title: `A1 ${id}` });
+    await aliceApi.createArticleReturnSlug({ title: `A2 ${id}` });
 
-    const follow = await danApi.post(`/api/profiles/${jake}/follow`);
-    expect(follow.status()).toBe(200);
+    await danApi.follow(jake);
 
-    const res = await danApi.get("/api/articles/feed");
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{
-        slug: string;
-        author: { username: string; following: boolean };
-      }>;
-      articlesCount: number;
-    };
+    const body = await danApi.feedArticles();
     // Filter to this spec's seeded slugs (parallel suites may add others).
     const mine = body.articles.filter((a) => a.slug === j1 || a.slug === j2);
     expect(mine.length).toBe(2);
@@ -81,19 +48,14 @@ test.describe("issue #11 — API GET /api/articles/feed", () => {
     const id = uniq();
     const dan = `dan-${id}`;
     const jake = `jake-${id}`;
-    const danApi = await request.newContext({ baseURL: API_URL });
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(danApi, dan);
-    await registerUser(jakeApi, jake);
+    const danApi = await ArticlesApi.newContext();
+    const jakeApi = await ArticlesApi.newContext();
+    await danApi.registerUser(dan);
+    await jakeApi.registerUser(jake);
     // Some article exists authored by someone dan does NOT follow.
-    await createArticle(jakeApi, `Other ${id}`);
+    await jakeApi.createArticleReturnSlug({ title: `Other ${id}` });
 
-    const res = await danApi.get("/api/articles/feed");
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: unknown[];
-      articlesCount: number;
-    };
+    const body = await danApi.feedArticles();
     expect(body.articles).toEqual([]);
     expect(body.articlesCount).toBe(0);
   });
@@ -102,25 +64,22 @@ test.describe("issue #11 — API GET /api/articles/feed", () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
 
     // Seed 30 articles from jake (the only user dan follows). Slight
     // delay between creates so createdAt ordering is deterministic at
     // ms granularity.
     for (let i = 0; i < 30; i += 1) {
-      await createArticle(jakeApi, `P${i.toString().padStart(2, "0")} ${id}`);
+      await jakeApi.createArticleReturnSlug({
+        title: `P${i.toString().padStart(2, "0")} ${id}`,
+      });
     }
-    await danApi.post(`/api/profiles/${jake}/follow`);
+    await danApi.follow(jake);
 
-    const res = await danApi.get("/api/articles/feed?limit=10&offset=10");
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      articles: Array<{ title: string }>;
-      articlesCount: number;
-    };
+    const body = await danApi.feedArticles({ limit: 10, offset: 10 });
     expect(body.articles.length).toBe(10);
     expect(body.articlesCount).toBeGreaterThanOrEqual(30);
     // Newest-first: P29 at offset 0, so offset 10 lands at P19.
@@ -129,8 +88,8 @@ test.describe("issue #11 — API GET /api/articles/feed", () => {
   });
 
   test("Scenario 4: feed requires auth — 401 anonymous", async () => {
-    const anon = await request.newContext({ baseURL: API_URL });
-    const res = await anon.get("/api/articles/feed");
+    const anon = await ArticlesApi.newContext();
+    const res = await anon.feedRaw();
     expect(res.status()).toBe(401);
   });
 });

--- a/tests/e2e/specs/8-api-articles-create-read.spec.ts
+++ b/tests/e2e/specs/8-api-articles-create-read.spec.ts
@@ -1,4 +1,5 @@
 import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
 
 // BDD coverage for issue #8: POST /api/articles + GET /api/articles/:slug.
 // Six scenarios from the issue body. Article envelope shape is
@@ -7,6 +8,10 @@ import { expect, request, test } from "@playwright/test";
 // (placeholder 0 until #12), author (Profile sub-object with viewer-
 // relative following). This spec doesn't touch favorite-related
 // behaviour — those AC belong to #12.
+//
+// #96 Phase 2 refactor: API helpers via `ArticlesApi`. Scenarios 5 + 6
+// need raw responses (404 / 401 / 422), so they use request.newContext
+// directly — the POP's wrappers assert 200/201/204 status.
 
 const API_URL =
   process.env.API_URL ??
@@ -15,47 +20,19 @@ const API_URL =
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
 test.describe("issue #8 — API articles (create + read by slug)", () => {
   test("Scenario 1: create article with tags computes unique slug + persists tag rows", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
-    const res = await api.post("/api/articles", {
-      data: {
-        article: {
-          title: "How to train your dragon",
-          description: "Ever wonder how?",
-          body: "You have to believe",
-          tagList: ["dragons", "training"],
-        },
-      },
+    const article = await api.createArticle({
+      title: "How to train your dragon",
+      description: "Ever wonder how?",
+      body: "You have to believe",
+      tagList: ["dragons", "training"],
     });
-    expect(res.status()).toBe(201);
-    const body = (await res.json()) as { article: Record<string, unknown> };
-    const article = body.article as {
-      slug: string;
-      title: string;
-      description: string;
-      body: string;
-      tagList: string[];
-      createdAt: string;
-      updatedAt: string;
-      favorited: boolean;
-      favoritesCount: number;
-      author: { username: string; bio: unknown; image: unknown; following: boolean };
-    };
     expect(article.slug).toMatch(/^how-to-train-your-dragon-[a-z0-9]{4}$/);
     expect(article.title).toBe("How to train your dragon");
     expect(article.description).toBe("Ever wonder how?");
@@ -74,76 +51,58 @@ test.describe("issue #8 — API articles (create + read by slug)", () => {
   test("Scenario 2: two articles with the same title get distinct slugs", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
-    const payload = {
-      article: { title: `Same title ${id}`, description: "d", body: "b" },
-    };
-    const first = await api.post("/api/articles", { data: payload });
-    const second = await api.post("/api/articles", { data: payload });
-    expect(first.status()).toBe(201);
-    expect(second.status()).toBe(201);
-    const a = (await first.json()) as { article: { slug: string } };
-    const b = (await second.json()) as { article: { slug: string } };
-    expect(a.article.slug).not.toBe(b.article.slug);
+    const input = { title: `Same title ${id}` };
+    const a = await api.createArticle(input);
+    const b = await api.createArticle(input);
+    expect(a.slug).not.toBe(b.slug);
     // Both slugs share the same base (slugify(title)) but differ in the
     // 4-char suffix.
-    const base = a.article.slug.replace(/-[a-z0-9]{4}$/, "");
-    expect(b.article.slug.startsWith(base + "-")).toBe(true);
+    const base = a.slug.replace(/-[a-z0-9]{4}$/, "");
+    expect(b.slug.startsWith(base + "-")).toBe(true);
   });
 
   test("Scenario 3: anonymous read by slug returns envelope with following=false", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const created = await jakeApi.post("/api/articles", {
-      data: { article: { title: `Anon read ${id}`, description: "d", body: "b" } },
-    });
-    const slug = ((await created.json()) as { article: { slug: string } }).article.slug;
+    const jakeApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticleReturnSlug({ title: `Anon read ${id}` });
 
-    const anonApi = await request.newContext({ baseURL: API_URL });
-    const res = await anonApi.get(`/api/articles/${slug}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      article: { slug: string; favorited: boolean; author: { following: boolean } };
-    };
-    expect(body.article.slug).toBe(slug);
-    expect(body.article.favorited).toBe(false);
-    expect(body.article.author.following).toBe(false);
+    const anonApi = await ArticlesApi.newContext();
+    const article = await anonApi.readBySlug(slug);
+    expect(article.slug).toBe(slug);
+    expect(article.favorited).toBe(false);
+    expect(article.author.following).toBe(false);
   });
 
   test("Scenario 4: authenticated viewer who follows the author sees following=true", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
 
-    const created = await jakeApi.post("/api/articles", {
-      data: { article: { title: `Follow-check ${id}`, description: "d", body: "b" } },
-    });
-    const slug = ((await created.json()) as { article: { slug: string } }).article.slug;
+    const slug = await jakeApi.createArticleReturnSlug({ title: `Follow-check ${id}` });
+    await danApi.follow(jake);
 
-    const follow = await danApi.post(`/api/profiles/${jake}/follow`);
-    expect(follow.status()).toBe(200);
-
-    const res = await danApi.get(`/api/articles/${slug}`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as { article: { author: { following: boolean } } };
-    expect(body.article.author.following).toBe(true);
+    const article = await danApi.readBySlug(slug);
+    expect(article.author.following).toBe(true);
   });
 
   test("Scenario 5: read non-existent slug returns 404", async () => {
+    // Raw request — POP's readBySlug expects 200.
     const anonApi = await request.newContext({ baseURL: API_URL });
     const res = await anonApi.get("/api/articles/no-such-slug-exists");
     expect(res.status()).toBe(404);
   });
 
   test("Scenario 6: create requires auth and validates body", async () => {
+    // Raw request — POP's createArticle asserts 201.
     const anonApi = await request.newContext({ baseURL: API_URL });
     const anon = await anonApi.post("/api/articles", {
       data: { article: { title: "t", description: "d", body: "b" } },
@@ -152,9 +111,9 @@ test.describe("issue #8 — API articles (create + read by slug)", () => {
 
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const blank = await jakeApi.post("/api/articles", {
+    const jakeApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    const blank = await jakeApi.api.post("/api/articles", {
       data: { article: { title: "", description: "d", body: "b" } },
     });
     expect(blank.status()).toBe(422);

--- a/tests/e2e/specs/9-api-articles-update-delete.spec.ts
+++ b/tests/e2e/specs/9-api-articles-update-delete.spec.ts
@@ -1,112 +1,79 @@
-import { expect, request, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
 
 // BDD coverage for issue #9: PUT + DELETE /api/articles/:slug.
 // Six scenarios from the issue body. The spec seeds each scenario with
 // its own registered user(s) + authored article so tests are
 // independent and can run in any order.
-
-const API_URL =
-  process.env.API_URL ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:3101";
+//
+// #96 Phase 2 refactor: API helpers via `ArticlesApi`. Scenarios that
+// assert error statuses (403/401/404) use `api.api.*` raw calls —
+// the POP's wrappers assert 200/201/204 on the happy path.
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
-const createArticle = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  title: string,
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b" } },
-  });
-  expect(res.status()).toBe(201);
-  const body = (await res.json()) as { article: { slug: string } };
-  return body.article.slug;
-};
 
 test.describe("issue #9 — API articles update + delete (author-scoped)", () => {
   test("Scenario 1: author updates title → new slug + updatedAt advances; old slug 404s", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
-    const originalSlug = await createArticle(api, "How to train your dragon");
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const originalSlug = await api.createArticleReturnSlug({
+      title: "How to train your dragon",
+    });
 
     // Snapshot createdAt so the AC's `updatedAt > createdAt` assertion
     // has a concrete lower bound.
-    const before = await api.get(`/api/articles/${originalSlug}`);
-    const beforeBody = (await before.json()) as {
-      article: { createdAt: string; updatedAt: string };
-    };
-    const createdAt = Date.parse(beforeBody.article.createdAt);
+    const before = await api.readBySlug(originalSlug);
+    const createdAt = Date.parse(before.createdAt);
 
     // Ensure the Prisma update lands on a later ms than the row's
     // createdAt, even when the test process is faster than the DB clock
     // granularity.
     await new Promise((resolve) => setTimeout(resolve, 25));
 
-    const put = await api.put(`/api/articles/${originalSlug}`, {
-      data: { article: { title: "Did you train your dragon?" } },
+    const updated = await api.updateArticle(originalSlug, {
+      title: "Did you train your dragon?",
     });
-    expect(put.status()).toBe(200);
-    const putBody = (await put.json()) as {
-      article: { slug: string; title: string; updatedAt: string };
-    };
-    expect(putBody.article.slug).toMatch(/^did-you-train-your-dragon-[a-z0-9]{4}$/);
-    expect(putBody.article.title).toBe("Did you train your dragon?");
-    expect(Date.parse(putBody.article.updatedAt)).toBeGreaterThan(createdAt);
+    expect(updated.slug).toMatch(/^did-you-train-your-dragon-[a-z0-9]{4}$/);
+    expect(updated.title).toBe("Did you train your dragon?");
+    expect(Date.parse(updated.updatedAt)).toBeGreaterThan(createdAt);
 
-    const newSlug = putBody.article.slug;
-    const getNew = await api.get(`/api/articles/${newSlug}`);
-    expect(getNew.status()).toBe(200);
+    const newSlug = updated.slug;
+    await api.readBySlug(newSlug); // asserts 200 via POP
 
-    const getOld = await api.get(`/api/articles/${originalSlug}`);
+    const getOld = await api.api.get(`/api/articles/${originalSlug}`);
     expect(getOld.status()).toBe(404);
   });
 
   test("Scenario 2: author updates body-only → slug unchanged, body reflects new value", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
-    const slug = await createArticle(api, `Body-only ${id}`);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `Body-only ${id}` });
 
-    const put = await api.put(`/api/articles/${slug}`, {
-      data: { article: { body: "rewritten body content" } },
-    });
-    expect(put.status()).toBe(200);
-    const body = (await put.json()) as {
-      article: { slug: string; body: string };
-    };
-    expect(body.article.slug).toBe(slug);
-    expect(body.article.body).toBe("rewritten body content");
+    const updated = await api.updateArticle(slug, { body: "rewritten body content" });
+    expect(updated.slug).toBe(slug);
+    expect(updated.body).toBe("rewritten body content");
 
-    const get = await api.get(`/api/articles/${slug}`);
-    const getBody = (await get.json()) as { article: { body: string } };
-    expect(getBody.article.body).toBe("rewritten body content");
+    const fetched = await api.readBySlug(slug);
+    expect(fetched.body).toBe("rewritten body content");
   });
 
   test("Scenario 3: non-author PUT → 403", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Jake's article ${id}`);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticleReturnSlug({
+      title: `Jake's article ${id}`,
+    });
 
-    const put = await danApi.put(`/api/articles/${slug}`, {
+    const put = await danApi.api.put(`/api/articles/${slug}`, {
       data: { article: { title: "dan hijacks the post" } },
     });
     expect(put.status()).toBe(403);
@@ -115,31 +82,25 @@ test.describe("issue #9 — API articles update + delete (author-scoped)", () =>
   test("Scenario 4: author DELETE → 204; subsequent GET → 404; cascades remove comments + tags + favorites", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const api = await request.newContext({ baseURL: API_URL });
-    await registerUser(api, jake);
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
 
     // Create an article with two tags so the M:N join rows exist.
-    const createRes = await api.post("/api/articles", {
-      data: {
-        article: {
-          title: `With tags ${id}`,
-          description: "d",
-          body: "b",
-          tagList: [`t1-${id}`, `t2-${id}`],
-        },
-      },
+    const slug = await api.createArticleReturnSlug({
+      title: `With tags ${id}`,
+      tagList: [`t1-${id}`, `t2-${id}`],
     });
-    expect(createRes.status()).toBe(201);
-    const slug = ((await createRes.json()) as { article: { slug: string } }).article.slug;
 
-    const del = await api.delete(`/api/articles/${slug}`);
+    // Raw delete to inspect status + body (POP asserts 204 but
+    // doesn't expose the body).
+    const del = await api.api.delete(`/api/articles/${slug}`);
     expect(del.status()).toBe(204);
     // 204 responses MUST have empty body per RFC 7230 §3.3.3. Playwright
     // returns an empty Buffer here.
     const delBody = await del.body();
     expect(delBody.byteLength).toBe(0);
 
-    const get = await api.get(`/api/articles/${slug}`);
+    const get = await api.api.get(`/api/articles/${slug}`);
     expect(get.status()).toBe(404);
   });
 
@@ -147,33 +108,36 @@ test.describe("issue #9 — API articles update + delete (author-scoped)", () =>
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Jake's other article ${id}`);
+    const jakeApi = await ArticlesApi.newContext();
+    const danApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticleReturnSlug({
+      title: `Jake's other article ${id}`,
+    });
 
-    const del = await danApi.delete(`/api/articles/${slug}`);
+    const del = await danApi.api.delete(`/api/articles/${slug}`);
     expect(del.status()).toBe(403);
 
     // Sanity: the article still exists — non-author DELETE must not
     // destroy the row.
-    const get = await jakeApi.get(`/api/articles/${slug}`);
-    expect(get.status()).toBe(200);
+    await jakeApi.readBySlug(slug); // asserts 200 via POP
   });
 
   test("Scenario 6: anonymous DELETE → 401; anonymous PUT → 401", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const anonApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Anonymous check ${id}`);
+    const jakeApi = await ArticlesApi.newContext();
+    const anonApi = await ArticlesApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticleReturnSlug({
+      title: `Anonymous check ${id}`,
+    });
 
-    const del = await anonApi.delete(`/api/articles/${slug}`);
+    const del = await anonApi.api.delete(`/api/articles/${slug}`);
     expect(del.status()).toBe(401);
 
-    const put = await anonApi.put(`/api/articles/${slug}`, {
+    const put = await anonApi.api.put(`/api/articles/${slug}`, {
       data: { article: { title: "anon hijack" } },
     });
     expect(put.status()).toBe(401);


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #96.

## User Intent

Fourth of the 8 per-feature Phase-2 PRs from #35 (sibling to #95/PR
#103 auth, #102/PR #104 settings, #101/PR #105 profile). The
articles family is different from the other POP PRs: the 4 in-scope
specs (8, 9, 10, 11) are **API-only** — they hit
`/api/articles*` via Playwright's `request.newContext()` with no
browser involvement.

## Interpretation note

#96 AC scenario 1 says "zero direct `page.locator(selector)` calls
against articles DOM". There is no DOM in these specs — every line
is an API call. The *spirit* of the #95/#101/#102 POP pattern
(semantic methods, not copy-pasted helpers) maps to a different
concrete shape here: an **API-client POP**.

Previously, each of the 4 specs independently re-implemented:

```ts
const registerUser = async (api, username) => {
  const res = await api.post("/api/users", {
    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
  });
  expect(res.status()).toBe(201);
};

const createArticle = async (api, title, tagList = []) => {
  const res = await api.post("/api/articles", {
    data: { article: { title, description: "d", body: "b", tagList } },
  });
  expect(res.status()).toBe(201);
  return ((await res.json()) as { article: { slug: string } }).article.slug;
};
```

That same block, copy-pasted 4× across specs, is now one
`ArticlesApi` class.

## What ships

### `tests/e2e/page-objects/articles.ts` — new

Class `ArticlesApi(apiContext, baseURL?)` with:

- **Construction**: `ArticlesApi.newContext(baseURL?)` static —
  creates + wraps a fresh `APIRequestContext`.
- **User helpers**: `registerUser(username)`.
- **Articles CRUD**: `createArticle({ title, description?, body?, tagList? })`
  returning the full `Article`, `createArticleReturnSlug(...)` for
  the common spec pattern, `readBySlug(slug)`, `updateArticle(slug, patch)`,
  `deleteArticle(slug)`.
- **List / feed**: `listArticles({ author?, tag?, favorited?, limit?, offset? })`,
  `feedArticles({ limit?, offset? })`, `feedRaw(...)` (returns
  the raw Response for error-path 401 assertions).
- **Relationship shortcuts**: `favorite(slug)`, `unfavorite(slug)`,
  `follow(username)`.
- **Raw escape hatch**: the `api` field is `public readonly` so
  error-path scenarios (403/404/422) can call `api.api.put(...)` /
  `api.api.delete(...)` directly without fighting the POP's
  happy-path assertions.

Types exported for callers: `Article`, `ArticlesEnvelope`,
`ArticleInput`, `ArticleUpdate`, `ListFilters`.

### Specs refactored

All 4 in-scope specs use `ArticlesApi`:

- `specs/8-api-articles-create-read.spec.ts` — 6 scenarios
- `specs/9-api-articles-update-delete.spec.ts` — 6 scenarios
- `specs/10-api-articles-list.spec.ts` — 7 scenarios
- `specs/11-api-articles-feed.spec.ts` — 4 scenarios

Scenarios 5+6 in spec 8, Scenario 7 in spec 10, Scenarios 3-6 in
spec 9 use `api.api.*` raw requests for error-status assertions —
the POP's wrappers assert 200/201/204 for the happy path.

Net: 408 added (mostly the POP), 366 removed (spec duplication).

## Fixture migration

Per #96 AC scenario 3 "where authed specs used inline primeSession":
these specs never used primeSession. They're API-only, authenticated
via cookies in the API request context (from `POST /api/users`
Set-Cookie) — the `authedContext` browser fixture doesn't apply.

Same precedent as PR #103 (auth, specs 4 + 6) and PR #105 (profile,
spec 7): API-only specs skip fixture migration.

## Verification

```
$ pnpm lint && pnpm typecheck       → ✓
$ bash scripts/db-reset.sh

# 4 in-scope specs isolated:
$ npx playwright test specs/{8,9,10,11}-api-articles-*.spec.ts
  23 passed (6.0s)

# Full suite:
$ pnpm test:e2e
  125 passed (1.4m)
```

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] 23/23 across the 4 refactored specs (6+6+7+4)
- [x] Full suite 125/125 (desktop + mobile)
- [x] POP methods describe intent (createArticleReturnSlug, favorite,
      feedArticles) not HTTP paths
- [x] Raw `.api` escape hatch preserved for error-path scenarios
- [ ] CI green on this PR
