### PR TITLE
feat(infra): baseline security headers on API + web (#124)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/error.js";
 import { requestLogger } from "./middleware/logger.js";
 import { requestId, type RequestIdVars } from "./middleware/request-id.js";
+import { securityHeaders } from "./middleware/security-headers.js";
 import { registerArticleRoutes } from "./routes/articles.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerCommentRoutes } from "./routes/comments.js";
@@ -49,6 +50,12 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
   app.use("*", requestId());
   app.use("*", requestLogger());
   app.use("*", corsMiddleware());
+  // Baseline security headers (#124). Sits after CORS so the CORS
+  // preflight response still carries the OPTIONS headers CORS owns,
+  // then secure-headers stacks nosniff / DENY / Referrer-Policy /
+  // Permissions-Policy on the already-prepared response. HSTS is
+  // gated by ENFORCE_HSTS=true (off for local HTTP).
+  app.use("*", securityHeaders());
   // Global body-size cap (#126). DoS shield — rejects oversized
   // bodies before they hit the zod validators or the DB layer. Runs
   // after request-id + logger so the 413 carries a request id and is

--- a/apps/api/src/middleware/security-headers.ts
+++ b/apps/api/src/middleware/security-headers.ts
@@ -1,0 +1,38 @@
+import { secureHeaders } from "hono/secure-headers";
+import type { MiddlewareHandler } from "hono";
+
+// Baseline security headers (#124). Wraps `hono/secure-headers` with
+// tuned defaults that match what a Level-2 production API is
+// expected to surface on every response (mozilla/observatory B+):
+//
+//   X-Content-Type-Options: nosniff
+//   X-Frame-Options: DENY
+//   Referrer-Policy: strict-origin-when-cross-origin
+//   Permissions-Policy: camera=(), geolocation=(), microphone=()
+//
+// HSTS is OFF by default because local dev + the CI compose stack
+// run on plain HTTP. Set `ENFORCE_HSTS=true` in any env that
+// terminates TLS (staging/prod) to emit the 2-year preload header.
+//
+// Hono's secure-headers module sets several additional headers
+// (Cross-Origin-*-Policy, Origin-Agent-Cluster, etc.) that are safe
+// for a JSON API; we let those through with defaults. `x-xss-protection`
+// default value of `0` is kept — modern browsers ignore it and `1;
+// mode=block` is actively harmful with a strict CSP.
+
+const hstsEnabled = process.env.ENFORCE_HSTS === "true";
+
+export const securityHeaders = (): MiddlewareHandler =>
+  secureHeaders({
+    xContentTypeOptions: "nosniff",
+    xFrameOptions: "DENY",
+    referrerPolicy: "strict-origin-when-cross-origin",
+    permissionsPolicy: {
+      camera: [],
+      geolocation: [],
+      microphone: [],
+    },
+    strictTransportSecurity: hstsEnabled
+      ? "max-age=63072000; includeSubDomains; preload"
+      : false,
+  });

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,6 +21,18 @@ COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY apps/web ./apps/web
 ENV NEXT_TELEMETRY_DISABLED=1
+# Bake the browser-visible API URL into the build so next.config.ts's
+# CSP `connect-src` directive (#124) reflects the host's mapped port.
+# Next.js evaluates next.config at build time and materializes the
+# resolved headers into routes-manifest.json; runtime env changes
+# won't flip the CSP. Pass via `--build-arg NEXT_PUBLIC_API_URL=...`
+# per deploy target. Defaults keep local builds on http://localhost:3001.
+ARG NEXT_PUBLIC_API_URL=http://localhost:3001
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+# ENFORCE_HSTS also has to be baked in for the same reason — the
+# header list is computed at build time in next.config.
+ARG ENFORCE_HSTS
+ENV ENFORCE_HSTS=${ENFORCE_HSTS}
 RUN corepack enable && pnpm --filter @conduit/web build
 
 # ---- runner ----

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,64 @@
 import type { NextConfig } from "next";
 
+// Baseline security headers (#124). Emitted on every page + route
+// response. Rationale + tuning guidance in docs/security-headers.md.
+//
+// HSTS is only attached when ENFORCE_HSTS=true — local dev runs on
+// plain HTTP, and a max-age HSTS pin on localhost would lock the
+// browser into treating http://localhost as HTTPS-only for 2 years.
+//
+// CSP stance: moderate. Next.js's runtime requires `'unsafe-inline'`
+// for its bootstrap scripts + inline styles until a nonce-based
+// pipeline lands (follow-up, see docs). The `connect-src` pulls
+// `NEXT_PUBLIC_API_URL` so the browser can reach the API regardless
+// of host/port per env (compose maps 3101 → 3001 inside the
+// container, for instance).
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const hstsEnabled = process.env.ENFORCE_HSTS === "true";
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "img-src 'self' https: data:",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  `connect-src 'self' ${apiUrl}`,
+  "font-src 'self' data:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ");
+
+const baseHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), geolocation=(), microphone=()",
+  },
+];
+
+const hstsHeader = {
+  key: "Strict-Transport-Security",
+  value: "max-age=63072000; includeSubDomains; preload",
+};
+
+const securityHeaders = hstsEnabled
+  ? [...baseHeaders, hstsHeader]
+  : baseHeaders;
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/docs/adr/001-initial-architecture.md
+++ b/docs/adr/001-initial-architecture.md
@@ -151,3 +151,11 @@ process env; nothing hardcoded in `src/`. Portability checklist
 - **Response shape**: `{ "errors": { "body": ["payload too large, max NKB"] } }` — same envelope as the spec-422 validator hook so clients have one error shape to parse. No `Retry-After` (413 is not transient).
 - **Env knobs**: `API_BODY_LIMIT_GLOBAL_KB` (default 1024), `API_BODY_LIMIT_ARTICLE_KB` (default 100). Defaults ship everywhere; no disable knob.
 - **Why not streaming uploads**: out of scope — this codebase has no binary upload path. If file attachments ever land, they get their own multipart middleware with its own ceiling.
+
+## Addendum — Security headers (2026-04-29, #124)
+
+- **API**: `hono/secure-headers` wrapped in `apps/api/src/middleware/security-headers.ts`; ships `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/geolocation/microphone empty), plus secure-headers' default COOP/CORP/Origin-Agent-Cluster set. HSTS gated on `ENFORCE_HSTS=true`.
+- **Web**: `apps/web/next.config.ts` `async headers()` emits CSP + the same baseline headers. CSP stance is **moderate** — keeps `'unsafe-inline'` on script + style so Next.js's runtime scripts work out of the box. Nonce-based CSP is a follow-up (requires middleware rewire).
+- **Build-time bake**: CSP + HSTS are resolved at `next build` time and written into `routes-manifest.json`; `NEXT_PUBLIC_API_URL` and `ENFORCE_HSTS` must therefore flow through as Docker build args per deploy target. `infra/docker-compose.yml` passes both from `.env`.
+- **HSTS in local dev**: forbidden. A 2-year preload pin on `localhost` locks the browser into HTTPS-only for every other dev server on the host. All local envs keep `ENFORCE_HSTS` unset.
+- **Reference**: `docs/security-headers.md` — full table, tuning guide, verification commands.

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,0 +1,127 @@
+# Security headers (#124)
+
+Baseline HTTP security headers on every API and web response. The
+goal is a Level-2 production floor: each header closes a concrete
+attack class a penetration test would otherwise flag. Together with
+the request-body cap (#126) and rate-limiting (#116), these form the
+reliability-and-security floor of the service.
+
+## Header set
+
+| Header | API | Web | Value |
+|---|---|---|---|
+| `X-Content-Type-Options` | ✓ | ✓ | `nosniff` |
+| `X-Frame-Options` | ✓ | ✓ | `DENY` |
+| `Referrer-Policy` | ✓ | ✓ | `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | ✓ | ✓ | `camera=(), geolocation=(), microphone=()` |
+| `Content-Security-Policy` |  | ✓ | see below |
+| `Strict-Transport-Security` | ✓ (cloud) | ✓ (cloud) | `max-age=63072000; includeSubDomains; preload` when `ENFORCE_HSTS=true` |
+
+API-only extras surfaced by `hono/secure-headers` defaults:
+`Cross-Origin-Opener-Policy: same-origin`,
+`Cross-Origin-Resource-Policy: same-origin`,
+`Origin-Agent-Cluster: ?1`,
+`X-DNS-Prefetch-Control: off`,
+`X-Download-Options: noopen`,
+`X-Permitted-Cross-Domain-Policies: none`,
+`X-XSS-Protection: 0`.
+
+## CSP (web only)
+
+```
+default-src 'self';
+img-src 'self' https: data:;
+script-src 'self' 'unsafe-inline';
+style-src 'self' 'unsafe-inline';
+connect-src 'self' <NEXT_PUBLIC_API_URL>;
+font-src 'self' data:;
+frame-ancestors 'none';
+base-uri 'self';
+form-action 'self';
+```
+
+- `'unsafe-inline'` on `script-src` + `style-src` is what Next.js
+  needs for its bootstrap inline scripts and inline `style` attrs.
+  Tightening to nonce-based CSP requires rewiring the Next.js runtime
+  via middleware and is tracked as a follow-up.
+- `connect-src` includes `NEXT_PUBLIC_API_URL` so client-side fetches
+  to the API aren't CSP-blocked. Value is baked at build time (see
+  "Build-time vs runtime" below).
+- `frame-ancestors 'none'` duplicates `X-Frame-Options: DENY` — modern
+  browsers prefer the CSP directive, but we keep both because
+  security scanners still flag apps that ship only one.
+
+## Build-time vs runtime
+
+**The CSP + HSTS decision is baked at build time** for the web app.
+Next.js evaluates `next.config.ts` once per build and writes the
+resolved headers into `.next/routes-manifest.json`; changing
+`NEXT_PUBLIC_API_URL` or `ENFORCE_HSTS` at runtime does NOT update the
+CSP. That's why the Dockerfile receives both as `ARG` + `ENV`:
+
+```dockerfile
+ARG NEXT_PUBLIC_API_URL=http://localhost:3001
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ARG ENFORCE_HSTS
+ENV ENFORCE_HSTS=${ENFORCE_HSTS}
+RUN pnpm --filter @conduit/web build
+```
+
+And `infra/docker-compose.yml` passes the compose-level values
+through as build args so a single `docker compose up --build` produces
+the right image for the target env.
+
+The API side uses runtime env — `hono/secure-headers` recomputes its
+header list per-process startup, so `ENFORCE_HSTS=true` on restart is
+enough to flip HSTS on.
+
+## HSTS in local dev
+
+**Never turn HSTS on for localhost.** A `max-age=63072000` header pins
+the browser into treating `http://localhost` as HTTPS-only for 2
+years, which breaks every other dev server on that host. The default
+is off everywhere; only staging/prod compose files set
+`ENFORCE_HSTS=true`.
+
+## Adding a third-party script
+
+1. Add its origin to `script-src` and, if it fetches data, to
+   `connect-src` in `apps/web/next.config.ts`.
+2. Rebuild the web image so the new CSP gets baked into
+   `routes-manifest.json`.
+3. Re-run `pnpm test:e2e` — spec `124-web-security-headers` asserts
+   the CSP's shape; adjust the assertion if the directive list grew.
+
+If the script needs inline execution (ads, analytics), consider
+switching to a nonce-based CSP at that point rather than broadening
+`'unsafe-inline'`.
+
+## Verification
+
+```sh
+# API
+curl -I http://localhost:3101/api/articles | grep -Ei 'x-content|x-frame|referrer|permissions'
+
+# Web
+curl -I http://localhost:3100/ | grep -Ei 'content-security|x-content|x-frame|referrer|permissions'
+```
+
+Expected:
+
+```
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), geolocation=(), microphone=()
+Content-Security-Policy: default-src 'self'; ...
+```
+
+Against a live deploy: https://observatory.mozilla.org/ should score
+at least a `B`. Lower grades usually mean the CSP missed a directive
+the tool is looking for (e.g. `report-uri`) — those are nice-to-have,
+not blocking.
+
+## Related
+
+- `docs/rate-limits.md` — rate + body-size floor (#116, #126).
+- ADR 001 §"Security headers" — the tuning rationale.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -62,6 +62,12 @@ services:
       # apps/api/src/middleware/body-limit.ts when these are unset.
       API_BODY_LIMIT_GLOBAL_KB: ${API_BODY_LIMIT_GLOBAL_KB:-}
       API_BODY_LIMIT_ARTICLE_KB: ${API_BODY_LIMIT_ARTICLE_KB:-}
+      # Security headers (#124). Off for local HTTP; any env that
+      # terminates TLS (staging/prod) sets ENFORCE_HSTS=true to
+      # emit the 2-year HSTS preload header. The other baseline
+      # headers (nosniff / DENY / Referrer-Policy / Permissions-
+      # Policy) ship unconditionally.
+      ENFORCE_HSTS: ${ENFORCE_HSTS:-}
     ports:
       - "${API_HOST_PORT:-3001}:3001"
     healthcheck:
@@ -80,6 +86,13 @@ services:
     build:
       context: ..
       dockerfile: apps/web/Dockerfile
+      args:
+        # Must flow in at build time because next.config.ts's CSP
+        # `connect-src` + HSTS decision are baked into the static
+        # routes-manifest. Compose passes the same .env values as
+        # runtime environment.
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+        ENFORCE_HSTS: ${ENFORCE_HSTS:-}
     depends_on:
       api:
         condition: service_healthy
@@ -90,6 +103,11 @@ services:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
       NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3000}
       CONDUIT_TEST_SLOW_SUSPENSE: ${CONDUIT_TEST_SLOW_SUSPENSE:-}
+      # Security headers (#124). Mirrors the API's flag — only cloud
+      # envs behind a TLS terminator set this; local dev runs on
+      # http:// and must not emit HSTS (would lock the browser into
+      # treating localhost as HTTPS-only).
+      ENFORCE_HSTS: ${ENFORCE_HSTS:-}
     ports:
       - "${WEB_HOST_PORT:-3000}:3000"
     healthcheck:

--- a/tests/e2e/specs/124-web-security-headers.spec.ts
+++ b/tests/e2e/specs/124-web-security-headers.spec.ts
@@ -1,0 +1,132 @@
+import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #124 — baseline security headers on the API
+// and the web app. Headers are verified on concrete URLs that
+// production traffic would hit: a page render path, an article detail,
+// a profile, the API's article list.
+//
+// HSTS is conditional on `ENFORCE_HSTS=true` (set only in HTTPS-
+// terminating envs). Local dev + CI compose stack run on plain HTTP
+// so the assertion skips by reading the response header and matching
+// presence to the runtime flag.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const hstsEnabled = process.env.ENFORCE_HSTS === "true";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+type HeaderBag = Record<string, string>;
+
+const getHeaders = async (url: string): Promise<HeaderBag> => {
+  const ctx = await request.newContext();
+  const res = await ctx.get(url);
+  return res.headers();
+};
+
+test.describe("issue #124 — baseline security headers", () => {
+  test("Scenario 1: API responses include the baseline security headers", async () => {
+    const h = await getHeaders(`${API_URL}/api/articles`);
+
+    expect(h["x-content-type-options"]).toBe("nosniff");
+    expect(h["x-frame-options"]).toBe("DENY");
+    expect(h["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(h["permissions-policy"]).toBe(
+      "camera=(), geolocation=(), microphone=()",
+    );
+    // CORS + request-id must still flow through — pre-existing behavior
+    // must not regress when secure-headers stacks on.
+    expect(h["x-request-id"]).toBeTruthy();
+  });
+
+  test("Scenario 2: web homepage response includes CSP + baseline headers", async () => {
+    const h = await getHeaders(`${WEB_URL}/`);
+
+    expect(h["content-security-policy"]).toBeTruthy();
+    const csp = h["content-security-policy"] ?? "";
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    // connect-src must include the browser-visible API URL so that
+    // client-side fetches don't get CSP-blocked. The bundled next
+    // image always carries the canonical API URL per env; we assert
+    // the directive's presence + that it names `self`.
+    expect(csp).toContain("connect-src 'self'");
+
+    expect(h["x-content-type-options"]).toBe("nosniff");
+    expect(h["x-frame-options"]).toBe("DENY");
+    expect(h["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(h["permissions-policy"]).toBe(
+      "camera=(), geolocation=(), microphone=()",
+    );
+  });
+
+  test("Scenario 3: article detail page inherits the security headers", async () => {
+    // Seed an article so /article/:slug is real (RSC 404 on unknown
+    // slug would technically still carry the headers, but seeding
+    // exercises the success path too).
+    const id = uniq();
+    const jake = `sec-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `sec-${id}` });
+
+    const h = await getHeaders(`${WEB_URL}/article/${slug}`);
+
+    expect(h["content-security-policy"]).toBeTruthy();
+    expect(h["x-content-type-options"]).toBe("nosniff");
+    expect(h["x-frame-options"]).toBe("DENY");
+  });
+
+  test("Scenario 4: profile page inherits the security headers", async () => {
+    const id = uniq();
+    const jake = `sec-p-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    const h = await getHeaders(`${WEB_URL}/profile/${jake}`);
+
+    expect(h["content-security-policy"]).toBeTruthy();
+    expect(h["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(h["x-frame-options"]).toBe("DENY");
+  });
+
+  test("Scenario 5: HSTS header presence tracks the ENFORCE_HSTS flag", async () => {
+    const h = await getHeaders(`${WEB_URL}/`);
+    const hsts = h["strict-transport-security"];
+
+    if (hstsEnabled) {
+      expect(hsts).toBeTruthy();
+      expect(hsts).toContain("max-age=");
+      expect(hsts).toContain("includeSubDomains");
+    } else {
+      // Local dev must NOT emit HSTS — a 2-year pin on localhost
+      // would lock the dev browser into treating it as HTTPS.
+      expect(hsts).toBeFalsy();
+    }
+  });
+
+  test("Scenario 6: API preserves CORS + rate-limit headers alongside secure-headers", async () => {
+    // Existing middleware stack must not regress. We probe the API
+    // list endpoint and confirm CORS vary + request-id still ship
+    // when secure-headers is active.
+    const ctx = await request.newContext({
+      extraHTTPHeaders: { Origin: WEB_URL },
+    });
+    const res = await ctx.get(`${API_URL}/api/articles?limit=1`);
+    expect(res.status()).toBe(200);
+
+    const h = res.headers();
+    expect(h["vary"] ?? "").toMatch(/Origin/i);
+    expect(h["x-request-id"]).toBeTruthy();
+    expect(h["x-content-type-options"]).toBe("nosniff");
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #124

## User Intent

Every API and web response now ships production-grade security headers (nosniff, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` tightened, `Content-Security-Policy` on the web app, HSTS on cloud envs). A Mozilla Observatory scan should move from an "F" (no headers) to at least a "B" on a TLS deploy. No visible change to users; this is a Level-2 security floor pair with rate-limits (#116) and body-size caps (#126).

## Summary

- **API** — `apps/api/src/middleware/security-headers.ts` wraps `hono/secure-headers` with tuned values; wired in `apps/api/src/app.ts` right after CORS. HSTS is gated on `ENFORCE_HSTS=true`.
- **Web** — `apps/web/next.config.ts` `async headers()` emits CSP + the same baseline. CSP is **moderate**: `default-src 'self'; img-src 'self' https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' <NEXT_PUBLIC_API_URL>; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`. Nonce-based CSP is noted as a follow-up.
- **Build-time bake** — Next.js evaluates `next.config.ts` once per build and writes headers into `routes-manifest.json`; runtime env changes don't flip the CSP. `apps/web/Dockerfile` now takes `NEXT_PUBLIC_API_URL` + `ENFORCE_HSTS` as build args, and `infra/docker-compose.yml` passes both from `.env`. A runtime-only flag would leave CSP stale against a rebuilt image.
- **Spec** — `tests/e2e/specs/124-web-security-headers.spec.ts` (6 scenarios): API headers, web homepage CSP + baseline, article detail, profile page, HSTS-tracks-flag, CORS/request-id preservation.
- **Docs** — `docs/security-headers.md` (full table + tuning guide + verification curl) and ADR 001 addendum.

## Evidence

**Spec 124 alone:**
```
  ✓ Scenario 1: API responses include the baseline security headers (38ms)
  ✓ Scenario 2: web homepage response includes CSP + baseline headers (59ms)
  ✓ Scenario 3: article detail page inherits the security headers (273ms)
  ✓ Scenario 4: profile page inherits the security headers (150ms)
  ✓ Scenario 5: HSTS header presence tracks the ENFORCE_HSTS flag (45ms)
  ✓ Scenario 6: API preserves CORS + rate-limit headers alongside secure-headers (15ms)
  6 passed (1.4s)
```

**Full Playwright suite:** 162 passed, 6 skipped (including the RATE_LIMIT spec that auto-skips when the flag is off). No regressions.

**Bruno conformance:** 149/149 assertions passed, baseline 0/0 regressions.

```
│ Status        │      ✓ PASS      │
│ Requests      │ 149 (149 Passed) │
│ Assertions    │     149/149      │
```

**Manual verification:**

```
$ curl -sI http://localhost:3101/api/articles | grep -E '^(x-|referrer|permissions)'
permissions-policy: camera=(), geolocation=(), microphone=()
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
x-frame-options: DENY
[+ hono's COOP/CORP/origin-agent-cluster defaults]

$ curl -sI http://localhost:3100/ | grep -Ei '^(content-security|x-|referrer|permissions)'
Content-Security-Policy: default-src 'self'; img-src 'self' https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:3101; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), geolocation=(), microphone=()
```

HSTS correctly absent in local dev (ENFORCE_HSTS unset).

**Typecheck + lint** — clean on both apps.

**OpenAPI drift** — snapshot unchanged (no schema-surfacing changes).

**Portability check:**
- `localhost:[0-9]` — only in code comments + CSP fallback default; real values flow through env.
- Absolute `/home/` paths — none.
- Inline secrets — none.
- All env-dependent values (`NEXT_PUBLIC_API_URL`, `ENFORCE_HSTS`) parameterised and documented.

## Notes for review

- The Dockerfile gained two build args. That's the only way to keep the web app's CSP honest across environments, because Next's `next.config.ts` is single-evaluated at build time. Runtime env is insufficient — documented in `docs/security-headers.md` §"Build-time vs runtime" so future contributors don't get bitten.
- API pipeline ordering: `requestId → logger → cors → security-headers → body-limit → routes`. CORS runs before secure-headers so the preflight OPTIONS response still carries CORS headers cleanly.
- `'unsafe-inline'` on script-src + style-src is deliberately retained — Next.js's bootstrap scripts need it. The follow-up note in docs flags where to start if nonce-based CSP becomes required.
- Local HTTP: HSTS is OFF. A `max-age=63072000` header pinned to localhost would lock the dev browser into HTTPS-only for every other project on the host.
