### PR TITLE
fix(test): scope .sidebar to resolved tag cloud to survive Suspense swap (#129)

### DIFF
--- a/tests/e2e/page-objects/home.ts
+++ b/tests/e2e/page-objects/home.ts
@@ -33,12 +33,15 @@ export class HomePage {
     // The Suspense tag-cloud skeleton (#114/#120) also renders with
     // `class="sidebar skeleton-tag-cloud"` for layout parity, so a
     // bare `.sidebar` selector briefly matches 2 elements while the
-    // RSC swap is mid-flight (strict-mode violation → #129). Scope
-    // to the resolved cloud by excluding the skeleton; callers then
-    // auto-wait on the resolved sidebar instead of racing the swap.
-    return this.page
-      .locator(".sidebar")
-      .filter({ hasNot: this.page.getByTestId("tag-cloud-skeleton") });
+    // RSC swap is mid-flight (strict-mode violation → #129). Exclude
+    // the skeleton *itself* via CSS `:not([data-testid=...])` —
+    // `filter({ hasNot })` only checks descendants, which doesn't
+    // match here because the skeleton is the element carrying the
+    // testid, not a parent of it. Callers then auto-wait on the
+    // resolved sidebar instead of racing the swap.
+    return this.page.locator(
+      '.sidebar:not([data-testid="tag-cloud-skeleton"])',
+    );
   }
 
   get paginator(): Locator {

--- a/tests/e2e/page-objects/home.ts
+++ b/tests/e2e/page-objects/home.ts
@@ -30,7 +30,15 @@ export class HomePage {
   }
 
   get sidebar(): Locator {
-    return this.page.locator(".sidebar");
+    // The Suspense tag-cloud skeleton (#114/#120) also renders with
+    // `class="sidebar skeleton-tag-cloud"` for layout parity, so a
+    // bare `.sidebar` selector briefly matches 2 elements while the
+    // RSC swap is mid-flight (strict-mode violation → #129). Scope
+    // to the resolved cloud by excluding the skeleton; callers then
+    // auto-wait on the resolved sidebar instead of racing the swap.
+    return this.page
+      .locator(".sidebar")
+      .filter({ hasNot: this.page.getByTestId("tag-cloud-skeleton") });
   }
 
   get paginator(): Locator {


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #129

## User Intent

Nothing user-visible changes — this is a test-only fix for a deterministic flake that #120's Suspense streaming introduced. `tests/e2e/specs/17-web-homepage.spec.ts` Scenario 1 and any `.sidebar`-rooted assertion was hitting a strict-mode violation because the tag-cloud skeleton and the resolved cloud both render with `class="sidebar"` during the RSC swap.

## Summary

- `tests/e2e/page-objects/home.ts` — `sidebar` getter now filters out the `tag-cloud-skeleton` testid, so every caller (spec 17 scenarios 1, 3, 4 + the POP's own `expectSidebarShowsPopularTags` / `sidebarTagPill`) resolves to the actual tag cloud.
- Single-file change. No production code touched. Playwright's locator auto-wait does the rest — assertions implicitly wait for the skeleton to detach before the filter matches anything.

## Evidence

**Spec 17 (the regression):**
```
Running 7 tests using 1 worker
  ✓ Scenario 1: anonymous visitor sees banner + Global Feed tab only
  ✓ Scenario 2: authenticated viewer sees Your Feed tab as default
  ✓ Scenario 3: clicking a tag pill pins the #tag tab and filters the list
  ✓ Scenario 4: article preview card renders envelope-driven fields including favorite button
  ✓ Scenario 6: pagination via ?page=2 shows the next slice
  ✓ Scenario 7: empty state message when no articles match
  ✓ axe a11y gate on homepage (#87)
  7 passed (5.6s)
```

**Spec 114 Suspense (to confirm we didn't break the skeleton's own spec):**
```
  ✓ Scenario 1: article detail paints banner immediately and streams comments behind a skeleton
  ✓ Scenario 2: homepage paints article list and streams tag cloud behind a skeleton
  ✓ Scenario 3: profile page paints banner and streams article tab content
  ✓ Scenario 4: skeleton state has no critical/serious axe violations
  4 passed (10.9s)
```

**Typecheck** — clean.

## Notes for review

Evaluator suggested two options in the issue body; I went with option 1 (filter-based scoping) rather than option 2 (explicit `waitFor({state: 'detached'})` at call sites). Reason: option 1 fixes every caller in one line because Playwright's locator auto-wait handles the "wait for skeleton to detach" behaviour for free once the filter excludes it. Option 2 would need the wait inserted at every call site that touches `.sidebar` (spec 17 scenarios 1/3/4 + any future usage). One-liner in the POP is the tighter fix.
