### PR TITLE
feat(api): body-size limits — 413 before parse on mutating endpoints (#126)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import type { Context } from "hono";
 import type { ZodIssue } from "zod";
+import { globalBodyLimit } from "./middleware/body-limit.js";
 import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/error.js";
 import { requestLogger } from "./middleware/logger.js";
@@ -48,6 +49,12 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
   app.use("*", requestId());
   app.use("*", requestLogger());
   app.use("*", corsMiddleware());
+  // Global body-size cap (#126). DoS shield — rejects oversized
+  // bodies before they hit the zod validators or the DB layer. Runs
+  // after request-id + logger so the 413 carries a request id and is
+  // traceable in logs. GET / HEAD have no body; the underlying hono
+  // middleware short-circuits there.
+  app.use("*", globalBodyLimit());
 
   registerHealthzRoute(app);
   registerAuthRoutes(app);

--- a/apps/api/src/middleware/body-limit.ts
+++ b/apps/api/src/middleware/body-limit.ts
@@ -1,0 +1,67 @@
+import { bodyLimit } from "hono/body-limit";
+import type { Context, MiddlewareHandler } from "hono";
+
+// Request body-size caps (#126). DoS shield for the API — a client
+// cannot make us allocate multi-megabyte buffers just by POSTing a
+// large body. Two tiers: a global cap applies to every mutating
+// endpoint, a smaller per-endpoint cap layers on top for article
+// create/update (the largest legitimate payloads, but still bounded).
+//
+// The 413 envelope matches the rest of the spec's error shape so
+// clients (Bruno conformance, Playwright, RealWorld reference UIs)
+// all parse errors the same way.
+
+const DEFAULT_GLOBAL_KB = 1024;
+const DEFAULT_ARTICLE_KB = 100;
+
+const parseKb = (env: string | undefined, fallback: number): number => {
+  const n = env ? Number.parseInt(env, 10) : Number.NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+export const globalBodyLimitKb = parseKb(
+  process.env.API_BODY_LIMIT_GLOBAL_KB,
+  DEFAULT_GLOBAL_KB,
+);
+
+export const articleBodyLimitKb = parseKb(
+  process.env.API_BODY_LIMIT_ARTICLE_KB,
+  DEFAULT_ARTICLE_KB,
+);
+
+const tooLargeEnvelope = (limitKb: number) => ({
+  errors: { body: [`payload too large, max ${limitKb}KB`] },
+});
+
+// Rejecting an oversized request before the body is consumed leaves
+// the rest of the upload bytes buffered on a keep-alive socket. The
+// next request on the same connection then gets mis-framed (Node's
+// HTTP parser treats the leftover bytes as the start of a new
+// request). Playwright/undici surfaces this as `socket hang up`;
+// curl without keep-alive dodges it because the connection closes
+// anyway. Set `Connection: close` on the 413 so the client (and the
+// server's own HTTP parser) tears down the socket cleanly after the
+// response flushes.
+const tooLargeResponse = (c: Context, limitKb: number) => {
+  c.header("Connection", "close");
+  return c.json(tooLargeEnvelope(limitKb), 413);
+};
+
+// Global cap — wired at app.use("*", …). Applies to every request
+// with a body; GETs have no body so the hono/body-limit middleware
+// short-circuits before doing any work.
+export const globalBodyLimit = (): MiddlewareHandler =>
+  bodyLimit({
+    maxSize: globalBodyLimitKb * 1024,
+    onError: (c) => tooLargeResponse(c, globalBodyLimitKb),
+  });
+
+// Per-endpoint cap for article create/update. Article `body` is
+// Markdown prose — 100 KB is roughly 50 pages of text, which is an
+// order of magnitude above realistic long-form writing. Anything
+// bigger is either a mistake or abuse.
+export const articleBodyLimit = (): MiddlewareHandler =>
+  bodyLimit({
+    maxSize: articleBodyLimitKb * 1024,
+    onError: (c) => tooLargeResponse(c, articleBodyLimitKb),
+  });

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -14,6 +14,7 @@ import {
   updateArticle,
 } from "../services/articles.service.js";
 import { optionalAuth, requireAuth, type UserVars } from "../middleware/jwt-cookie.js";
+import { articleBodyLimit } from "../middleware/body-limit.js";
 import { rateLimit } from "../middleware/rate-limit.js";
 import { ErrorResponseSchema } from "../schemas/user.js";
 import {
@@ -326,6 +327,13 @@ export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
     return c.json(result, 200);
   });
 
+  // Per-endpoint body-size cap (#126) on POST — article body is the
+  // largest legitimate payload and still has an obvious ceiling
+  // (API_BODY_LIMIT_ARTICLE_KB, default 100KB). Registered before
+  // the rate-limit middleware so an oversized request short-circuits
+  // with 413 without consuming from the write bucket.
+  authed.use(createArticleRoute.getRoutingPath(), articleBodyLimit());
+
   // Article-write throttle (#116) — per-user, covers POST on the
   // collection path.
   authed.use(
@@ -377,6 +385,12 @@ export const registerArticleRoutes = (app: OpenAPIHono<AppEnv>): void => {
   //
   // Rate-limit middleware uses the same trick: `methods: [PUT, DELETE]`
   // so anonymous + authed GETs pass untouched.
+  // Per-endpoint body-size cap (#126) on PUT only — DELETE has no
+  // body so it's a no-op there; hono/body-limit short-circuits when
+  // c.req.raw.body is null. Kept on the same path so PUT /slug is
+  // bounded identically to POST /articles.
+  authed.use(updateArticleRoute.getRoutingPath(), articleBodyLimit());
+
   authed.use(
     updateArticleRoute.getRoutingPath(),
     rateLimit({

--- a/docs/adr/001-initial-architecture.md
+++ b/docs/adr/001-initial-architecture.md
@@ -143,3 +143,11 @@ process env; nothing hardcoded in `src/`. Portability checklist
 - **UI surface**: `GET /api/docs` renders Scalar (`@scalar/hono-api-reference`) — modern, lightweight Vue-based reference page. Chosen over Swagger UI for bundle size + default UX; swappable via the route handler.
 - **Drift gate**: `pnpm openapi:emit` writes `docs/openapi-snapshot.json`. CI's `openapi-drift` job runs the emit and `git diff --exit-code`s the snapshot; a schema change without a refresh fails the PR. Generator refreshes the snapshot in the same PR as the route change.
 - **A11y carve-out**: Scalar's vendor Vue DOM surfaces a handful of critical + serious axe violations (sidebar aria-allowed-attr, button-name on collapse toggles, contrast inside syntax-highlighted code blocks). We don't own that DOM — the spec 123 scenario-4 axe gate was dropped to a structural assertion (`/api/docs` reachable + references the JSON spec). Follow-up: file a vendor-upgrade or swap-UI issue once Scalar ships an a11y-conformant build.
+
+## Addendum — Request body-size limits (2026-04-29, #126)
+
+- **Implementation**: `hono/body-limit` wrapped in `apps/api/src/middleware/body-limit.ts`. Two tiers so the DoS shield (global 1 MB) is independent from the business ceiling on article payloads (100 KB).
+- **Placement**: global cap wired at `app.use("*", …)` after request-id + logger so the 413 is traceable; per-endpoint cap on article routes registered *before* the rate-limit middleware so an oversized POST 413s without consuming the write bucket.
+- **Response shape**: `{ "errors": { "body": ["payload too large, max NKB"] } }` — same envelope as the spec-422 validator hook so clients have one error shape to parse. No `Retry-After` (413 is not transient).
+- **Env knobs**: `API_BODY_LIMIT_GLOBAL_KB` (default 1024), `API_BODY_LIMIT_ARTICLE_KB` (default 100). Defaults ship everywhere; no disable knob.
+- **Why not streaming uploads**: out of scope — this codebase has no binary upload path. If file attachments ever land, they get their own multipart middleware with its own ceiling.

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -1,4 +1,11 @@
-# Rate limiting (#116)
+# Rate + body-size limits (#116, #126)
+
+The API has two reliability primitives that run before any route
+handler: per-bucket rate limits (#116) and per-request body-size
+caps (#126). Both are DoS shields; together they bound the worst-
+case cost a misbehaving client can impose on the server.
+
+## Rate limiting (#116)
 
 Per-bucket fixed-window counter on every write endpoint. The goal is a
 reliability floor — a misbehaving client can't exhaust DB connections
@@ -97,3 +104,58 @@ rotate. A future cron can `DELETE FROM "RateLimit" WHERE "updatedAt"
 < NOW() - INTERVAL '1 day'`. Not wired yet — row volume is low
 enough that startup migration doesn't need to VACUUM. File an
 issue when volume suggests otherwise.
+
+## Body-size limits (#126)
+
+A client cannot make the API allocate multi-megabyte buffers just
+by posting a large body. Two tiers:
+
+| Scope | Env | Default | Applies to |
+|---|---|---|---|
+| Global floor | `API_BODY_LIMIT_GLOBAL_KB` | 1024 (1 MB) | Every mutating request (POST/PUT/PATCH/DELETE with body) |
+| Per-endpoint | `API_BODY_LIMIT_ARTICLE_KB` | 100 | `POST /api/articles`, `PUT /api/articles/:slug` |
+
+Implementation wraps `hono/body-limit`. See
+`apps/api/src/middleware/body-limit.ts`. The global cap is wired
+in `apps/api/src/app.ts` via `app.use("*", globalBodyLimit())`;
+the per-endpoint cap sits on the article create/update paths
+before the rate-limit middleware so an oversized request
+short-circuits with 413 without consuming from the write bucket.
+
+### 413 response shape
+
+```json
+{ "errors": { "body": ["payload too large, max 100KB"] } }
+```
+
+The `errors.body[0]` message echoes the effective cap in KB so
+clients can surface a useful error. Status is 413. No
+`Retry-After` — this isn't transient; the client needs to resend
+with a smaller body.
+
+### Why two tiers?
+
+- The 1 MB global floor catches the DoS axis — a drive-by that
+  posts `{"x": "A".repeat(20_000_000)}` to any endpoint is
+  rejected before Node allocates the string.
+- The 100 KB article cap is a business ceiling — article body is
+  the largest *legitimate* payload (long-form Markdown) and
+  100 KB ≈ 50 pages of prose is an order of magnitude above any
+  realistic post. Per-field zod caps (title.max(300),
+  body.max(50_000)) remain authoritative for validation errors
+  and surface as 422 with the usual envelope.
+
+### Interaction with rate limiting
+
+Body-limit runs before rate-limit on the article write routes.
+Consequence: an oversized POST returns 413 and does **not**
+consume from the write bucket. The ordering is deliberate — we
+want clients to fix their payload and retry immediately, not to
+also get rate-limited because their app is buggy.
+
+### Disable knob
+
+None. Body-limit is always on; the defaults are safe for dev,
+CI, and production. The env vars exist only for per-env tuning
+(e.g. bumping the article cap to 200 KB for a future long-form
+demo).

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -56,6 +56,12 @@ services:
       # Production compose sets RATE_LIMIT_ENABLED=1; spec 116
       # explicitly enables it via a separate test run in CI.
       RATE_LIMIT_ENABLED: ${RATE_LIMIT_ENABLED:-}
+      # Body-size caps (#126). Global floor applies to every mutating
+      # endpoint; the smaller article cap applies to POST /articles +
+      # PUT /articles/{slug}. Defaults (1024 / 100) are enforced by
+      # apps/api/src/middleware/body-limit.ts when these are unset.
+      API_BODY_LIMIT_GLOBAL_KB: ${API_BODY_LIMIT_GLOBAL_KB:-}
+      API_BODY_LIMIT_ARTICLE_KB: ${API_BODY_LIMIT_ARTICLE_KB:-}
     ports:
       - "${API_HOST_PORT:-3001}:3001"
     healthcheck:

--- a/tests/e2e/specs/126-api-body-limit.spec.ts
+++ b/tests/e2e/specs/126-api-body-limit.spec.ts
@@ -1,0 +1,172 @@
+import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #126 — API request body-size limits.
+//
+// Two-tier cap. The global cap (API_BODY_LIMIT_GLOBAL_KB, default
+// 1024) is a DoS shield on every mutating endpoint; the per-endpoint
+// cap (API_BODY_LIMIT_ARTICLE_KB, default 100) layers on for article
+// create/update where the legitimate payload is largest but still
+// bounded. Per-field zod caps (title.max(300), body.max(50_000)) still
+// surface as 422; those are business rules, not DoS shields.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Distinct synthetic IPs so this spec doesn't share rate-limit
+// buckets with any other spec running nearby. Even with rate-
+// limiting disabled in dev, the body-limit spec is safe to run
+// alongside the rest of the suite because each newContext gets its
+// own X-Forwarded-For.
+const fakeIp = (id: string) =>
+  `10.1.${(Number.parseInt(id.slice(-3), 10) || 0) % 250}.${(Number.parseInt(id.slice(-5, -3), 10) || 0) % 250}`;
+
+type BodyLimitResponse = {
+  status(): number;
+  json(): Promise<unknown>;
+};
+
+const assertBodyLimitEnvelope = async (
+  res: BodyLimitResponse,
+  expectedKb: number,
+) => {
+  expect(res.status()).toBe(413);
+  const body = (await res.json()) as { errors: Record<string, string[]> };
+  expect(body.errors.body?.[0] ?? "").toBe(
+    `payload too large, max ${expectedKb}KB`,
+  );
+};
+
+test.describe("issue #126 — API body-size limits", () => {
+  test("Scenario 1: oversized POST /api/articles body returns 413 with per-endpoint cap", async () => {
+    const id = uniq();
+    const jake = `bl-a-${id}`;
+    const api = await ArticlesApi.newContext(undefined, {
+      "X-Forwarded-For": fakeIp(id),
+    });
+    await api.registerUser(jake);
+
+    // Body > 500KB — well past the 100KB per-endpoint cap and also
+    // past the 50KB zod cap, but body-limit runs first so zod never
+    // sees it.
+    const oversized = "x".repeat(600 * 1024);
+    const res = await api.api.post("/api/articles", {
+      data: {
+        article: {
+          title: `bl-${id}`,
+          description: "d",
+          body: oversized,
+        },
+      },
+    });
+    await assertBodyLimitEnvelope(res, 100);
+  });
+
+  test("Scenario 2: global 1MB cap fires on a non-article mutating endpoint", async () => {
+    const id = uniq();
+    const jake = `bl-g-${id}`;
+    const api = await ArticlesApi.newContext(undefined, {
+      "X-Forwarded-For": fakeIp(id),
+    });
+    await api.registerUser(jake);
+
+    // PUT /api/user with a 1.5 MB bio. Zod would 422 on bio.max(2000)
+    // but the global cap rejects first. Article routes have the 100KB
+    // cap; user-update inherits only the 1MB global.
+    const giantBio = "y".repeat(1_500 * 1024);
+    const res = await api.api.put("/api/user", {
+      data: { user: { bio: giantBio } },
+    });
+    await assertBodyLimitEnvelope(res, 1024);
+  });
+
+  test("Scenario 3: per-field zod caps still produce 422 for requests under the body-size cap", async () => {
+    const id = uniq();
+    const jake = `bl-z-${id}`;
+    const api = await ArticlesApi.newContext(undefined, {
+      "X-Forwarded-For": fakeIp(id),
+    });
+    await api.registerUser(jake);
+
+    // 60KB body — under the 100KB per-endpoint cap, over the 50KB
+    // zod cap. Must surface as 422 on `body` (too_big), not 413.
+    const overZodButUnderLimit = "z".repeat(60 * 1024);
+    const res = await api.api.post("/api/articles", {
+      data: {
+        article: {
+          title: `bl-z-${id}`,
+          description: "d",
+          body: overZodButUnderLimit,
+        },
+      },
+    });
+    expect(res.status()).toBe(422);
+    const envelope = (await res.json()) as {
+      errors: Record<string, string[]>;
+    };
+    expect(envelope.errors.body).toBeTruthy();
+    expect(envelope.errors.body?.[0] ?? "").not.toBe(
+      "payload too large, max 100KB",
+    );
+  });
+
+  test("Scenario 4: GET reads are unaffected — no body, no 413", async () => {
+    const id = uniq();
+    const api = await request.newContext({
+      baseURL: API_URL,
+      extraHTTPHeaders: { "X-Forwarded-For": fakeIp(id) },
+    });
+
+    const list = await api.get("/api/articles?limit=5");
+    expect(list.status()).toBe(200);
+
+    const tags = await api.get("/api/tags");
+    expect(tags.status()).toBe(200);
+
+    const healthz = await api.get("/healthz");
+    expect(healthz.status()).toBe(200);
+  });
+
+  test("Scenario 5: normal-sized writes succeed — no regression", async () => {
+    const id = uniq();
+    const jake = `bl-ok-${id}`;
+    const api = await ArticlesApi.newContext(undefined, {
+      "X-Forwarded-For": fakeIp(id),
+    });
+    await api.registerUser(jake);
+
+    // 40 KB body — under every cap.
+    const normal = "n".repeat(40 * 1024);
+    const slug = await api.createArticleReturnSlug({
+      title: `bl-ok-${id}`,
+      body: normal,
+    });
+    expect(slug).toMatch(/^bl-ok-/);
+
+    // PUT on the same article with an equally normal-sized update.
+    const upd = await api.api.put(`/api/articles/${slug}`, {
+      data: { article: { body: "updated" } },
+    });
+    expect(upd.status()).toBe(200);
+  });
+
+  test("Scenario 6: PUT /api/articles/:slug enforces the same per-endpoint cap as POST", async () => {
+    const id = uniq();
+    const jake = `bl-p-${id}`;
+    const api = await ArticlesApi.newContext(undefined, {
+      "X-Forwarded-For": fakeIp(id),
+    });
+    await api.registerUser(jake);
+
+    const slug = await api.createArticleReturnSlug({ title: `bl-p-${id}` });
+    const oversized = "u".repeat(600 * 1024);
+    const res = await api.api.put(`/api/articles/${slug}`, {
+      data: { article: { body: oversized } },
+    });
+    await assertBodyLimitEnvelope(res, 100);
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #126

## User Intent

The API now rejects oversized request bodies with `413 Payload Too Large` before the handler runs, shielding it from a trivial DoS vector (a client POSTing a 50 MB article body would have tied up memory until GC; now it's bounced at middleware-level in microseconds). Reuse of an aborted keep-alive socket is also fixed so subsequent requests don't stall.

## Summary

- New `apps/api/src/middleware/body-limit.ts` wrapping `hono/body-limit`. Two tiers: global 1 MB cap (every mutating endpoint) + per-endpoint 100 KB cap on `POST /api/articles` + `PUT /api/articles/:slug`.
- 413 envelope matches spec-422 shape: `{ "errors": { "body": ["payload too large, max NKB"] } }`. Clients parse one error shape across 413/422.
- `Connection: close` header on the 413 — without it the next request on the same keep-alive socket gets mis-framed by the Node HTTP parser (Playwright/undici saw this as `socket hang up`). Curl dodged it because it closes anyway.
- Per-field zod caps (`body.max(50_000)`, `description.max(1000)`, `title.max(300)`) still return 422; the body-size cap is the DoS shield, not a validation rule.
- Envs: `API_BODY_LIMIT_GLOBAL_KB` (default 1024), `API_BODY_LIMIT_ARTICLE_KB` (default 100). Wired through `infra/docker-compose.yml`.
- `tests/e2e/specs/126-api-body-limit.spec.ts` — 6 scenarios from the AC.
- `docs/rate-limits.md` retitled to cover both rate + body-size; ADR 001 gains a `Request body-size limits` addendum.

## Evidence

**Local Playwright (spec 126 alone, serial + full suite)**

```
Running 6 tests using 1 worker
  ✓ Scenario 1: oversized POST /api/articles body returns 413 with per-endpoint cap
  ✓ Scenario 2: global 1MB cap fires on a non-article mutating endpoint
  ✓ Scenario 3: per-field zod caps still produce 422 for requests under the body-size cap
  ✓ Scenario 4: GET reads are unaffected — no body, no 413
  ✓ Scenario 5: normal-sized writes succeed — no regression
  ✓ Scenario 6: PUT /api/articles/:slug enforces the same per-endpoint cap as POST
  6 passed (1.5s)
```

**Local Playwright (full suite)** — 151/152 specs pass; the 1 intermittent failure is the pre-existing `14-api-tags-list.spec.ts Scenario 1` parallel-seed flake (#72-class), unrelated to this PR. Verified green in isolation.

**Bruno conformance** — 149/149 assertions passed, baseline 0/0 regressions.

```
│ Status        │      ✓ PASS      │
│ Requests      │ 149 (149 Passed) │
│ Assertions    │     149/149      │
```

**Typecheck + lint** — clean (`pnpm --filter @conduit/api typecheck lint`).

**OpenAPI drift** — snapshot unchanged (no new routes or response schemas surface through `@hono/zod-openapi`; body-limit is a pre-handler rejection, not a declared response).

**Portability check** — grep of the diff for hardcoded values:
- `localhost:[0-9]` → none in shipped code (only in existing spec helpers).
- absolute `/home/` paths → none.
- inline secrets → none.
- region / account literals → none.
- All env-dependent values routed through `API_BODY_LIMIT_GLOBAL_KB` / `API_BODY_LIMIT_ARTICLE_KB` with safe defaults.

## Notes for review

- Placement: global cap sits in `app.use("*", …)` **after** request-id + logger so every 413 carries a request id and is grep-able. Per-endpoint cap sits on the article routes **before** `rateLimit({...})` so an oversized POST 413s without consuming the write bucket — clients fix their payload and retry immediately instead of also getting 429'd.
- The `Connection: close` on 413 is load-bearing; if it gets dropped in a future refactor, expect flaky Playwright runs the moment two scenarios share a context. There's a comment in `body-limit.ts` explaining why.
