### PR TITLE
feat(test): page-object — favorite (#99 Phase 2 of #35)

### DIFF
--- a/tests/e2e/page-objects/favorite.ts
+++ b/tests/e2e/page-objects/favorite.ts
@@ -1,0 +1,154 @@
+import { expect, request, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+
+// POP module for the favorite surface — covers two shapes:
+//
+//   1. `FavoritesApi` (API-client) — wraps POST/DELETE
+//      /api/articles/:slug/favorite + baseline GET. Shape matches
+//      CommentsApi / ArticlesApi (see #96, #97).
+//
+//   2. `FavoriteButton` (component POP) — a thin wrapper around a
+//      single `[data-testid=favorite-button]` inside a preview card
+//      or article header. Used by spec 56 for the homepage toggle UX.
+//
+// #99 (Phase 2 of #35). Adapted from
+// `mutoe/vue3-realworld-example-app @ dd34ba90` (MIT). Vue → Next/
+// React port: favorite triggers a Next Server Action that flows
+// through the API; the component POP owns the optimistic-flip +
+// aria-pressed / aria-busy / data-errored interaction contract.
+
+const DEFAULT_API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+export type ArticleFavoriteFields = {
+  slug: string;
+  favorited: boolean;
+  favoritesCount: number;
+};
+
+export class FavoritesApi {
+  constructor(
+    public readonly api: APIRequestContext,
+    private readonly baseURL: string = DEFAULT_API_URL,
+  ) {}
+
+  static async newContext(baseURL = DEFAULT_API_URL): Promise<FavoritesApi> {
+    const ctx = await request.newContext({ baseURL });
+    return new FavoritesApi(ctx, baseURL);
+  }
+
+  // ─── Seed helpers (user + article) ───────────────────────────
+
+  async registerUser(username: string): Promise<string> {
+    const res = await this.api.post("/api/users", {
+      data: {
+        user: {
+          username,
+          email: `${username}@jake.jake`,
+          password: "jakejake",
+        },
+      },
+    });
+    expect(res.status()).toBe(201);
+    const setCookie = res.headers()["set-cookie"] ?? "";
+    const match = setCookie.match(/conduit_session=([^;]+)/);
+    if (!match) {
+      throw new Error("expected conduit_session cookie from register");
+    }
+    return match[1];
+  }
+
+  async createArticle(title: string): Promise<string> {
+    const res = await this.api.post("/api/articles", {
+      data: { article: { title, description: "d", body: "b" } },
+    });
+    expect(res.status()).toBe(201);
+    const body = (await res.json()) as { article: { slug: string } };
+    return body.article.slug;
+  }
+
+  // ─── Favorite / unfavorite ───────────────────────────────────
+
+  async favorite(slug: string): Promise<ArticleFavoriteFields> {
+    const res = await this.api.post(`/api/articles/${slug}/favorite`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: ArticleFavoriteFields };
+    return body.article;
+  }
+
+  async unfavorite(slug: string): Promise<ArticleFavoriteFields> {
+    const res = await this.api.delete(`/api/articles/${slug}/favorite`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: ArticleFavoriteFields };
+    return body.article;
+  }
+
+  async readBySlug(slug: string): Promise<ArticleFavoriteFields> {
+    const res = await this.api.get(`/api/articles/${slug}`);
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { article: ArticleFavoriteFields };
+    return body.article;
+  }
+
+  // Raw escape hatches for error-path scenarios (401/404).
+  rawFavorite(slug: string) {
+    return this.api.post(`/api/articles/${slug}/favorite`);
+  }
+
+  rawUnfavorite(slug: string) {
+    return this.api.delete(`/api/articles/${slug}/favorite`);
+  }
+
+  async deleteArticle(slug: string): Promise<void> {
+    const res = await this.api.delete(`/api/articles/${slug}`);
+    expect(res.status()).toBe(204);
+  }
+}
+
+// Component POP for the FavoriteButton rendered inside an article
+// preview card or article header. Takes a `Locator` for the enclosing
+// card so the same button class composes with homepage (multiple
+// cards) and article-detail (single header) surfaces.
+export class FavoriteButton {
+  constructor(private readonly button: Locator) {}
+
+  static inCard(page: Page, slug: string): FavoriteButton {
+    const card = page.locator(
+      `.article-preview:has(a[href="/article/${slug}"])`,
+    );
+    return new FavoriteButton(card.getByTestId("favorite-button"));
+  }
+
+  get locator(): Locator {
+    return this.button;
+  }
+
+  async click(): Promise<void> {
+    await this.button.click();
+  }
+
+  async expectPressed(pressed: boolean): Promise<void> {
+    await expect(this.button).toHaveAttribute(
+      "aria-pressed",
+      pressed ? "true" : "false",
+    );
+  }
+
+  async expectCount(count: number | string): Promise<void> {
+    await expect(this.button).toContainText(String(count));
+  }
+
+  // Wait for the server-action transition to finish so subsequent
+  // independent-fetch assertions observe the committed DB state,
+  // not the pre-commit optimistic state. See spec 56's #89 note.
+  async expectTransitionSettled(): Promise<void> {
+    await expect(this.button).not.toHaveAttribute("aria-busy", "true");
+  }
+
+  async expectErrored(timeout = 2000): Promise<void> {
+    await expect(this.button).toHaveAttribute("data-errored", "true", {
+      timeout,
+    });
+  }
+}

--- a/tests/e2e/specs/12-api-favorite-article.spec.ts
+++ b/tests/e2e/specs/12-api-favorite-article.spec.ts
@@ -1,4 +1,5 @@
-import { expect, request, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { FavoritesApi } from "../page-objects/favorite";
 
 // BDD coverage for issue #12: POST + DELETE /api/articles/:slug/favorite.
 // Six of the seven AC scenarios run here; scenario 5 ("other article
@@ -8,102 +9,64 @@ import { expect, request, test } from "@playwright/test";
 // carries real favorited/favoritesCount) is exercised throughout.
 // When #10 merges its own spec can assert the list-envelope half with
 // one extra seed; no changes needed here.
-
-const API_URL =
-  process.env.API_URL ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:3101";
+//
+// #99 Phase 2 refactor: API helpers via `FavoritesApi`. Scenarios 6
+// (anon 401) + 7 (non-existent slug 404) use `rawFavorite`/
+// `rawUnfavorite` — the POP's wrappers assert 200.
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-
-const registerUser = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  username: string,
-) => {
-  const res = await api.post("/api/users", {
-    data: { user: { username, email: `${username}@jake.jake`, password: "jakejake" } },
-  });
-  expect(res.status()).toBe(201);
-};
-
-const createArticle = async (
-  api: Awaited<ReturnType<typeof request.newContext>>,
-  title: string,
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b" } },
-  });
-  expect(res.status()).toBe(201);
-  const body = (await res.json()) as { article: { slug: string } };
-  return body.article.slug;
-};
 
 test.describe("issue #12 — API favorite / unfavorite article", () => {
   test("Scenario 1: first favorite flips count 0 → 1 and favorited true", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Favorite me ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Favorite me ${id}`);
 
     // Baseline: envelope reports 0 + false pre-favorite.
-    const before = await danApi.get(`/api/articles/${slug}`);
-    const beforeBody = (await before.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(beforeBody.article.favoritesCount).toBe(0);
-    expect(beforeBody.article.favorited).toBe(false);
+    const before = await danApi.readBySlug(slug);
+    expect(before.favoritesCount).toBe(0);
+    expect(before.favorited).toBe(false);
 
-    const fav = await danApi.post(`/api/articles/${slug}/favorite`);
-    expect(fav.status()).toBe(200);
-    const favBody = (await fav.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(favBody.article.favoritesCount).toBe(1);
-    expect(favBody.article.favorited).toBe(true);
+    const fav = await danApi.favorite(slug);
+    expect(fav.favoritesCount).toBe(1);
+    expect(fav.favorited).toBe(true);
   });
 
   test("Scenario 2: favoriting twice is idempotent — count stays 1", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Idempotent ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Idempotent ${id}`);
 
-    await danApi.post(`/api/articles/${slug}/favorite`);
-    const second = await danApi.post(`/api/articles/${slug}/favorite`);
-    expect(second.status()).toBe(200);
-    const body = (await second.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(body.article.favoritesCount).toBe(1);
-    expect(body.article.favorited).toBe(true);
+    await danApi.favorite(slug);
+    const second = await danApi.favorite(slug);
+    expect(second.favoritesCount).toBe(1);
+    expect(second.favorited).toBe(true);
   });
 
   test("Scenario 3: unfavorite flips count 1 → 0 and favorited false", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Unfavorite ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Unfavorite ${id}`);
 
-    await danApi.post(`/api/articles/${slug}/favorite`);
-    const un = await danApi.delete(`/api/articles/${slug}/favorite`);
-    expect(un.status()).toBe(200);
-    const body = (await un.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(body.article.favoritesCount).toBe(0);
-    expect(body.article.favorited).toBe(false);
+    await danApi.favorite(slug);
+    const un = await danApi.unfavorite(slug);
+    expect(un.favoritesCount).toBe(0);
+    expect(un.favorited).toBe(false);
   });
 
   test("Scenario 4: favoritesCount reflects multiple users", async () => {
@@ -111,26 +74,23 @@ test.describe("issue #12 — API favorite / unfavorite article", () => {
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
     const alice = `alice-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    const aliceApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    await registerUser(aliceApi, alice);
-    const slug = await createArticle(jakeApi, `Multi-fav ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
+    const aliceApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    await aliceApi.registerUser(alice);
+    const slug = await jakeApi.createArticle(`Multi-fav ${id}`);
 
-    await danApi.post(`/api/articles/${slug}/favorite`);
-    await aliceApi.post(`/api/articles/${slug}/favorite`);
+    await danApi.favorite(slug);
+    await aliceApi.favorite(slug);
 
-    const anon = await request.newContext({ baseURL: API_URL });
-    const res = await anon.get(`/api/articles/${slug}`);
-    const body = (await res.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(body.article.favoritesCount).toBe(2);
+    const anon = await FavoritesApi.newContext();
+    const article = await anon.readBySlug(slug);
+    expect(article.favoritesCount).toBe(2);
     // Anonymous viewer sees favorited=false regardless of other users'
     // state — `favorited` is strictly viewer-relative.
-    expect(body.article.favorited).toBe(false);
+    expect(article.favorited).toBe(false);
   });
 
   test("Scenario 5 (detail-endpoint half): viewer-relative favorited is per-user", async () => {
@@ -142,52 +102,46 @@ test.describe("issue #12 — API favorite / unfavorite article", () => {
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
     const alice = `alice-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    const danApi = await request.newContext({ baseURL: API_URL });
-    const aliceApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    await registerUser(danApi, dan);
-    await registerUser(aliceApi, alice);
-    const slug = await createArticle(jakeApi, `Per-viewer ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
+    const aliceApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    await danApi.registerUser(dan);
+    await aliceApi.registerUser(alice);
+    const slug = await jakeApi.createArticle(`Per-viewer ${id}`);
 
-    await danApi.post(`/api/articles/${slug}/favorite`);
+    await danApi.favorite(slug);
 
-    const danView = await danApi.get(`/api/articles/${slug}`);
-    const danBody = (await danView.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(danBody.article.favorited).toBe(true);
-    expect(danBody.article.favoritesCount).toBe(1);
+    const danView = await danApi.readBySlug(slug);
+    expect(danView.favorited).toBe(true);
+    expect(danView.favoritesCount).toBe(1);
 
-    const aliceView = await aliceApi.get(`/api/articles/${slug}`);
-    const aliceBody = (await aliceView.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(aliceBody.article.favorited).toBe(false);
-    expect(aliceBody.article.favoritesCount).toBe(1);
+    const aliceView = await aliceApi.readBySlug(slug);
+    expect(aliceView.favorited).toBe(false);
+    expect(aliceView.favoritesCount).toBe(1);
   });
 
   test("Scenario 6: favorite endpoints require auth", async () => {
     const id = uniq();
     const jake = `jake-${id}`;
-    const jakeApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(jakeApi, jake);
-    const slug = await createArticle(jakeApi, `Auth-check ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(jake);
+    const slug = await jakeApi.createArticle(`Auth-check ${id}`);
 
-    const anon = await request.newContext({ baseURL: API_URL });
-    const post = await anon.post(`/api/articles/${slug}/favorite`);
+    const anon = await FavoritesApi.newContext();
+    const post = await anon.rawFavorite(slug);
     expect(post.status()).toBe(401);
-    const del = await anon.delete(`/api/articles/${slug}/favorite`);
+    const del = await anon.rawUnfavorite(slug);
     expect(del.status()).toBe(401);
   });
 
   test("Scenario 7: favorite non-existent article → 404", async () => {
     const id = uniq();
     const dan = `dan-${id}`;
-    const danApi = await request.newContext({ baseURL: API_URL });
-    await registerUser(danApi, dan);
+    const danApi = await FavoritesApi.newContext();
+    await danApi.registerUser(dan);
 
-    const res = await danApi.post(`/api/articles/no-such-slug-${id}/favorite`);
+    const res = await danApi.rawFavorite(`no-such-slug-${id}`);
     expect(res.status()).toBe(404);
   });
 });

--- a/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
+++ b/tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
@@ -1,54 +1,22 @@
 import {
   expect,
-  request,
   test,
   type BrowserContext,
 } from "@playwright/test";
 import { runAxe } from "../axe-config";
+import { FavoriteButton, FavoritesApi } from "../page-objects/favorite";
 
 // BDD coverage for issue #56: interactive favorite toggle on the
 // homepage ArticlePreview card. Four scenarios from the issue body.
-
-const API_URL =
-  process.env.API_URL ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:3101";
+//
+// #99 Phase 2 refactor: API seeds go through `FavoritesApi`; the
+// FavoriteButton on each preview card is driven by the
+// `FavoriteButton` component POP (resolved by slug via
+// `FavoriteButton.inCard(page, slug)`).
 
 const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
 
 const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-
-type ApiCtx = Awaited<ReturnType<typeof request.newContext>>;
-const apiContext = () => request.newContext({ baseURL: API_URL });
-
-const registerUser = async (api: ApiCtx, username: string): Promise<string> => {
-  const res = await api.post("/api/users", {
-    data: {
-      user: {
-        username,
-        email: `${username}@jake.jake`,
-        password: "jakejake",
-      },
-    },
-  });
-  expect(res.status()).toBe(201);
-  const setCookie = res.headers()["set-cookie"] ?? "";
-  const match = setCookie.match(/conduit_session=([^;]+)/);
-  if (!match) throw new Error("expected conduit_session cookie from register");
-  return match[1];
-};
-
-const createArticle = async (
-  api: ApiCtx,
-  title: string,
-): Promise<string> => {
-  const res = await api.post("/api/articles", {
-    data: { article: { title, description: "d", body: "b" } },
-  });
-  expect(res.status()).toBe(201);
-  const payload = (await res.json()) as { article: { slug: string } };
-  return payload.article.slug;
-};
 
 const primeSession = async (
   context: BrowserContext,
@@ -75,16 +43,6 @@ const primeSession = async (
   ]);
 };
 
-// The preview card carrying slug `<slug>` scopes the FavoriteButton
-// assertions to that one article — otherwise sibling previews (seeded
-// by other specs running in parallel) would poison role queries.
-const cardFor = (page: Parameters<typeof test>[1] extends (args: {
-  page: infer P;
-}) => unknown
-  ? P
-  : never, slug: string) =>
-  page.locator(`.article-preview:has(a[href="/article/${slug}"])`);
-
 test.describe("issue #56 — homepage favorite toggle", () => {
   // Cold-start warmup (#89). A fresh `docker compose up --build` leaves
   // Next's first-compile window open for a few seconds after the web
@@ -108,13 +66,13 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     context,
   }) => {
     const id = uniq();
-    const jakeApi = await apiContext();
-    const danApi = await apiContext();
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    await registerUser(jakeApi, jake);
-    const danSession = await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Fav1 ${id}`);
+    await jakeApi.registerUser(jake);
+    const danSession = await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Fav1 ${id}`);
     await primeSession(context, danSession, dan);
 
     // The favorite POST runs server-side (Next action → internal
@@ -123,33 +81,28 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     // persisted state after reload + independent API read.
 
     await page.goto(`${WEB_URL}/`);
-    const card = cardFor(page, slug);
-    await expect(card).toBeVisible();
+    const btn = FavoriteButton.inCard(page, slug);
+    await expect(btn.locator).toBeVisible();
 
-    const btn = card.getByTestId("favorite-button");
-    await expect(btn).toHaveAttribute("aria-pressed", "false");
-    await expect(btn).toContainText("0");
+    await btn.expectPressed(false);
+    await btn.expectCount(0);
     await btn.click();
 
     // Optimistic flip lands immediately; the final committed value
     // should still be 1 after the client's router.refresh() cycle.
-    await expect(btn).toHaveAttribute("aria-pressed", "true");
-    await expect(btn).toContainText("1");
+    await btn.expectPressed(true);
+    await btn.expectCount(1);
     // Wait for the server action's transition to complete (aria-busy
     // clears when router.refresh() has returned + props landed). The
     // earlier aria-pressed check satisfies the optimistic path; this
     // guarantees the DB write committed before the independent-fetch
     // persistence check below — closes the cold-start race in #89.
-    await expect(btn).not.toHaveAttribute("aria-busy", "true");
+    await btn.expectTransitionSettled();
 
     // Persistence: independent API fetch confirms the DB write landed.
-    const check = await danApi.get(`/api/articles/${slug}`);
-    expect(check.status()).toBe(200);
-    const body = (await check.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(body.article.favorited).toBe(true);
-    expect(body.article.favoritesCount).toBe(1);
+    const article = await danApi.readBySlug(slug);
+    expect(article.favorited).toBe(true);
+    expect(article.favoritesCount).toBe(1);
   });
 
   test("Scenario 2: unfavorite on a preview card — optimistic flip + persists", async ({
@@ -157,38 +110,32 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     context,
   }) => {
     const id = uniq();
-    const jakeApi = await apiContext();
-    const danApi = await apiContext();
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    await registerUser(jakeApi, jake);
-    const danSession = await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Fav2 ${id}`);
+    await jakeApi.registerUser(jake);
+    const danSession = await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Fav2 ${id}`);
     // Seed: dan favorites via the API so the UI starts with favorited=true.
-    const favSeed = await danApi.post(`/api/articles/${slug}/favorite`);
-    expect(favSeed.status()).toBe(200);
+    await danApi.favorite(slug);
     await primeSession(context, danSession, dan);
 
     await page.goto(`${WEB_URL}/`);
-    const card = cardFor(page, slug);
-    const btn = card.getByTestId("favorite-button");
-    await expect(btn).toHaveAttribute("aria-pressed", "true");
-    await expect(btn).toContainText("1");
+    const btn = FavoriteButton.inCard(page, slug);
+    await btn.expectPressed(true);
+    await btn.expectCount(1);
     await btn.click();
 
-    await expect(btn).toHaveAttribute("aria-pressed", "false");
-    await expect(btn).toContainText("0");
+    await btn.expectPressed(false);
+    await btn.expectCount(0);
     // Wait for the transition to commit before the independent-fetch
     // persistence check — see Scenario 1 note and #89.
-    await expect(btn).not.toHaveAttribute("aria-busy", "true");
+    await btn.expectTransitionSettled();
 
-    const check = await danApi.get(`/api/articles/${slug}`);
-    expect(check.status()).toBe(200);
-    const body = (await check.json()) as {
-      article: { favorited: boolean; favoritesCount: number };
-    };
-    expect(body.article.favorited).toBe(false);
-    expect(body.article.favoritesCount).toBe(0);
+    const article = await danApi.readBySlug(slug);
+    expect(article.favorited).toBe(false);
+    expect(article.favoritesCount).toBe(0);
   });
 
   test("Scenario 3: server rejects the toggle — UI reverts + error indication", async ({
@@ -196,13 +143,13 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     context,
   }) => {
     const id = uniq();
-    const jakeApi = await apiContext();
-    const danApi = await apiContext();
+    const jakeApi = await FavoritesApi.newContext();
+    const danApi = await FavoritesApi.newContext();
     const jake = `jake-${id}`;
     const dan = `dan-${id}`;
-    await registerUser(jakeApi, jake);
-    const danSession = await registerUser(danApi, dan);
-    const slug = await createArticle(jakeApi, `Fav3 ${id}`);
+    await jakeApi.registerUser(jake);
+    const danSession = await danApi.registerUser(dan);
+    const slug = await jakeApi.createArticle(`Fav3 ${id}`);
     await primeSession(context, danSession, dan);
 
     // Induce a 404 from the server action by deleting the article
@@ -210,29 +157,27 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     // throws when the API responds non-2xx, which surfaces as
     // data-errored + optimistic revert via useOptimistic.
     await page.goto(`${WEB_URL}/`);
-    const card = cardFor(page, slug);
-    const btn = card.getByTestId("favorite-button");
-    await expect(btn).toHaveAttribute("aria-pressed", "false");
+    const btn = FavoriteButton.inCard(page, slug);
+    await btn.expectPressed(false);
 
-    const del = await jakeApi.delete(`/api/articles/${slug}`);
-    expect(del.status()).toBe(204);
+    await jakeApi.deleteArticle(slug);
 
     await btn.click();
 
     // Within the 1s AC window, the button returns to favorited=false
     // and flags the error via data-errored.
-    await expect(btn).toHaveAttribute("data-errored", "true", { timeout: 2000 });
-    await expect(btn).toHaveAttribute("aria-pressed", "false");
-    await expect(btn).toContainText("0");
+    await btn.expectErrored();
+    await btn.expectPressed(false);
+    await btn.expectCount(0);
   });
 
   test("Scenario 4: anonymous click navigates to /login?next=... and fires no POST", async ({
     page,
   }) => {
     const id = uniq();
-    const jakeApi = await apiContext();
-    await registerUser(jakeApi, `jake-${id}`);
-    const slug = await createArticle(jakeApi, `Fav4 ${id}`);
+    const jakeApi = await FavoritesApi.newContext();
+    await jakeApi.registerUser(`jake-${id}`);
+    const slug = await jakeApi.createArticle(`Fav4 ${id}`);
 
     // Assert no favorite POST is ever attempted.
     let favPostSeen = false;
@@ -246,9 +191,8 @@ test.describe("issue #56 — homepage favorite toggle", () => {
     });
 
     await page.goto(`${WEB_URL}/`);
-    const card = cardFor(page, slug);
-    await expect(card).toBeVisible();
-    const btn = card.getByTestId("favorite-button");
+    const btn = FavoriteButton.inCard(page, slug);
+    await expect(btn.locator).toBeVisible();
     await btn.click();
 
     const expectedNext = `/article/${encodeURIComponent(slug)}`;
@@ -263,9 +207,9 @@ test.describe("issue #56 — homepage favorite toggle", () => {
 
 test("axe a11y gate on homepage with articles (#87)", async ({ page }) => {
   const id = uniq();
-  const jakeApi = await apiContext();
-  await registerUser(jakeApi, `jake-${id}`);
-  await createArticle(jakeApi, `Axe ${id}`);
+  const api = await FavoritesApi.newContext();
+  await api.registerUser(`jake-${id}`);
+  await api.createArticle(`Axe ${id}`);
   await page.goto(`${WEB_URL}/`);
   await runAxe(page);
 });


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #99.

## User Intent

Seventh of the 8 per-feature Phase-2 PRs from #35. Unique in this
series: **two** POP shapes ship in the same module — an API client
and a component POP for the `FavoriteButton` used on the homepage
and article-detail surfaces.

## What ships

### `tests/e2e/page-objects/favorite.ts` — new

**`FavoritesApi`** (API client) — matches the CommentsApi /
ArticlesApi pattern from #96 / #97:

- `registerUser(username)` → returns the session cookie (unlike
  siblings, because spec 56 threads the cookie into the browser
  context).
- `createArticle(title)` — minimal title-only overload (spec 12
  never needs tags).
- `favorite(slug)` / `unfavorite(slug)` / `readBySlug(slug)` —
  happy-path methods asserting 200 + returning the
  `{ slug, favorited, favoritesCount }` shape.
- `rawFavorite(slug)` / `rawUnfavorite(slug)` — escape hatches for
  401/404 scenarios.
- `deleteArticle(slug)` — used by Scenario 3 of spec 56 to induce a
  server-side error after the page renders.

**`FavoriteButton`** (component POP) — thin wrapper around a single
`[data-testid=favorite-button]` Locator. Composes with either
surface via a factory:

- `FavoriteButton.inCard(page, slug)` — resolves the button inside
  the preview card matching `article-preview:has(a[href="/article/${slug}"])`.
  Same selector the raw spec used, now POP-owned.
- Methods: `click()`, `expectPressed(bool)`, `expectCount(n)`,
  `expectTransitionSettled()` (aria-busy cleared), `expectErrored()`
  (data-errored within timeout).
- `locator` getter for the handful of raw interactions a spec needs
  (visibility checks, network intercepts around the click).

### Specs refactored

- **Spec 12** (API, 7 scenarios) — consumes `FavoritesApi`. Error
  scenarios 6+7 use `rawFavorite` / `rawUnfavorite`. Line count:
  193 → 147 (-24%).
- **Spec 56** (web, 4 scenarios + axe gate) — consumes both classes.
  Every FavoriteButton assertion (aria-pressed, count, transition
  settle, errored) routes through the component POP. Line count:
  271 → 213 (-21%).

Example:

```ts
// Before:
const card = page.locator(`.article-preview:has(a[href="/article/${slug}"])`);
const btn = card.getByTestId("favorite-button");
await expect(btn).toHaveAttribute("aria-pressed", "false");
await expect(btn).toContainText("0");
await btn.click();
await expect(btn).toHaveAttribute("aria-pressed", "true");
await expect(btn).toContainText("1");
await expect(btn).not.toHaveAttribute("aria-busy", "true");

// After:
const btn = FavoriteButton.inCard(page, slug);
await btn.expectPressed(false);
await btn.expectCount(0);
await btn.click();
await btn.expectPressed(true);
await btn.expectCount(1);
await btn.expectTransitionSettled();
```

Grep proof of POP ownership on the favorite surface:

```
$ grep -E "page\.locator|getByTestId|getByRole" \
    tests/e2e/specs/56-web-home-favorite-toggle.spec.ts
(no matches)
```

## Fixture migration

Per #99 AC scenario 3: kept inline priming on spec 56. Every
scenario exercises **non-self** favoriting (dan favoriting jake's
article) — the fixture provides one user, Scenarios 1-3 need
jake-as-author-dan-as-favoriter, Scenario 4 is anon. The pattern
doesn't compose cleanly. Same reasoning as spec 20 profile (#101).

Spec 12 is API-only — fixture doesn't apply (BrowserContext vs
APIRequestContext). Same precedent as #96/#97/#103/#105/#108/#110.

## Verification

```
$ pnpm lint && pnpm typecheck       → ✓
$ bash scripts/db-reset.sh
$ npx playwright test specs/{12-api-favorite,56-web-home-favorite}-*.spec.ts
  12 passed (7.2s)
$ pnpm test:e2e                     → 125 passed (1.4m)
```

Spec 56's cold-start warmup `beforeAll` (#89) preserved — still a
test-infra concern, not favorite DOM.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] Spec 12 + 56 isolated: 12/12 (7.2s, includes axe gate)
- [x] Full suite: 125/125 (desktop + mobile)
- [x] Zero direct DOM calls against favorite surface in spec 56
      (grep proof)
- [x] Cold-start race from #89 still covered via
      `expectTransitionSettled` before independent-fetch persistence
      check
- [x] Error path (Scenario 3) routes through `expectErrored` —
      matches the 2s timeout the raw test used
- [ ] CI green on this PR
