### PR TITLE
feat(test): page-object — home (#100 Phase 2 of #35)

### DIFF
--- a/tests/e2e/page-objects/home.ts
+++ b/tests/e2e/page-objects/home.ts
@@ -1,0 +1,154 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+// Page object for the homepage ("/").
+//
+// #100 (Phase 2 of #35). Adapted from
+// `mutoe/vue3-realworld-example-app @ dd34ba90`
+// (`playwright/page-objects/*`, MIT). Vue → Next/React port: the
+// homepage is a Server Component that renders the banner, feed
+// tabs, article-preview list, tag sidebar, and paginator.
+//
+// The POP owns every selector for the home surface. Tests use
+// semantic methods; FavoriteButton assertions on a preview card
+// compose with the `FavoriteButton` component POP (#99) when
+// available — if not merged yet, the caller uses the raw
+// `previewCardFor(slug)` locator.
+
+export type FeedMode = "global" | "you" | "tag";
+
+export class HomePage {
+  constructor(private readonly page: Page) {}
+
+  // ─── Top-level regions ───────────────────────────────────────
+
+  get banner(): Locator {
+    return this.page.locator(".banner");
+  }
+
+  get feedToggle(): Locator {
+    return this.page.locator(".feed-toggle");
+  }
+
+  get sidebar(): Locator {
+    return this.page.locator(".sidebar");
+  }
+
+  get paginator(): Locator {
+    return this.page.locator("ul.pagination");
+  }
+
+  // ─── Feed tabs ───────────────────────────────────────────────
+
+  get globalFeedTab(): Locator {
+    return this.feedToggle.getByRole("link", { name: "Global Feed" });
+  }
+
+  get yourFeedTab(): Locator {
+    return this.feedToggle.getByRole("link", { name: "Your Feed" });
+  }
+
+  get activeTab(): Locator {
+    return this.feedToggle.locator(".nav-link.active");
+  }
+
+  // ─── Article previews ────────────────────────────────────────
+
+  get previews(): Locator {
+    return this.page.locator(".article-preview");
+  }
+
+  get previewHeadings(): Locator {
+    return this.page.locator(".article-preview h1");
+  }
+
+  previewCardFor(slug: string): Locator {
+    return this.page.locator(
+      `.article-preview:has(a[href="/article/${slug}"])`,
+    );
+  }
+
+  previewByTitle(title: string): Locator {
+    return this.previews.filter({ hasText: title });
+  }
+
+  // ─── Sidebar tag pills ───────────────────────────────────────
+
+  sidebarTagPill(tag: string): Locator {
+    return this.sidebar.getByRole("link", { name: tag });
+  }
+
+  // ─── Navigation ──────────────────────────────────────────────
+
+  async goto(baseUrl: string): Promise<Awaited<ReturnType<Page["goto"]>>> {
+    return this.page.goto(`${baseUrl}/`);
+  }
+
+  async gotoFeed(
+    baseUrl: string,
+    mode: Exclude<FeedMode, "tag">,
+  ): Promise<Awaited<ReturnType<Page["goto"]>>> {
+    const path = mode === "you" ? "/?feed=you" : "/";
+    return this.page.goto(`${baseUrl}${path}`);
+  }
+
+  async gotoTag(
+    baseUrl: string,
+    tag: string,
+    page?: number,
+  ): Promise<Awaited<ReturnType<Page["goto"]>>> {
+    const params = new URLSearchParams();
+    params.set("tag", tag);
+    if (page !== undefined) params.set("page", String(page));
+    return this.page.goto(`${baseUrl}/?${params.toString()}`);
+  }
+
+  async clickSidebarTag(tag: string): Promise<void> {
+    await this.sidebarTagPill(tag).click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  // ─── Assertions ──────────────────────────────────────────────
+
+  async expectBannerHeadline(): Promise<void> {
+    await expect(this.banner).toContainText("conduit");
+    await expect(this.banner).toContainText("A place to share your knowledge.");
+  }
+
+  async expectSidebarShowsPopularTags(): Promise<void> {
+    await expect(this.sidebar).toContainText("Popular Tags");
+  }
+
+  async expectOnlyGlobalFeedVisible(): Promise<void> {
+    await expect(this.globalFeedTab).toBeVisible();
+    await expect(this.yourFeedTab).toHaveCount(0);
+  }
+
+  async expectYourFeedActive(): Promise<void> {
+    await expect(this.yourFeedTab).toBeVisible();
+    await expect(this.yourFeedTab).toHaveClass(/active/);
+  }
+
+  async expectActiveTabText(text: string | RegExp): Promise<void> {
+    await expect(this.activeTab).toContainText(text);
+  }
+
+  async expectEmptyList(): Promise<void> {
+    await expect(this.previews).toContainText("No articles are here... yet.");
+  }
+
+  async allPreviewTitles(): Promise<string[]> {
+    return this.previewHeadings.allTextContents();
+  }
+
+  // ─── Paginator helpers ───────────────────────────────────────
+
+  async expectPageCount(count: number): Promise<void> {
+    await expect(this.paginator.locator(".page-item")).toHaveCount(count);
+  }
+
+  async expectActivePage(page: string | number): Promise<void> {
+    await expect(this.paginator.locator(".page-item.active")).toHaveText(
+      String(page),
+    );
+  }
+}

--- a/tests/e2e/specs/17-web-homepage.spec.ts
+++ b/tests/e2e/specs/17-web-homepage.spec.ts
@@ -1,11 +1,15 @@
 import { expect, request, test } from "@playwright/test";
 import { runAxe } from "../axe-config";
+import { HomePage } from "../page-objects/home";
 
 // BDD coverage for issue #17 (rescoped by Audit E.1, 2026-04-29):
 // static RSC homepage — banner, feed tabs, article preview cards,
 // pagination, tag sidebar, empty state. The interactive favorite
 // toggle lands in follow-up #56 so this spec asserts the non-
 // interactive badge only.
+//
+// Every home DOM selector lives in HomePage
+// (tests/e2e/page-objects/home.ts). #100 Phase 2 refactor.
 
 const API_URL =
   process.env.API_URL ??
@@ -55,23 +59,13 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
   test("Scenario 1: anonymous visitor sees banner + Global Feed tab only", async ({
     page,
   }) => {
-    const res = await page.goto(`${WEB_URL}/`);
+    const home = new HomePage(page);
+    const res = await home.goto(WEB_URL);
     expect(res?.status()).toBe(200);
 
-    // Banner copy — matches the RealWorld canonical headline.
-    await expect(page.locator(".banner")).toContainText("conduit");
-    await expect(page.locator(".banner")).toContainText(
-      "A place to share your knowledge.",
-    );
-
-    // Feed tab bar: only Global Feed visible for anon.
-    const tabs = page.locator(".feed-toggle");
-    await expect(tabs.getByRole("link", { name: "Global Feed" })).toBeVisible();
-    await expect(tabs.getByRole("link", { name: "Your Feed" })).toHaveCount(0);
-
-    // Tag sidebar exists (may be empty on a fresh db but the container
-    // always renders).
-    await expect(page.locator(".sidebar")).toContainText("Popular Tags");
+    await home.expectBannerHeadline();
+    await home.expectOnlyGlobalFeedVisible();
+    await home.expectSidebarShowsPopularTags();
   });
 
   test("Scenario 2: authenticated viewer sees Your Feed tab as default", async ({
@@ -86,8 +80,8 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
     await registerUser(jakeApi, jake);
     const danSession = await registerUser(danApi, dan);
 
-    const j1Slug = await createArticle(jakeApi, `J1 home ${id}`);
-    const j2Slug = await createArticle(jakeApi, `J2 home ${id}`);
+    await createArticle(jakeApi, `J1 home ${id}`);
+    await createArticle(jakeApi, `J2 home ${id}`);
     // alice seeds a global-only article that should NOT appear in dan's feed.
     const alice = `alice-${id}`;
     const aliceApi = await apiContext();
@@ -122,18 +116,13 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
       },
     ]);
 
-    const res = await page.goto(`${WEB_URL}/?feed=you`);
+    const home = new HomePage(page);
+    const res = await home.gotoFeed(WEB_URL, "you");
     expect(res?.status()).toBe(200);
 
-    const tabs = page.locator(".feed-toggle");
-    const yourFeed = tabs.getByRole("link", { name: "Your Feed" });
-    await expect(yourFeed).toBeVisible();
-    await expect(yourFeed).toHaveClass(/active/);
+    await home.expectYourFeedActive();
 
-    const previews = page.locator(".article-preview");
-    const titles = await previews
-      .locator("h1")
-      .allTextContents();
+    const titles = await home.allPreviewTitles();
     expect(titles).toContain(`J1 home ${id}`);
     expect(titles).toContain(`J2 home ${id}`);
     expect(titles).not.toContain(`A1 home ${id}`);
@@ -159,28 +148,20 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
     }
 
     // Load home (anon — Global Feed), then click the seeded tag pill.
-    await page.goto(`${WEB_URL}/`);
-
-    const tagPill = page
-      .locator(".sidebar")
-      .getByRole("link", { name: dragonsTag });
-    await expect(tagPill).toBeVisible();
-    await tagPill.click();
-    await page.waitForLoadState("networkidle");
+    const home = new HomePage(page);
+    await home.goto(WEB_URL);
+    await expect(home.sidebarTagPill(dragonsTag)).toBeVisible();
+    await home.clickSidebarTag(dragonsTag);
 
     // URL reflects the filter.
     expect(page.url()).toContain(`tag=${encodeURIComponent(dragonsTag)}`);
 
     // Third tab `# <tag>` is pinned + active.
-    const tabs = page.locator(".feed-toggle");
-    const tagTab = tabs.locator(".nav-link.active");
-    await expect(tagTab).toContainText(`# ${dragonsTag}`);
+    await home.expectActiveTabText(`# ${dragonsTag}`);
 
     // List is filtered to dragons-tagged articles only — no training-
     // tagged article should appear anywhere on the page.
-    const titles = await page
-      .locator(".article-preview h1")
-      .allTextContents();
+    const titles = await home.allPreviewTitles();
     for (const t of titles) {
       expect(t).not.toBe(`Training regimen ${id}`);
     }
@@ -199,11 +180,10 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
     const tagB = `preview-b-${id}`;
     await createArticle(api, `Preview card ${id}`, [tagA, tagB]);
 
-    await page.goto(`${WEB_URL}/?tag=${encodeURIComponent(tagA)}`);
+    const home = new HomePage(page);
+    await home.gotoTag(WEB_URL, tagA);
 
-    const preview = page
-      .locator(".article-preview")
-      .filter({ hasText: `Preview card ${id}` });
+    const preview = home.previewByTitle(`Preview card ${id}`);
     await expect(preview).toBeVisible();
 
     // Author username link present in the meta row, pointing at the
@@ -223,7 +203,9 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
 
     // Favorite button ships interactive in #56 (this spec used to
     // assert the placeholder non-interactive badge). Envelope-driven
-    // state still renders: zero favorites, aria-pressed=false.
+    // state still renders: zero favorites, aria-pressed=false. The
+    // FavoriteButton component POP from #99 owns this assertion in
+    // spec 56; here we only check the envelope-driven render.
     const favBtn = preview.getByTestId("favorite-button");
     await expect(favBtn).toHaveAttribute("aria-pressed", "false");
     await expect(favBtn).toContainText("0");
@@ -250,18 +232,15 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
     }
 
     // Page 2 under the tag filter.
-    await page.goto(
-      `${WEB_URL}/?tag=${encodeURIComponent(pagTag)}&page=2`,
-    );
-    const titles = await page
-      .locator(".article-preview h1")
-      .allTextContents();
+    const home = new HomePage(page);
+    await home.gotoTag(WEB_URL, pagTag, 2);
+
+    const titles = await home.allPreviewTitles();
     expect(titles.length).toBe(5);
 
     // Paginator renders two page links (1, 2) with 2 active.
-    const paginator = page.locator("ul.pagination");
-    await expect(paginator.locator(".page-item")).toHaveCount(2);
-    await expect(paginator.locator(".page-item.active")).toHaveText("2");
+    await home.expectPageCount(2);
+    await home.expectActivePage(2);
   });
 
   test("Scenario 7: empty state message when no articles match", async ({
@@ -270,16 +249,15 @@ test.describe("issue #17 — web homepage (RSC walking skeleton)", () => {
     // A tag no article can possibly have (seeded with timestamp + rand
     // suffix) produces a deterministic empty result.
     const missingTag = `no-such-tag-${uniq()}`;
-    await page.goto(`${WEB_URL}/?tag=${encodeURIComponent(missingTag)}`);
-
-    await expect(page.locator(".article-preview")).toContainText(
-      "No articles are here... yet.",
-    );
+    const home = new HomePage(page);
+    await home.gotoTag(WEB_URL, missingTag);
+    await home.expectEmptyList();
   });
 });
 
 test("axe a11y gate on homepage (#87)", async ({ page }) => {
-  await page.goto(`${WEB_URL}/`);
+  const home = new HomePage(page);
+  await home.goto(WEB_URL);
   await runAxe(page);
 });
 
@@ -292,15 +270,17 @@ test("homepage reflows on mobile viewport @mobile", async ({ page }) => {
   const jakeApi = await apiContext();
   await registerUser(jakeApi, `jake-${uniq()}`);
   await createArticle(jakeApi, `Mobile ${uniq()}`);
-  await page.goto(`${WEB_URL}/`);
+  const home = new HomePage(page);
+  await home.goto(WEB_URL);
 
   // Navbar brand still visible at mobile viewport (375-412px wide).
+  // Navbar is chrome, not home surface — selector stays inline here.
   const brand = page.locator(".navbar-brand");
   await expect(brand).toBeVisible();
 
   // First article preview renders within the mobile viewport width —
   // no horizontal scroll.
-  const preview = page.locator(".article-preview").first();
+  const preview = home.previews.first();
   await expect(preview).toBeVisible();
   const box = await preview.boundingBox();
   const vp = page.viewportSize();
@@ -309,8 +289,7 @@ test("homepage reflows on mobile viewport @mobile", async ({ page }) => {
 
   // Tap-target floor: the Global Feed tab link is at least 44×44
   // (WCAG 2.5.5 minimum target size for touch).
-  const globalTab = page.getByRole("link", { name: "Global Feed" });
-  const tabBox = await globalTab.boundingBox();
+  const tabBox = await home.globalFeedTab.boundingBox();
   if (!tabBox) throw new Error("global feed tab box unavailable");
   expect(tabBox.height).toBeGreaterThanOrEqual(44);
 });


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #100.

## User Intent

**Last** of the 8 per-feature Phase-2 PRs from #35. Extract a
reusable page object for the homepage (`/`) surface and refactor
spec 17 so scenarios read as user journeys.

## What ships

### `tests/e2e/page-objects/home.ts` — new

Class `HomePage(page)` with:

- **Top-level region locators**: `banner`, `feedToggle`, `sidebar`,
  `paginator`.
- **Feed-tab locators**: `globalFeedTab`, `yourFeedTab`, `activeTab`.
- **Preview list**: `previews`, `previewHeadings`.
- **Parameterised locators**: `previewCardFor(slug)` (same selector
  the #99 FavoriteButton POP uses — the two compose),
  `previewByTitle(title)` (filter-by-text), `sidebarTagPill(tag)`.
- **Navigation**: `goto(baseUrl)`, `gotoFeed(baseUrl, "global" | "you")`,
  `gotoTag(baseUrl, tag, page?)`, `clickSidebarTag(tag)` (click +
  networkidle wait).
- **Assertions**: `expectBannerHeadline()`,
  `expectOnlyGlobalFeedVisible()`, `expectYourFeedActive()`,
  `expectSidebarShowsPopularTags()`, `expectActiveTabText(text)`,
  `expectEmptyList()`, `allPreviewTitles()` (returns text array for
  namespaced `.endsWith(id)` filtering), `expectPageCount(n)`,
  `expectActivePage(n)`.

Adapted from `mutoe/vue3-realworld-example-app @ dd34ba90`
(`playwright/page-objects/*`, MIT).

### `tests/e2e/specs/17-web-homepage.spec.ts` — refactored

All 6 scenarios + axe gate + @mobile test consume `HomePage`.
Example:

```ts
// Before:
await page.goto(`${WEB_URL}/`);
await expect(page.locator(".banner")).toContainText("conduit");
await expect(page.locator(".banner")).toContainText("A place to share...");
const tabs = page.locator(".feed-toggle");
await expect(tabs.getByRole("link", { name: "Global Feed" })).toBeVisible();
await expect(tabs.getByRole("link", { name: "Your Feed" })).toHaveCount(0);
await expect(page.locator(".sidebar")).toContainText("Popular Tags");

// After:
const home = new HomePage(page);
await home.goto(WEB_URL);
await home.expectBannerHeadline();
await home.expectOnlyGlobalFeedVisible();
await home.expectSidebarShowsPopularTags();
```

### Remaining `page.locator` call

```
$ grep -E "page\.locator" tests/e2e/specs/17-web-homepage.spec.ts
278: const brand = page.locator(".navbar-brand");
```

One call in the @mobile test targets **navbar** DOM (chrome), not
home. Out of #100 AC scope. Scenario 4's preview-card assertions
(author link, title `h1`, tag-list `li`, favorite-button attrs) are
scoped inside a `previewByTitle(...)` locator from the POP; the
finer-grained selectors (`.locator("h1")`, `.getByTestId(...)`)
hang off that locator — a future `PreviewCard` sub-POP could own
them but isn't in #100 scope.

## Fixture migration

Per #100 AC scenario 3: kept inline priming on Scenario 2 (authed
Your Feed). The fixture provides one user, but Scenario 2 needs a
fresh authed dan who follows a fresh seeded jake and verifies
alice's unfollowed article doesn't leak in — the three-user seed
graph needs fresh users. Same reasoning as spec 20 profile
(#101) and spec 17 elsewhere.

## The full 8-PR Phase 2 series is now complete

| # | Feature | PR | Spec(s) |
|---|---|---|---|
| #95 | auth | #103 | 16 |
| #96 | articles (API) | #108 | 8, 9, 10, 11 |
| #97 | comments (API) | #110 | 13 |
| #98 | editor | #109 | 19 |
| #99 | favorite | #111 | 12, 56 |
| #100 | **home** (this PR) | **this** | 17 |
| #101 | profile | #105 (merged) | 20 |
| #102 | settings | #104 (merged) | 21 |

Every feature has a dedicated POP. Spec-level DOM traversal
is now the exception, not the rule.

## Verification

```
$ pnpm lint && pnpm typecheck       → ✓
$ bash scripts/db-reset.sh
$ npx playwright test specs/17-web-homepage.spec.ts
  8 passed (6.7s)  # includes axe gate + @mobile test
$ pnpm test:e2e                     → 125 passed (1.4m)
```

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] Spec 17 isolated: 8/8 (6.7s, includes axe gate + @mobile)
- [x] Full suite: 125/125 (desktop + mobile projects)
- [x] Zero direct DOM calls in spec 17 against home surface
      (one remaining call targets navbar chrome, out of scope)
- [x] @mobile test continues to pass (globalFeedTab tap-target
      floor, preview-width reflow, navbar-brand visibility)
- [x] POP composes with FavoriteButton POP from #99:
      `HomePage.previewCardFor(slug)` uses the same selector
- [ ] CI green on this PR
