### PR TITLE
feat(api,web): article read-time estimate — server-computed, rendered on previews + detail (#125)

### DIFF
--- a/apps/api/src/lib/read-time.ts
+++ b/apps/api/src/lib/read-time.ts
@@ -1,0 +1,25 @@
+// Article read-time estimate (#125). Medium's convention: 238 words
+// per minute, round up, minimum 1 minute so a one-sentence post still
+// reads as "1 min read".
+//
+// Word split is whitespace-based on the raw Markdown body. Code
+// fences, tables, and inline HTML that `rehype-sanitize` may rewrite
+// later are counted by their source tokens — good enough for an
+// expectation-setter, and cheap. Per the AC: we run against the
+// Markdown source (before HTML rewrite) so formatting syntax
+// (`**bold**`, `[text](url)`) contributes as users wrote it, not as
+// the rendered DOM exposes it.
+
+const WORDS_PER_MINUTE = 238;
+
+export const computeReadTimeMinutes = (body: string): number => {
+  if (!body) return 1;
+  // `.trim()` then `.split(/\s+/)` is the canonical Medium / dev.to
+  // approach — whitespace-separated tokens, empty string fast-paths
+  // to 1. A body of "   " (only whitespace) returns 1 because we
+  // pre-trim and then a zero-length split would yield [""], length 1.
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return 1;
+  const words = trimmed.split(/\s+/).length;
+  return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
+};

--- a/apps/api/src/schemas/article.ts
+++ b/apps/api/src/schemas/article.ts
@@ -23,6 +23,10 @@ export const ArticleSchema = z
     updatedAt: z.string(),
     favorited: z.boolean(),
     favoritesCount: z.number().int().nonnegative(),
+    // Server-computed read-time estimate in minutes (#125). Always
+    // at least 1 for legibility ("1 min read"); clients display it
+    // inline with the date in article meta.
+    readingTimeMinutes: z.number().int().positive(),
     author: ArticleAuthorSchema,
   })
   .openapi("Article");

--- a/apps/api/src/services/articles.service.ts
+++ b/apps/api/src/services/articles.service.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import type { Prisma } from "@prisma/client";
+import { computeReadTimeMinutes } from "../lib/read-time.js";
 import { prisma } from "../prisma/client.js";
 
 // Adapted from gothinkster/node-express-prisma-v1-official-app @ 6ac99ea5
@@ -29,6 +30,11 @@ export type ArticleEnvelope = {
   updatedAt: string;
   favorited: boolean;
   favoritesCount: number;
+  // Estimated reading time in minutes (#125). Computed from the
+  // article body on every envelope build — cheap whitespace split +
+  // ceil(words/238). Server-side so every client (web, Bruno,
+  // integrators) surfaces the same value without re-implementing.
+  readingTimeMinutes: number;
   author: {
     username: string;
     bio: string | null;
@@ -106,6 +112,7 @@ const toEnvelope = (
   updatedAt: article.updatedAt.toISOString(),
   favorited: article.favoritedBy.length > 0,
   favoritesCount: article._count.favoritedBy,
+  readingTimeMinutes: computeReadTimeMinutes(article.body),
   author: {
     username: article.author.username,
     bio: article.author.bio,
@@ -135,6 +142,7 @@ const toListItem = (
     updatedAt: envelope.updatedAt,
     favorited: envelope.favorited,
     favoritesCount: envelope.favoritesCount,
+    readingTimeMinutes: envelope.readingTimeMinutes,
     author: envelope.author,
   };
 };

--- a/apps/api/test/lib/read-time.test.ts
+++ b/apps/api/test/lib/read-time.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { computeReadTimeMinutes } from "../../src/lib/read-time.js";
+
+// Unit tests for the read-time helper (#125). The AC enumerates the
+// exact inputs — keep the table literal so a future refactor can't
+// silently change the contract.
+describe("computeReadTimeMinutes", () => {
+  it("returns 1 for an empty body", () => {
+    expect(computeReadTimeMinutes("")).toBe(1);
+  });
+
+  it("returns 1 for whitespace-only body", () => {
+    expect(computeReadTimeMinutes("   \n\t  ")).toBe(1);
+  });
+
+  it("returns 1 for a single word", () => {
+    expect(computeReadTimeMinutes("hello")).toBe(1);
+  });
+
+  it("returns 1 for 237 words (just under the 1-min cap)", () => {
+    const body = Array.from({ length: 237 }, (_, i) => `w${i}`).join(" ");
+    expect(computeReadTimeMinutes(body)).toBe(1);
+  });
+
+  it("returns 1 for exactly 238 words (boundary: 238/238 = 1)", () => {
+    const body = Array.from({ length: 238 }, (_, i) => `w${i}`).join(" ");
+    expect(computeReadTimeMinutes(body)).toBe(1);
+  });
+
+  it("returns 2 for 239 words (one over the 1-min cap rounds up)", () => {
+    const body = Array.from({ length: 239 }, (_, i) => `w${i}`).join(" ");
+    expect(computeReadTimeMinutes(body)).toBe(2);
+  });
+
+  it("returns 43 for 10000 words (ceil(10000/238) = 43)", () => {
+    const body = Array.from({ length: 10000 }, (_, i) => `w${i}`).join(" ");
+    expect(computeReadTimeMinutes(body)).toBe(43);
+  });
+
+  it("treats mixed whitespace (tabs, newlines) as word separators", () => {
+    const body = "one\ttwo\nthree four\n\nfive";
+    expect(computeReadTimeMinutes(body)).toBe(1);
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -388,3 +388,17 @@ footer .attribution {
 .empty-state-actions a:hover {
   color: var(--conduit-green-dark);
 }
+
+/* ── Read-time badge (#125) ───────────────────────────────────
+ * Secondary meta strip marker. #55595c on white yields ~7:1
+ * contrast, WCAG AA-safe, matching .empty-state-body. Visually
+ * still secondary to the bold author name. Canonical RealWorld
+ * `.date` uses #bbb which silently fails AA (#90-class regression);
+ * read-time starts correct-by-default.
+ */
+.article-meta .read-time {
+  margin-left: 0.5rem;
+  color: #55595c;
+  font-size: 0.8rem;
+  font-weight: 300;
+}

--- a/apps/web/src/components/article/ArticleMeta.tsx
+++ b/apps/web/src/components/article/ArticleMeta.tsx
@@ -47,6 +47,9 @@ export const ArticleMeta = ({ article, viewerUsername, authed }: Props) => {
           {article.author.username}
         </Link>
         <span className="date">{formatDate(article.createdAt)}</span>
+        <span className="read-time" data-testid="read-time">
+          {article.readingTimeMinutes} min read
+        </span>
       </div>
       {isOwn ? (
         <>

--- a/apps/web/src/components/article/ArticlePreview.tsx
+++ b/apps/web/src/components/article/ArticlePreview.tsx
@@ -49,6 +49,9 @@ export const ArticlePreview = ({ article, authed }: Props) => {
             {article.author.username}
           </Link>
           <span className="date">{formatDate(article.createdAt)}</span>
+          <span className="read-time" data-testid="read-time">
+            {article.readingTimeMinutes} min read
+          </span>
         </div>
         <FavoriteButton
           slug={article.slug}

--- a/apps/web/src/features/articles/queries.ts
+++ b/apps/web/src/features/articles/queries.ts
@@ -27,6 +27,8 @@ export type Article = {
   updatedAt: string;
   favorited: boolean;
   favoritesCount: number;
+  // Server-computed read-time estimate (#125). Always ≥ 1.
+  readingTimeMinutes: number;
   author: ArticleAuthor;
 };
 

--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -291,6 +291,10 @@
             "type": "integer",
             "minimum": 0
           },
+          "readingTimeMinutes": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
           "author": {
             "$ref": "#/components/schemas/ArticleAuthor"
           }
@@ -304,6 +308,7 @@
           "updatedAt",
           "favorited",
           "favoritesCount",
+          "readingTimeMinutes",
           "author"
         ]
       },
@@ -381,6 +386,10 @@
             "type": "integer",
             "minimum": 0
           },
+          "readingTimeMinutes": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
           "author": {
             "$ref": "#/components/schemas/ArticleAuthor"
           }
@@ -395,6 +404,7 @@
           "updatedAt",
           "favorited",
           "favoritesCount",
+          "readingTimeMinutes",
           "author"
         ]
       },

--- a/tests/e2e/page-objects/articles.ts
+++ b/tests/e2e/page-objects/articles.ts
@@ -31,6 +31,8 @@ export type Article = {
   updatedAt: string;
   favorited: boolean;
   favoritesCount: number;
+  // Server-computed read-time estimate (#125). Always ≥ 1.
+  readingTimeMinutes: number;
   author: {
     username: string;
     bio: string | null;

--- a/tests/e2e/specs/125-web-reading-time.spec.ts
+++ b/tests/e2e/specs/125-web-reading-time.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #125 — server-computed read-time estimate.
+// The API envelope carries `readingTimeMinutes` on every article
+// surface; the web renders "N min read" in the article-meta strip
+// on both preview cards and the detail page.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Helper: build a body with `n` whitespace-separated words.
+const bodyOf = (wordCount: number): string =>
+  Array.from({ length: wordCount }, (_, i) => `w${i}`).join(" ");
+
+test.describe("issue #125 — article read-time estimate", () => {
+  test("Scenario 1: API envelope includes readingTimeMinutes on single + list", async () => {
+    const id = uniq();
+    const jake = `rt-a-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    // 476 words → ceil(476/238) = 2 minutes per the AC.
+    const article = await api.createArticle({
+      title: `rt-${id}`,
+      body: bodyOf(476),
+    });
+    expect(article.readingTimeMinutes).toBe(2);
+
+    // List endpoint echoes the same value for the body-less envelope.
+    const list = await api.listArticles({ author: jake });
+    const listed = list.articles.find((a) => a.slug === article.slug);
+    expect(listed?.readingTimeMinutes).toBe(2);
+  });
+
+  test("Scenario 2: preview card shows N min read next to the date", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rt-p-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    // 1000 words → ceil(1000/238) = 5 min.
+    const article = await api.createArticle({
+      title: `rt-pv-${id}`,
+      body: bodyOf(1000),
+    });
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+    // Scope to the preview for THIS article so parallel seeds don't
+    // leak another author's read-time into our assertion.
+    const preview = page.locator(
+      `.article-preview:has(a[href="/article/${article.slug}"])`,
+    );
+    await expect(preview.getByTestId("read-time")).toContainText("5 min read");
+  });
+
+  test("Scenario 3: article detail page shows the read time in both meta strips", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rt-d-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    // 239 words → ceil(239/238) = 2 min (one over the boundary).
+    const article = await api.createArticle({
+      title: `rt-dt-${id}`,
+      body: bodyOf(239),
+    });
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+    // Banner + footer meta both render ArticleMeta → both emit the
+    // read-time testid. Check .count() ≥ 2 so the feature surfaces
+    // in both positions like the AC demands.
+    const readTimes = page.getByTestId("read-time");
+    await expect(readTimes.first()).toBeVisible();
+    await expect(readTimes.first()).toContainText("2 min read");
+    expect(await readTimes.count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test("Scenario 4: minimum 1 min for a short body (below the 238-word boundary)", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rt-s-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    // 10 words → ceil(10/238) = 1 min (floor is 1, never 0).
+    const article = await api.createArticle({
+      title: `rt-sh-${id}`,
+      body: bodyOf(10),
+    });
+    expect(article.readingTimeMinutes).toBe(1);
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+    await expect(page.getByTestId("read-time").first()).toContainText(
+      "1 min read",
+    );
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #125

## User Intent

Every article surface — homepage preview, profile tab, article detail banner + footer — now shows an estimated read time ("2 min read") alongside the date. Sets reader expectations the way Medium.com does; small but visible polish on a content feed.

## Summary

- `apps/api/src/lib/read-time.ts` — `computeReadTimeMinutes(body)` = `max(1, ceil(words/238))`. 238 wpm is the Medium convention; body splits on `/\s+/` after trim. Empty / whitespace-only / single-word bodies floor to 1.
- `apps/api/test/lib/read-time.test.ts` — vitest coverage for the exact inputs the AC enumerates: 0, whitespace, 1 word, 237, 238, 239, 10000. 8 green.
- Envelope + serializer gain `readingTimeMinutes` on both `ArticleSchema` and `ArticleListItemSchema`. `toEnvelope` computes it once from `article.body`; `toListItem` propagates.
- Web `Article` / `ArticleListItem` types get the field; `ArticlePreview` + `ArticleMeta` render `<span class="read-time" data-testid="read-time">{readingTimeMinutes} min read</span>`.
- `docs/openapi-snapshot.json` regenerated — diff is purely additive.
- CSS: color `#55595c` on white for ~7:1 contrast (WCAG AA). Canonical RealWorld `.date` is `#bbb` (fails AA); read-time ships correct-by-default.

## Evidence

**Unit tests:**
```
✓ computeReadTimeMinutes > returns 1 for an empty body
✓ computeReadTimeMinutes > returns 1 for whitespace-only body
✓ computeReadTimeMinutes > returns 1 for a single word
✓ computeReadTimeMinutes > returns 1 for 237 words (just under the 1-min cap)
✓ computeReadTimeMinutes > returns 1 for exactly 238 words (boundary: 238/238 = 1)
✓ computeReadTimeMinutes > returns 2 for 239 words (one over the 1-min cap rounds up)
✓ computeReadTimeMinutes > returns 43 for 10000 words (ceil(10000/238) = 43)
✓ computeReadTimeMinutes > treats mixed whitespace (tabs, newlines) as word separators
8 passed
```

**Spec 125 (Playwright):**
```
✓ Scenario 1: API envelope includes readingTimeMinutes on single + list (173ms)
✓ Scenario 2: preview card shows N min read next to the date (392ms)
✓ Scenario 3: article detail page shows the read time in both meta strips (478ms)
✓ Scenario 4: minimum 1 min for a short body (below the 238-word boundary) (343ms)
4 passed (2.4s)
```

**Full Playwright suite:** 165 passed, 6 skipped, 1 intermittent (`#56` axe a11y on homepage with articles) — verified green in isolation 5/5. Pre-existing parallel-seed flake, not caused by this PR.

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions. The new field is additive; existing per-field `expect(...)` assertions don't touch it.

**Typecheck + lint** clean on both apps.

**OpenAPI drift** — snapshot refreshed with `pnpm openapi:emit`; CI's drift gate will be green.

**Manual verification:**
```
$ curl -s -b cookiejar -X POST http://localhost:3101/api/articles \
    -H 'content-type: application/json' \
    -d '{"article":{"title":"probe","description":"d","body":"one two three"}}' \
  | jq .article.readingTimeMinutes
1
```

## Notes for review

- Computed in the serializer, not persisted in Prisma — per the planner's lean. No migration, no read-time-stale-on-update bug, cost is a whitespace split per envelope.
- AC says the calc runs on the Markdown source before `rehype-sanitize` rewrite. That's where we compute — `article.body` is stored raw Markdown and that's the string the word-count sees.
- CSS color deviates from canonical RealWorld (`#bbb`) for WCAG AA compliance. The `/* ── Read-time badge (#125) ── */` block comment flags the reason.
- `data-testid="read-time"` present on both preview and detail for test targeting; the visible text remains the assertion target for humans.
