### PR TITLE
feat(test): comments API client POP (#97 Phase 2 of #35)

### DIFF
--- a/tests/e2e/page-objects/comments.ts
+++ b/tests/e2e/page-objects/comments.ts
@@ -1,0 +1,121 @@
+import { expect, request, type APIRequestContext } from "@playwright/test";
+
+// API-client POP for `/api/articles/:slug/comments*`.
+//
+// #97 (Phase 2 of #35). Same API-client shape as `ArticlesApi`
+// (#96, PR #108) since spec 13 is API-only. The POP owns the
+// repeated comment-operation helpers every comment test uses.
+//
+// Duplication note: `registerUser` + `createArticle` live here
+// alongside the comment methods because this branch is off latest
+// (pre-#108). Once #108 merges, a follow-up can collapse these to
+// share ArticlesApi's versions.
+//
+// Adapted from mutoe/vue3-realworld-example-app @ dd34ba90 (MIT) —
+// the Vue ref exposes `axios.get/post/delete` shortcuts with
+// similar names.
+
+const DEFAULT_API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+export type Comment = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: {
+    username: string;
+    bio: string | null;
+    image: string | null;
+    following: boolean;
+  };
+};
+
+export class CommentsApi {
+  constructor(
+    public readonly api: APIRequestContext,
+    private readonly baseURL: string = DEFAULT_API_URL,
+  ) {}
+
+  static async newContext(baseURL = DEFAULT_API_URL): Promise<CommentsApi> {
+    const ctx = await request.newContext({ baseURL });
+    return new CommentsApi(ctx, baseURL);
+  }
+
+  // ─── User + article seed helpers ─────────────────────────────
+
+  async registerUser(username: string): Promise<void> {
+    const res = await this.api.post("/api/users", {
+      data: {
+        user: {
+          username,
+          email: `${username}@jake.jake`,
+          password: "jakejake",
+        },
+      },
+    });
+    expect(res.status()).toBe(201);
+  }
+
+  async createArticle(title: string, tagList: string[] = []): Promise<string> {
+    const res = await this.api.post("/api/articles", {
+      data: { article: { title, description: "d", body: "b", tagList } },
+    });
+    expect(res.status()).toBe(201);
+    const body = (await res.json()) as { article: { slug: string } };
+    return body.article.slug;
+  }
+
+  // ─── Comments CRUD ───────────────────────────────────────────
+
+  async addComment(slug: string, body: string): Promise<Comment> {
+    const res = await this.api.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body } },
+    });
+    expect(res.status()).toBe(201);
+    const payload = (await res.json()) as { comment: Comment };
+    return payload.comment;
+  }
+
+  // Convenience: most spec sites only want the id of the created
+  // comment for the subsequent DELETE assertion.
+  async addCommentReturnId(slug: string, body: string): Promise<number> {
+    const c = await this.addComment(slug, body);
+    return c.id;
+  }
+
+  async listComments(slug: string): Promise<Comment[]> {
+    const res = await this.api.get(`/api/articles/${slug}/comments`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { comments: Comment[] };
+    return body.comments;
+  }
+
+  async deleteComment(slug: string, commentId: number): Promise<void> {
+    const res = await this.api.delete(
+      `/api/articles/${slug}/comments/${commentId}`,
+    );
+    expect(res.status()).toBe(204);
+    // 204 MUST have empty body per RFC 7230 §3.3.3.
+    const delBody = await res.body();
+    expect(delBody.byteLength).toBe(0);
+  }
+
+  // ─── Raw escape hatch for error paths (401/403/404/422) ──────
+
+  rawAddComment(slug: string, body: string) {
+    return this.api.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body } },
+    });
+  }
+
+  rawDeleteComment(slug: string, commentId: number) {
+    return this.api.delete(`/api/articles/${slug}/comments/${commentId}`);
+  }
+
+  rawListComments(slug: string) {
+    return this.api.get(`/api/articles/${slug}/comments`);
+  }
+}

--- a/tests/e2e/specs/13-api-comments.spec.ts
+++ b/tests/e2e/specs/13-api-comments.spec.ts
@@ -1,216 +1,144 @@
-import { expect, request, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { CommentsApi } from "../page-objects/comments";
 
 // BDD coverage for issue #13: comments CRUD on articles.
 // Seven AC scenarios. Each test seeds its own jake / dan / article so
 // suites are independent of other specs running against the same
 // compose stack.
-
-const API_URL =
-  process.env.API_URL ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:3101";
+//
+// #97 Phase 2 refactor: API helpers via `CommentsApi`. Scenarios 4-7
+// need raw responses (403/401/404/422) and use the POP's `raw*`
+// shortcuts — the happy-path wrappers assert 200/201/204.
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
-const createArticle = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  title: string,
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b" } },
-  });
-  expect(res.status()).toBe(201);
-  const body = (await res.json()) as { article: { slug: string } };
-  return body.article.slug;
-};
-
-const addComment = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  slug: string,
-  body: string,
-): Promise<number> => {
-  const res = await api.post(`/api/articles/${slug}/comments`, {
-    data: { comment: { body } },
-  });
-  expect(res.status()).toBe(201);
-  const payload = (await res.json()) as { comment: { id: number } };
-  return payload.comment.id;
-};
 
 test.describe("issue #13 — API comments CRUD", () => {
   test("Scenario 1: anonymous list — 200, shape + order", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `List ${id}`);
+    const jakeApi = await CommentsApi.newContext();
+    const danApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`List ${id}`);
 
-    await addComment(jakeApi, slug, "jake's first");
+    await jakeApi.addComment(slug, "jake's first");
     // A hair of delay so createdAt values are strictly increasing at
     // the ms granularity postgres exposes.
     await new Promise((resolve) => setTimeout(resolve, 25));
-    await addComment(danApi, slug, "dan replies");
+    await danApi.addComment(slug, "dan replies");
 
-    const anon = await request.newContext({ baseURL: API_URL });
-    const res = await anon.get(`/api/articles/${slug}/comments`);
-    expect(res.status()).toBe(200);
-    const body = (await res.json()) as {
-      comments: Array<{
-        id: number;
-        createdAt: string;
-        updatedAt: string;
-        body: string;
-        author: {
-          username: string;
-          bio: string | null;
-          image: string | null;
-          following: boolean;
-        };
-      }>;
-    };
-    expect(body.comments.length).toBe(2);
+    const anon = await CommentsApi.newContext();
+    const comments = await anon.listComments(slug);
+    expect(comments.length).toBe(2);
     // Descending by createdAt — dan's "dan replies" (newer) comes first.
-    expect(body.comments[0].author.username).toBe(dan);
-    expect(body.comments[1].author.username).toBe(jake);
-    expect(body.comments[0].body).toBe("dan replies");
-    expect(body.comments[1].body).toBe("jake's first");
-    expect(Date.parse(body.comments[0].createdAt)).toBeGreaterThanOrEqual(
-      Date.parse(body.comments[1].createdAt),
+    expect(comments[0].author.username).toBe(dan);
+    expect(comments[1].author.username).toBe(jake);
+    expect(comments[0].body).toBe("dan replies");
+    expect(comments[1].body).toBe("jake's first");
+    expect(Date.parse(comments[0].createdAt)).toBeGreaterThanOrEqual(
+      Date.parse(comments[1].createdAt),
     );
     // Envelope shape: author is a Profile with viewer-relative flag.
-    expect(body.comments[0].author.following).toBe(false);
+    expect(comments[0].author.following).toBe(false);
     // Fresh users have bio = null and image = null (our register path
     // stores the defaults as nulls, matching #4's established shape).
-    expect(body.comments[0].author.bio).toBeNull();
-    expect(body.comments[0].author.image).toBeNull();
+    expect(comments[0].author.bio).toBeNull();
+    expect(comments[0].author.image).toBeNull();
   });
 
   test("Scenario 2: add comment as authenticated user → 201 + envelope", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Add ${id}`);
+    const jakeApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticle(`Add ${id}`);
 
-    const res = await jakeApi.post(`/api/articles/${slug}/comments`, {
-      data: { comment: { body: "Thank you!" } },
-    });
-    expect(res.status()).toBe(201);
-    const body = (await res.json()) as {
-      comment: {
-        id: number;
-        body: string;
-        author: { username: string };
-      };
-    };
-    expect(body.comment.body).toBe("Thank you!");
-    expect(body.comment.author.username).toBe(jake);
-    expect(Number.isInteger(body.comment.id)).toBe(true);
+    const comment = await jakeApi.addComment(slug, "Thank you!");
+    expect(comment.body).toBe("Thank you!");
+    expect(comment.author.username).toBe(jake);
+    expect(Number.isInteger(comment.id)).toBe(true);
 
     // Round-trip: GET lists it.
-    const listRes = await jakeApi.get(`/api/articles/${slug}/comments`);
-    const list = (await listRes.json()) as { comments: Array<{ id: number }> };
-    expect(list.comments.map((c) => c.id)).toContain(body.comment.id);
+    const comments = await jakeApi.listComments(slug);
+    expect(comments.map((c) => c.id)).toContain(comment.id);
   });
 
   test("Scenario 3: delete own comment → 204, subsequent list omits it", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Del ${id}`);
-    const commentId = await addComment(jakeApi, slug, "delete me");
+    const jakeApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticle(`Del ${id}`);
+    const commentId = await jakeApi.addCommentReturnId(slug, "delete me");
 
-    const del = await jakeApi.delete(`/api/articles/${slug}/comments/${commentId}`);
-    expect(del.status()).toBe(204);
-    const delBody = await del.body();
-    expect(delBody.byteLength).toBe(0);
+    await jakeApi.deleteComment(slug, commentId);
 
-    const list = await jakeApi.get(`/api/articles/${slug}/comments`);
-    const body = (await list.json()) as { comments: Array<{ id: number }> };
-    expect(body.comments.map((c) => c.id)).not.toContain(commentId);
+    const comments = await jakeApi.listComments(slug);
+    expect(comments.map((c) => c.id)).not.toContain(commentId);
   });
 
   test("Scenario 4: delete someone else's comment → 403", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Owned ${id}`);
-    const danCommentId = await addComment(danApi, slug, "dan's comment");
+    const jakeApi = await CommentsApi.newContext();
+    const danApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Owned ${id}`);
+    const danCommentId = await danApi.addCommentReturnId(slug, "dan's comment");
 
-    const res = await jakeApi.delete(`/api/articles/${slug}/comments/${danCommentId}`);
+    const res = await jakeApi.rawDeleteComment(slug, danCommentId);
     expect(res.status()).toBe(403);
 
     // Sanity: comment still exists.
-    const list = await jakeApi.get(`/api/articles/${slug}/comments`);
-    const body = (await list.json()) as { comments: Array<{ id: number }> };
-    expect(body.comments.map((c) => c.id)).toContain(danCommentId);
+    const comments = await jakeApi.listComments(slug);
+    expect(comments.map((c) => c.id)).toContain(danCommentId);
   });
 
   test("Scenario 5: anon POST + DELETE → 401 each", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Auth ${id}`);
-    const commentId = await addComment(jakeApi, slug, "gate");
+    const jakeApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticle(`Auth ${id}`);
+    const commentId = await jakeApi.addCommentReturnId(slug, "gate");
 
-    const anon = await request.newContext({ baseURL: API_URL });
-    const post = await anon.post(`/api/articles/${slug}/comments`, {
-      data: { comment: { body: "anon try" } },
-    });
+    const anon = await CommentsApi.newContext();
+    const post = await anon.rawAddComment(slug, "anon try");
     expect(post.status()).toBe(401);
-    const del = await anon.delete(`/api/articles/${slug}/comments/${commentId}`);
+    const del = await anon.rawDeleteComment(slug, commentId);
     expect(del.status()).toBe(401);
   });
 
   test("Scenario 6: any comment op on non-existent slug → 404", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
+    const jakeApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
 
-    const anon = await request.newContext({ baseURL: API_URL });
+    const anon = await CommentsApi.newContext();
     const missing = `does-not-exist-${id}`;
-    const getRes = await anon.get(`/api/articles/${missing}/comments`);
+    const getRes = await anon.rawListComments(missing);
     expect(getRes.status()).toBe(404);
 
-    const postRes = await jakeApi.post(`/api/articles/${missing}/comments`, {
-      data: { comment: { body: "ghost" } },
-    });
+    const postRes = await jakeApi.rawAddComment(missing, "ghost");
     expect(postRes.status()).toBe(404);
 
-    const delRes = await jakeApi.delete(`/api/articles/${missing}/comments/1`);
+    const delRes = await jakeApi.rawDeleteComment(missing, 1);
     expect(delRes.status()).toBe(404);
   });
 
   test("Scenario 7: empty body → 422 with errors.body", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Empty ${id}`);
+    const jakeApi = await CommentsApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticle(`Empty ${id}`);
 
-    const res = await jakeApi.post(`/api/articles/${slug}/comments`, {
-      data: { comment: { body: "" } },
-    });
+    const res = await jakeApi.rawAddComment(slug, "");
     expect(res.status()).toBe(422);
     const body = (await res.json()) as { errors: Record<string, string[]> };
     const allMessages = Object.values(body.errors).flat().join(" ");


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #97.

## User Intent

Sixth of the 8 per-feature Phase-2 PRs from #35. Same API-client POP
shape as #96 articles (PR #108) — spec 13 is API-only.

## What ships

### `tests/e2e/page-objects/comments.ts` — new

Class `CommentsApi(apiContext, baseURL?)` with:

- **Construction**: `CommentsApi.newContext(baseURL?)` static.
- **User + article seed helpers**: `registerUser(username)`,
  `createArticle(title, tagList?)`.
- **Comments CRUD**: `addComment(slug, body)` returning the full
  `Comment`, `addCommentReturnId(slug, body)` for the common spec
  pattern, `listComments(slug)`, `deleteComment(slug, commentId)`
  (asserts 204 + empty body per RFC 7230 §3.3.3).
- **Raw escape hatches**: `rawAddComment`, `rawDeleteComment`,
  `rawListComments` return the raw Response for error-path
  scenarios (401/403/404/422).

Types exported: `Comment`.

### `tests/e2e/specs/13-api-comments.spec.ts` — refactored

All 7 scenarios consume `CommentsApi`. Line count: 218 → 145 on the
spec body (-33% after POP replaces the three local helpers).

Example:

```ts
// Before:
const jakeApi = await request.newContext({ baseURL: API_URL });
await registerUser(jakeApi, jake);
const slug = await createArticle(jakeApi, `List ${id}`);
await addComment(jakeApi, slug, "jake's first");

// After:
const jakeApi = await CommentsApi.newContext();
await jakeApi.registerUser(jake);
const slug = await jakeApi.createArticle(`List ${id}`);
await jakeApi.addComment(slug, "jake's first");
```

## Duplication note

`registerUser` + `createArticle` are ~20 lines duplicated from
`ArticlesApi` (PR #108). This branch is off pre-#108 `latest`, so
importing isn't possible. Once #108 merges, a small follow-up PR
can collapse them to share ArticlesApi's versions (or introduce a
shared `UsersApi` seed class). Not blocking; pure duplication.

## Fixture migration

Per #97 AC scenario 3: spec 13 is API-only, same as specs 4/6/7/8/9/10/11.
The authedContext fixture provides a BrowserContext, not an
APIRequestContext — not applicable. Same precedent as PRs #103,
#105, #108.

## Verification

```
$ pnpm lint && pnpm typecheck        → ✓
$ bash scripts/db-reset.sh
$ npx playwright test specs/13-api-comments.spec.ts
  7 passed (2.2s)
$ pnpm test:e2e                      → 125 passed (1.4m)
```

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] Spec 13 isolated: 7/7 (2.2s)
- [x] Full suite: 125/125 (desktop + mobile)
- [x] POP methods describe intent (addCommentReturnId, listComments,
      deleteComment) not HTTP paths
- [x] Raw escape hatches for error-path status assertions
      (401/403/404/422) preserved
- [ ] CI green on this PR
