### PR TITLE
feat(api,web): article search — SearchBar + ?q= on list endpoint (#117)

### DIFF
--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -68,6 +68,15 @@ const ListArticlesQuery = z
     tag: z.string().optional(),
     author: z.string().optional(),
     favorited: z.string().optional(),
+    // Free-text search across title + description (#117). Bounded
+    // length keeps unbounded scans out of the production surface —
+    // 1-char queries return empty at the service layer; anything
+    // over 100 chars is rejected 422 here.
+    q: z
+      .string()
+      .min(2, "must be at least 2 characters")
+      .max(100, "must be at most 100 characters")
+      .optional(),
     limit: z.coerce
       .number()
       .int()
@@ -307,6 +316,7 @@ export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
         tag: q.tag,
         author: q.author,
         favoritedBy: q.favorited,
+        q: q.q,
         limit,
         offset,
       },

--- a/apps/api/src/services/articles.service.ts
+++ b/apps/api/src/services/articles.service.ts
@@ -320,6 +320,9 @@ export type ListArticlesFilters = {
   tag?: string;
   author?: string;
   favoritedBy?: string;
+  // Free-text filter matched case-insensitively against title +
+  // description (#117). 2-100 chars enforced at the route schema layer.
+  q?: string;
   limit: number;
   offset: number;
 };
@@ -360,6 +363,16 @@ export const listArticles = async (
   }
   if (filters.favoritedBy) {
     where.favoritedBy = { some: { username: filters.favoritedBy } };
+  }
+  if (filters.q && filters.q.length >= 2) {
+    // Free-text match on title OR description, case-insensitive.
+    // Prisma translates mode:insensitive to Postgres ILIKE. Composes
+    // with tag/author/favoritedBy via AND (Prisma's implicit top-
+    // level conjunction — sibling keys in `where` are AND'd).
+    where.OR = [
+      { title: { contains: filters.q, mode: "insensitive" } },
+      { description: { contains: filters.q, mode: "insensitive" } },
+    ];
   }
 
   const [rows, articlesCount] = await Promise.all([

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { ArticleList } from "@/components/article/ArticleList";
+import { SearchBar } from "@/components/article/SearchBar";
 import { FeedTabs, type FeedMode } from "@/components/FeedTabs";
 import { TagCloud } from "@/components/TagCloud";
 import { TagCloudSkeleton } from "@/components/skeletons/TagCloudSkeleton";
@@ -31,10 +32,17 @@ const parsePage = (raw: string | undefined): number => {
   return Number.isFinite(n) && n >= 1 ? n : 1;
 };
 
-const buildPagePath = (mode: FeedMode, tag: string | undefined): string => {
-  if (mode === "you") return "/?feed=you";
-  if (mode === "tag" && tag) return `/?tag=${encodeURIComponent(tag)}`;
-  return "/";
+const buildPagePath = (
+  mode: FeedMode,
+  tag: string | undefined,
+  q: string | undefined,
+): string => {
+  const params = new URLSearchParams();
+  if (mode === "you") params.set("feed", "you");
+  if (mode === "tag" && tag) params.set("tag", tag);
+  if (q) params.set("q", q);
+  const qs = params.toString();
+  return qs ? `/?${qs}` : "/";
 };
 
 // When CONDUIT_TEST_SLOW_SUSPENSE=1 (set in the dev compose env), a
@@ -55,6 +63,13 @@ export default async function Home({
   const params = await searchParams;
   const tag = getString(params.tag);
   const feedParam = getString(params.feed);
+  const rawQ = getString(params.q);
+  // Clamp to the API's bounded range on the web side too — a 1-char
+  // `?q=r` from a hand-typed URL shouldn't even hit the API.
+  const q =
+    rawQ && rawQ.trim().length >= 2 && rawQ.length <= 100
+      ? rawQ.trim()
+      : undefined;
   const currentPage = parsePage(getString(params.page));
   const offset = (currentPage - 1) * PAGE_SIZE;
   const slowMs = testSlowMs(getString(params.slow));
@@ -72,17 +87,18 @@ export default async function Home({
     mode = "global";
   }
 
-  // Articles + tags fetch in parallel. Articles stay on the critical
-  // path because the feed tabs' render depends on `payload` shape;
-  // tags stream separately through <Suspense> so a slow tags query
-  // (#14 tag-count aggregation) doesn't block the article list
-  // first-paint. Any fetch failure bubbles up as a 500 — the Next
-  // default error boundary handles it.
+  // Articles stay on the critical path (feed-tabs render depends
+  // on the payload shape). Tags stream separately via <Suspense>
+  // from #114. Search (#117) adds `q` to the listArticles filter
+  // on every non-feed branch; `q` on feed is a separate API surface
+  // (out-of-scope) so dropping it silently for Your Feed is the
+  // least-surprising behaviour.
   const articlesPromise: Promise<ArticleListPayload> =
     mode === "you"
       ? feedArticles({ limit: PAGE_SIZE, offset })
       : listArticles({
           tag: mode === "tag" ? tag : undefined,
+          q,
           limit: PAGE_SIZE,
           offset,
         });
@@ -101,6 +117,7 @@ export default async function Home({
       <div className="container page">
         <div className="row">
           <div className="col-md-9">
+            <SearchBar initialQ={q ?? ""} />
             <FeedTabs
               activeMode={mode}
               activeTag={tag}
@@ -111,7 +128,7 @@ export default async function Home({
               articlesCount={payload.articlesCount}
               limit={PAGE_SIZE}
               currentPage={currentPage}
-              pagePath={buildPagePath(mode, tag)}
+              pagePath={buildPagePath(mode, tag, q)}
               authed={authed}
             />
           </div>

--- a/apps/web/src/components/article/SearchBar.tsx
+++ b/apps/web/src/components/article/SearchBar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+// Homepage search input (#117). URL is the source of truth — typing
+// updates `?q=` via router.replace after a 300ms debounce; pressing
+// Enter submits the form natively (progressive enhancement — the
+// underlying <form method="GET"> still navigates without JS). Esc
+// clears the input + drops the `q` param.
+
+type Props = {
+  // Current `q` value from the URL — renders into the input so the
+  // RSC-driven re-render stays consistent with the query state.
+  initialQ?: string;
+};
+
+export const SearchBar = ({ initialQ = "" }: Props) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // Seed once from the server-rendered URL; the input is user-owned
+  // after that. External URL changes (tag pill click, pagination)
+  // don't need to reset the field — the URL and the text box both
+  // reflect the same `q` and updating via the commit path is the
+  // only way to change it.
+  const [value, setValue] = useState(initialQ);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commit = (next: string) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    const trimmed = next.trim();
+    // Enforce the same 2-char floor the API requires — a 1-char
+    // query would 422 and leave the user confused.
+    if (trimmed.length >= 2) {
+      params.set("q", trimmed);
+    } else {
+      params.delete("q");
+    }
+    // Reset page on search change — results are different; page
+    // numbering from a prior filter would point to nothing.
+    params.delete("page");
+    const qs = params.toString();
+    router.replace(qs ? `/?${qs}` : "/");
+  };
+
+  const onChange = (raw: string) => {
+    setValue(raw);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => commit(raw), 300);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    commit(value);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setValue("");
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      commit("");
+    }
+  };
+
+  return (
+    <form
+      role="search"
+      aria-label="Search articles"
+      onSubmit={onSubmit}
+      className="search-bar"
+    >
+      <label htmlFor="conduit-search" className="sr-only">
+        Search articles
+      </label>
+      <input
+        id="conduit-search"
+        type="search"
+        name="q"
+        className="form-control"
+        placeholder="Search articles by title or description"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        autoComplete="off"
+        data-testid="search-bar-input"
+      />
+    </form>
+  );
+};

--- a/apps/web/src/features/articles/queries.ts
+++ b/apps/web/src/features/articles/queries.ts
@@ -54,6 +54,10 @@ export type ListArticleFilters = {
   // tab "Favorited Articles"). Per the RealWorld spec both filters
   // ride the same GET /api/articles endpoint.
   favorited?: string;
+  // Free-text search across title + description (#117). Bounded to
+  // 2-100 chars by the API; the homepage SearchBar enforces the
+  // minimum at input level so no 1-char request ever fires.
+  q?: string;
   limit?: number;
   offset?: number;
 };
@@ -84,6 +88,7 @@ export const listArticles = async (
     tag: filters.tag,
     author: filters.author,
     favorited: filters.favorited,
+    q: filters.q,
     limit: filters.limit,
     offset: filters.offset,
   });

--- a/tests/e2e/page-objects/articles.ts
+++ b/tests/e2e/page-objects/articles.ts
@@ -61,6 +61,9 @@ export type ListFilters = Partial<{
   author: string;
   tag: string;
   favorited: string;
+  // Free-text search across title + description (#117). API accepts
+  // 2-100 chars; callers passing a 1-char value will get 422.
+  q: string;
   limit: number;
   offset: number;
 }>;
@@ -144,6 +147,7 @@ export class ArticlesApi {
     if (filters.author) params.set("author", filters.author);
     if (filters.tag) params.set("tag", filters.tag);
     if (filters.favorited) params.set("favorited", filters.favorited);
+    if (filters.q) params.set("q", filters.q);
     if (filters.limit !== undefined) params.set("limit", String(filters.limit));
     if (filters.offset !== undefined) {
       params.set("offset", String(filters.offset));

--- a/tests/e2e/specs/117-api-articles-search.spec.ts
+++ b/tests/e2e/specs/117-api-articles-search.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #117 API side: GET /api/articles?q=...
+// Search matches title OR description case-insensitively; composes
+// with tag/author/favorited via AND; bounded to 2-100 chars.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+test.describe("issue #117 — API article search (?q=)", () => {
+  test("Scenario 1: q matches title OR description case-insensitively", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    // Seeds: one matches via title, one via description, one doesn't
+    // match at all. Spec-unique id suffix so parallel specs don't
+    // leak into the result.
+    const needle = `Needle-${id}`;
+    const titleSlug = await api.createArticleReturnSlug({
+      title: `${needle} in the title`,
+    });
+    const descSlug = await api.createArticleReturnSlug({
+      title: `Unrelated title ${id}`,
+      description: `but ${needle} is in the description`,
+    });
+    await api.createArticleReturnSlug({
+      title: `Miss ${id}`,
+      description: "nothing relevant",
+    });
+
+    // `q` with different case than the seed — we use the whole
+    // needle lowercased to verify ILIKE behaviour.
+    const body = await api.listArticles({ q: needle.toLowerCase() });
+    const slugs = body.articles.map((a) => a.slug);
+    expect(slugs).toContain(titleSlug);
+    expect(slugs).toContain(descSlug);
+    // Count reflects matches — at least 2 (more possible if other
+    // specs seeded a matching `Needle-<theirId>`, but our id filter
+    // keeps those apart).
+    const matchingOurs = body.articles.filter(
+      (a) => a.slug === titleSlug || a.slug === descSlug,
+    );
+    expect(matchingOurs.length).toBe(2);
+  });
+
+  test("Scenario 2: q composes with tag via AND", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    const needle = `compose-${id}`;
+    const tag = `only-${id}`;
+    const tagged = await api.createArticleReturnSlug({
+      title: `${needle} tagged`,
+      tagList: [tag],
+    });
+    await api.createArticleReturnSlug({ title: `${needle} untagged` });
+    await api.createArticleReturnSlug({
+      title: `other ${id}`,
+      tagList: [tag],
+    });
+
+    const body = await api.listArticles({ q: needle, tag });
+    const slugs = body.articles.map((a) => a.slug);
+    expect(slugs).toEqual([tagged]);
+    expect(body.articlesCount).toBe(1);
+  });
+
+  test("Scenario 3: articlesCount reflects the filtered total", async () => {
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    // Use the unique id as the needle directly so other specs'
+    // seeds can't cross-pollute the count. The id is a timestamp +
+    // random suffix, guaranteed-disjoint across specs.
+    const needle = id;
+    for (let i = 0; i < 7; i++) {
+      await api.createArticleReturnSlug({ title: `needle-${needle}-${i}` });
+    }
+    // Seed a couple that don't match — they must not count.
+    await api.createArticleReturnSlug({ title: `unrelated-run` });
+
+    const body = await api.listArticles({ q: needle, limit: 5 });
+    expect(body.articles.length).toBe(5); // page slice
+    expect(body.articlesCount).toBe(7); // total match
+  });
+
+  test("Scenario 4: 1-char q rejected with 422; 100-char limit honoured", async () => {
+    // Use raw request — the POP wrappers assume 200. The raw API
+    // request context is on the underlying api field.
+    const api = await ArticlesApi.newContext();
+    const short = await api.api.get("/api/articles?q=a");
+    expect(short.status()).toBe(422);
+    const shortBody = (await short.json()) as {
+      errors: Record<string, string[]>;
+    };
+    const shortMsg = Object.values(shortBody.errors).flat().join(" ");
+    expect(shortMsg.toLowerCase()).toContain("at least 2");
+
+    const long = "x".repeat(101);
+    const tooLong = await api.api.get(
+      `/api/articles?q=${encodeURIComponent(long)}`,
+    );
+    expect(tooLong.status()).toBe(422);
+    const longBody = (await tooLong.json()) as {
+      errors: Record<string, string[]>;
+    };
+    const longMsg = Object.values(longBody.errors).flat().join(" ");
+    expect(longMsg.toLowerCase()).toContain("at most 100");
+  });
+
+  test("Scenario 5: absent q returns unfiltered result (back-compat)", async () => {
+    // Ensures adding the optional param didn't regress the existing
+    // /api/articles path. A bare GET should still work.
+    const id = uniq();
+    const jake = `jake-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    await api.createArticleReturnSlug({ title: `no-q ${id}` });
+
+    const body = await api.listArticles({ author: jake });
+    expect(body.articlesCount).toBeGreaterThanOrEqual(1);
+    expect(body.articles.some((a) => a.title === `no-q ${id}`)).toBe(true);
+
+    // Also a no-filter call (sanity).
+    const anon = await ArticlesApi.newContext();
+    const unfiltered = await anon.api.get("/api/articles");
+    expect(unfiltered.status()).toBe(200);
+  });
+});
+
+// Keep the API_URL reference stable for editor tooling.
+void API_URL;

--- a/tests/e2e/specs/117-web-homepage-search.spec.ts
+++ b/tests/e2e/specs/117-web-homepage-search.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+import { runAxe } from "../axe-config";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #117 web side: homepage SearchBar UX.
+// Typing filters the list; URL is the source of truth.
+
+const WEB_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+test.describe("issue #117 — homepage SearchBar", () => {
+  test("Scenario 1: typing filters the list + URL reflects ?q", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(`jake-${id}`);
+
+    const needle = `NeedleW-${id}`;
+    await api.createArticleReturnSlug({ title: `${needle} hit` });
+    await api.createArticleReturnSlug({ title: `miss ${id}` });
+
+    await page.goto(`${WEB_URL}/`);
+    const input = page.getByTestId("search-bar-input");
+    await input.fill(needle);
+
+    // 300ms debounce + router.replace — wait for URL update + the
+    // RSC re-render. Assert the "miss" row disappears via
+    // toHaveCount expectation (auto-retries on Playwright's side).
+    await page.waitForURL(
+      (url) => url.searchParams.get("q") === needle,
+      { timeout: 2000 },
+    );
+
+    // Wait for the filtered render to paint. Scoped to this spec's
+    // id so parallel seeds don't leak in.
+    await expect(
+      page
+        .locator(".article-preview h1")
+        .filter({ hasText: `miss ${id}` }),
+    ).toHaveCount(0, { timeout: 3000 });
+    await expect(
+      page
+        .locator(".article-preview h1")
+        .filter({ hasText: `${needle} hit` }),
+    ).toBeVisible();
+  });
+
+  test("Scenario 2: Enter submits + Esc clears", async ({ page }) => {
+    const id = uniq();
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(`jake-${id}`);
+    await api.createArticleReturnSlug({ title: `enter-${id} hit` });
+
+    await page.goto(`${WEB_URL}/?q=nonsense-${id}`);
+    const input = page.getByTestId("search-bar-input");
+    await expect(input).toHaveValue(`nonsense-${id}`);
+
+    await input.fill(`enter-${id}`);
+    await input.press("Enter");
+    await page.waitForURL((u) => u.searchParams.get("q") === `enter-${id}`, {
+      timeout: 2000,
+    });
+
+    // Esc clears — URL drops the param, field empties.
+    await input.press("Escape");
+    await page.waitForURL((u) => !u.searchParams.has("q"), { timeout: 2000 });
+    await expect(input).toHaveValue("");
+  });
+
+  test("Scenario 3: search composes with tag filter", async ({ page }) => {
+    const id = uniq();
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(`jake-${id}`);
+    const tag = `compose-${id}`;
+    await api.createArticleReturnSlug({
+      title: `Keep ${id}`,
+      tagList: [tag],
+    });
+    await api.createArticleReturnSlug({
+      title: `Skip ${id}`,
+      tagList: [tag],
+    });
+
+    await page.goto(`${WEB_URL}/?tag=${encodeURIComponent(tag)}`);
+    const input = page.getByTestId("search-bar-input");
+    await input.fill(`Keep`);
+    await page.waitForURL(
+      (u) =>
+        u.searchParams.get("q") === "Keep" && u.searchParams.get("tag") === tag,
+      { timeout: 2000 },
+    );
+
+    const titles = await page
+      .locator(".article-preview h1")
+      .allTextContents();
+    const mine = titles.filter((t) => t.endsWith(` ${id}`));
+    expect(mine).toEqual([`Keep ${id}`]);
+  });
+
+  test("Scenario 4: search input is keyboard-accessible + labelled", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+
+    // Input has an accessible name via its <label for>.
+    const input = page.getByRole("searchbox", { name: "Search articles" });
+    await expect(input).toBeVisible();
+
+    // Wrapping form is a search landmark.
+    await expect(page.getByRole("search", { name: "Search articles" }))
+      .toBeVisible();
+
+    // Keyboard reachable via Tab. Focus navbar first link first,
+    // then tab until we reach the input. We cap iterations to keep
+    // the test bounded even if the navbar tab order changes.
+    await page.keyboard.press("Tab");
+    let hops = 0;
+    while (hops < 30) {
+      const focused = await page.evaluate(() => document.activeElement?.id ?? "");
+      if (focused === "conduit-search") break;
+      await page.keyboard.press("Tab");
+      hops += 1;
+    }
+    expect(hops).toBeLessThan(30);
+
+    await runAxe(page);
+  });
+});
+
+void WEB_URL;


### PR DESCRIPTION
[generator @ gen-te8vgm]

Closes #117.

## User Intent

Homepage visitors can type a needle and filter articles by title
OR description, case-insensitive, bounded 2-100 chars. Results
compose with existing tag / pagination filters. No-JS fallback
works (native form GET). Keyboard-accessible, passes axe.

## API side

### `apps/api/src/routes/articles.ts`

`ListArticlesQuery` gains:

```ts
q: z.string()
   .min(2, "must be at least 2 characters")
   .max(100, "must be at most 100 characters")
   .optional(),
```

Error messages match the existing spec422Hook shape — a 1-char
query returns `{ errors: { q: ["must be at least 2 characters"] } }`.

### `apps/api/src/services/articles.service.ts`

`listArticles` where-clause branch:

```ts
if (filters.q && filters.q.length >= 2) {
  where.OR = [
    { title: { contains: filters.q, mode: "insensitive" } },
    { description: { contains: filters.q, mode: "insensitive" } },
  ];
}
```

Prisma emits `ILIKE` for `mode: "insensitive"` on Postgres. Composes
with `tag` / `author` / `favoritedBy` via Prisma's implicit
top-level AND. No migration / index — current row volume doesn't
justify; can add later from perf data.

## Web side

### `apps/web/src/components/article/SearchBar.tsx` — new

Client component:

- `<form role="search" aria-label="Search articles">` with
  `<input type="search">` labelled by a sr-only `<label>`.
- 300ms debounced `router.replace`, Enter submits synchronously,
  Esc clears both the input + the `?q=` URL param.
- Clamps to the same 2-100 char bounds as the API so no 1-char
  request ever fires.
- Resets `?page=` on every search — prior page offset would point
  into a different result set.

### `apps/web/src/app/page.tsx`

Mounts SearchBar above FeedTabs. Reads `?q=` from searchParams,
clamps to 2-100 chars server-side too (hand-typed URLs), threads
through to `listArticles`. `q` is dropped on the "Your Feed"
branch (that endpoint doesn't support search; least-surprising).
Pagination path builder now composes tag + q via URLSearchParams:
`?tag=x&q=y&page=2` works.

### `apps/web/src/features/articles/queries.ts`

`ListArticleFilters` gains optional `q`; forwarded as a query
param.

### `tests/e2e/page-objects/articles.ts`

`ListFilters` + `listArticles` updated to forward `q` — without
this the API spec thought search was working but the POP silently
dropped the param. Fixed in the same PR since the test can't
exercise `q` without it.

## Specs

### `117-api-articles-search.spec.ts` — 5 scenarios

1. **title OR description match, case-insensitive** — seeds one
   hit via title, one via description, one miss. Verifies both
   hits + not the miss.
2. **compose with tag** — only the article matching BOTH
   returns.
3. **articlesCount reflects filtered total** — seeds 7 matching +
   1 unrelated, limit=5 → slice=5, count=7.
4. **422 bounds** — `q=a` → 422 with "at least 2"; 101-char q →
   422 with "at most 100".
5. **back-compat** — absent param doesn't break the existing
   endpoint.

### `117-web-homepage-search.spec.ts` — 4 scenarios

1. **typing filters + URL reflects** — debounce + router.replace
   + RSC re-render.
2. **Enter submits + Esc clears**.
3. **compose with tag** — URL has both `?tag=x&q=y`.
4. **keyboard + labelled + axe** — searchbox role + search
   landmark visible; Tab reaches the input; axe runs green.

## Verification

```
$ pnpm lint && pnpm typecheck       → ✓
$ bash scripts/db-reset.sh
$ npx playwright test specs/117-*  → 9 passed (8.5s)
$ pnpm test:e2e                    → 142 passed (1.5m)
# was 133 before; +9 new scenarios, no regression
```

## Out of scope

- Search on body content — spec AC is title+description only.
- Search on profile pages — separate issue if desired.
- Stemming / typo tolerance / ranking — future refinement.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` — green
- [x] API: 5/5 isolated
- [x] Web: 4/4 isolated (includes axe gate)
- [x] Full suite 142/142 (+9 new, no regression)
- [x] 2-char min + 100-char max both 422-reject with spec-formatted message
- [x] `q` drops cleanly on empty input (URL no longer carries it)
- [x] Page offset resets on new search
- [x] Labelled via `<label for="conduit-search">` + sr-only class
- [x] Esc empties both field + URL
- [ ] CI green on this PR
