### PR TITLE
feat(web): dynamic OG + Twitter metadata on article + profile (#113)

### DIFF
--- a/apps/web/src/app/article/[slug]/not-found.tsx
+++ b/apps/web/src/app/article/[slug]/not-found.tsx
@@ -1,4 +1,14 @@
+import type { Metadata } from "next";
 import Link from "next/link";
+
+// Static fallback metadata for the 404 boundary. The page-level
+// generateMetadata returns a non-article title when getArticle
+// resolves null, but if Next reaches this not-found boundary
+// directly the metadata below keeps the crawler from indexing a
+// stale article preview (#113 AC scenario 4).
+export const metadata: Metadata = {
+  title: "Article not found — Conduit",
+};
 
 export default function NotFound() {
   return (

--- a/apps/web/src/app/article/[slug]/page.tsx
+++ b/apps/web/src/app/article/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArticleBody } from "@/components/article/ArticleBody";
@@ -13,8 +14,50 @@ import {
   isAuthenticated,
   readCurrentUsername,
 } from "@/features/auth/session";
+import { siteUrl } from "@/lib/site";
 
-export const metadata = { title: "Article — Conduit" };
+// Dynamic share-preview metadata (#113). When a link previewer
+// (Slack / Twitter / LinkedIn / Discord / iMessage) fetches the
+// article HTML, the OG + Twitter tags below drive the preview card
+// off the article's own title + description + author, not the
+// generic site chrome.
+//
+// 404 path: if the slug doesn't resolve, return a plain title with
+// no og:type=article so crawlers don't cache the 404 as a real
+// article preview (AC scenario 4).
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const article = await getArticle(slug);
+
+  if (!article) {
+    return { title: "Article not found — Conduit" };
+  }
+
+  const url = `${siteUrl()}/article/${encodeURIComponent(article.slug)}`;
+  const title = `${article.title} — Conduit`;
+
+  return {
+    title,
+    description: article.description,
+    openGraph: {
+      title: article.title,
+      description: article.description,
+      type: "article",
+      url,
+      ...(article.author.image ? { images: [article.author.image] } : {}),
+    },
+    twitter: {
+      card: "summary",
+      title: article.title,
+      description: article.description,
+      ...(article.author.image ? { images: [article.author.image] } : {}),
+    },
+  };
+}
 
 // Article detail page (#18). RSC: fetches article + comments + viewer
 // state in parallel, renders banner + meta + body + tag list + comments

--- a/apps/web/src/app/profile/[username]/not-found.tsx
+++ b/apps/web/src/app/profile/[username]/not-found.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import Link from "next/link";
+
+// See article/[slug]/not-found.tsx for the rationale — same pattern,
+// applied to the profile 404 path (#113 AC scenario 4).
+export const metadata: Metadata = {
+  title: "Profile not found — Conduit",
+};
 
 export default function NotFound() {
   return (

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArticleList } from "@/components/article/ArticleList";
@@ -8,8 +9,48 @@ import {
   readCurrentUsername,
 } from "@/features/auth/session";
 import { getProfile } from "@/features/profiles/queries";
+import { siteUrl } from "@/lib/site";
 
-export const metadata = { title: "Profile — Conduit" };
+// Dynamic share-preview metadata (#113). See the article page's
+// generateMetadata for the broader rationale.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}): Promise<Metadata> {
+  const { username } = await params;
+  const profile = await getProfile(username);
+
+  if (!profile) {
+    return { title: "Profile not found — Conduit" };
+  }
+
+  // Fallback copy when the user hasn't written a bio — keeps the
+  // preview card informative instead of empty.
+  const description =
+    profile.bio && profile.bio.trim().length > 0
+      ? profile.bio
+      : `View ${profile.username}'s articles on Conduit`;
+  const url = `${siteUrl()}/profile/${encodeURIComponent(profile.username)}`;
+
+  return {
+    title: `${profile.username} — Conduit`,
+    description,
+    openGraph: {
+      title: profile.username,
+      description,
+      type: "profile",
+      url,
+      ...(profile.image ? { images: [profile.image] } : {}),
+    },
+    twitter: {
+      card: "summary",
+      title: profile.username,
+      description,
+      ...(profile.image ? { images: [profile.image] } : {}),
+    },
+  };
+}
 
 const PAGE_SIZE = 20;
 

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -1,0 +1,11 @@
+// Canonical site origin — used by generateMetadata (#113) for the
+// og:url tag. Reads NEXT_PUBLIC_SITE_URL at runtime; defaults to
+// localhost so dev works out of the box.
+//
+// Trailing slashes are stripped so callers can consistently
+// `${siteUrl()}/article/${slug}` without risking a double-slash
+// between origin + path.
+export const siteUrl = (): string => {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+  return raw.replace(/\/+$/, "");
+};

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       PORT: ${WEB_PORT:-3000}
       API_URL: ${API_URL_INTERNAL:-http://api:3001}
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3000}
     ports:
       - "${WEB_HOST_PORT:-3000}:3000"
     healthcheck:

--- a/tests/e2e/specs/113-web-og-metadata.spec.ts
+++ b/tests/e2e/specs/113-web-og-metadata.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #113: dynamic OG + Twitter metadata on the
+// article + profile pages. The crawler experience is what we're
+// testing — asserts on rendered <head> tags, not on interactive
+// behaviour, so no fixture auth needed.
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Read a meta tag's content attribute by selector. Returns `null` when
+// the tag is absent — lets Scenario 4 assert absence directly.
+const readMeta = async (
+  page: import("@playwright/test").Page,
+  selector: string,
+): Promise<string | null> => {
+  const tag = page.locator(selector);
+  if ((await tag.count()) === 0) return null;
+  return tag.getAttribute("content");
+};
+
+test.describe("issue #113 — dynamic OG + Twitter metadata", () => {
+  test("Scenario 1+2: article page emits dynamic title + OG + Twitter", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const api = await ArticlesApi.newContext();
+    const jake = `jake-${id}`;
+    await api.registerUser(jake);
+    const article = await api.createArticle({
+      title: `Structural editing ${id}`,
+      description: "A pattern for working with AST-shaped data",
+      body: "Body text",
+    });
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+
+    // Scenario 1: title + description computed from the article.
+    await expect(page).toHaveTitle(`Structural editing ${id} — Conduit`);
+    expect(await readMeta(page, 'meta[name="description"]')).toBe(
+      "A pattern for working with AST-shaped data",
+    );
+
+    // Scenario 2: OG + Twitter tags.
+    expect(await readMeta(page, 'meta[property="og:title"]')).toBe(
+      `Structural editing ${id}`,
+    );
+    expect(await readMeta(page, 'meta[property="og:description"]')).toBe(
+      "A pattern for working with AST-shaped data",
+    );
+    expect(await readMeta(page, 'meta[property="og:type"]')).toBe("article");
+
+    const ogUrl = await readMeta(page, 'meta[property="og:url"]');
+    expect(ogUrl).toBeTruthy();
+    expect(ogUrl).toContain(`/article/${article.slug}`);
+
+    expect(await readMeta(page, 'meta[name="twitter:card"]')).toBe("summary");
+  });
+
+  test("Scenario 3: profile page emits dynamic title + og:type=profile", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const api = await ArticlesApi.newContext();
+    const jake = `jake-${id}`;
+    await api.registerUser(jake);
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+
+    await expect(page).toHaveTitle(`${jake} — Conduit`);
+
+    // Fresh user has null bio → fallback copy.
+    const description = await readMeta(page, 'meta[name="description"]');
+    expect(description).toBe(`View ${jake}'s articles on Conduit`);
+
+    expect(await readMeta(page, 'meta[property="og:type"]')).toBe("profile");
+    expect(await readMeta(page, 'meta[property="og:title"]')).toBe(jake);
+
+    const ogUrl = await readMeta(page, 'meta[property="og:url"]');
+    expect(ogUrl).toBeTruthy();
+    expect(ogUrl).toContain(`/profile/${jake}`);
+  });
+
+  test("Scenario 4: 404 article page does not emit og:type=article", async ({
+    page,
+  }) => {
+    // A slug no article can have — the generateMetadata path returns
+    // the generic title, then notFound() renders the 404 boundary.
+    const res = await page.goto(`${WEB_URL}/article/no-such-slug-${uniq()}`);
+    expect(res?.status()).toBe(404);
+
+    // Title is the generic 404 copy — neither the stale slug nor a
+    // previous article's title should leak through.
+    const title = await page.title();
+    expect(title).toContain("not found");
+    expect(title).not.toContain("Structural editing");
+
+    // og:type=article absent. A previewer that does index this URL
+    // should treat it as a plain page, not an article.
+    const ogType = await readMeta(page, 'meta[property="og:type"]');
+    expect(ogType).not.toBe("article");
+  });
+});


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #113.

## User Intent

When a Conduit article or profile link is shared on Slack / Twitter /
LinkedIn / Discord / iMessage, the preview card now renders the
article's real title + description (and author avatar if present),
or the user's name + bio, instead of the generic "Conduit" chrome
that every link shared today in the wild is stuck with. Top-10%
RealWorld implementations treat OG metadata as a first-class concern
because it multiplies organic discovery.

## What ships

### Page-level `generateMetadata`

- **`apps/web/src/app/article/[slug]/page.tsx`** — drop the
  hard-coded `export const metadata`, replace with
  `generateMetadata({ params })`:
  ```ts
  const article = await getArticle(slug);
  if (!article) return { title: "Article not found — Conduit" };
  return {
    title: `${article.title} — Conduit`,
    description: article.description,
    openGraph: {
      title: article.title,
      description: article.description,
      type: "article",
      url: `${siteUrl()}/article/${encodeURIComponent(article.slug)}`,
      ...(article.author.image ? { images: [article.author.image] } : {}),
    },
    twitter: {
      card: "summary",
      title: article.title,
      description: article.description,
      ...(article.author.image ? { images: [article.author.image] } : {}),
    },
  };
  ```
  When `getArticle` returns `null` the metadata returns the generic
  404 title with **no** `og:type=article` — satisfies AC scenario 4
  (crawlers don't cache the 404 as a real article preview).

- **`apps/web/src/app/profile/[username]/page.tsx`** — same shape
  via `getProfile(username)`. `description` falls back to
  `View <user>'s articles on Conduit` when bio is null so the
  preview card stays informative. `og:type=profile`.

### Not-found fallbacks

- **`apps/web/src/app/article/[slug]/not-found.tsx`** +
  **`apps/web/src/app/profile/[username]/not-found.tsx`** — export
  a static `metadata` with the generic title so if Next routes
  directly to the not-found boundary (bypassing `generateMetadata`),
  the page still carries safe chrome.

### `apps/web/src/lib/site.ts` — new

Tiny helper:
```ts
export const siteUrl = (): string => {
  const raw = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
  return raw.replace(/\/+$/, "");
};
```
Trailing slashes stripped so callers can consistently build
`${siteUrl()}/article/${slug}` without risking double-slashes.

### `infra/docker-compose.yml`

Added `NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3000}`
to the web service environment. `.env` carries the dev value
(`http://localhost:3100`, matching the compose host port).

### `tests/e2e/specs/113-web-og-metadata.spec.ts` — new

3 scenarios mapping 1:1 to the AC:

1. **Article page** — seeds a real article via `ArticlesApi` and
   asserts every tag: `<title>`, `meta[name=description]`, og:title,
   og:description, og:type, og:url (contains the slug), twitter:card.
2. **Profile page** — asserts `<title>`, fallback description,
   og:type=profile, og:url.
3. **404 article path** — response status 404, title contains
   "not found", og:type is not "article".

## Out of scope (deferred per planner)

- Dynamic `og:image` generation (rendering a branded card from
  article content) — different scope, file separately if pursued.
  We use the author's existing avatar URL when present.
- RSS feed / sitemap — different axis of discoverability.

## Verification

```
$ pnpm lint && pnpm typecheck        → ✓
$ bash scripts/db-reset.sh
$ npx playwright test specs/113-web-og-metadata.spec.ts
  3 passed (2.1s)
$ pnpm test:e2e                      → 128 passed (1.4m)
  # was 125 before; +3 new scenarios, no regression
```

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] Spec 113 isolated: 3/3
- [x] Full suite: 128/128 (125 prior + 3 new)
- [x] Article page: title, description, og:title/description/type/url,
      twitter:card all present + correct
- [x] Profile page: title, fallback description, og:type=profile,
      og:url contain the username
- [x] 404 path: `<title>` contains "not found", `og:type` !== "article"
- [x] `NEXT_PUBLIC_SITE_URL` env var forwarded by docker-compose
- [ ] CI green on this PR
