### PR TITLE
feat(api): /metrics Prometheus endpoint — request histograms + rate-limit + auth counters (#139)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "pg": "8.16.3",
     "pino": "10.3.1",
     "prisma": "7.8.0",
+    "prom-client": "^15.1.3",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,11 @@ import { globalBodyLimit } from "./middleware/body-limit.js";
 import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/error.js";
 import { requestLogger } from "./middleware/logger.js";
+import {
+  isMetricsAuthorized,
+  metricsHandler,
+  metricsMiddleware,
+} from "./middleware/metrics.js";
 import { requestId, type RequestIdVars } from "./middleware/request-id.js";
 import { securityHeaders } from "./middleware/security-headers.js";
 import { registerArticleRoutes } from "./routes/articles.js";
@@ -50,6 +55,12 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
   app.use("*", requestId());
   app.use("*", requestLogger());
   app.use("*", corsMiddleware());
+  // Prometheus metrics (#139). Runs after request-id so the
+  // Hono router has resolved `c.req.routePath` by the time we
+  // label our histograms — that's how we keep cardinality bounded
+  // (pattern, not interpolated slug). Instrumentation skips
+  // /metrics itself to avoid scraper-feedback noise.
+  app.use("*", metricsMiddleware());
   // Baseline security headers (#124). Sits after CORS so the CORS
   // preflight response still carries the OPTIONS headers CORS owns,
   // then secure-headers stacks nosniff / DENY / Referrer-Policy /
@@ -105,6 +116,21 @@ export const createApp = (): OpenAPIHono<AppEnv> => {
       pageTitle: "Conduit API",
     }),
   );
+
+  // /metrics (#139). Prometheus text exposition. Dev runs without
+  // a token for local scraping; production requires the
+  // `X-Metrics-Token: $METRICS_TOKEN` header. Mounted here (not
+  // through the OpenAPI router) so the endpoint stays outside the
+  // `/api/` tree that `@hono/zod-openapi` publishes — metrics are
+  // ops surface, not product API.
+  app.get("/metrics", async (c) => {
+    const token = c.req.header("x-metrics-token");
+    if (!isMetricsAuthorized(token)) {
+      return c.json({ errors: { metrics: ["unauthorized"] } }, 401);
+    }
+    const { body, contentType } = await metricsHandler();
+    return c.body(body, 200, { "Content-Type": contentType });
+  });
 
   app.notFound((c) => c.json({ errors: { body: ["not found"] } }, 404));
 

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -26,6 +26,10 @@ export const errorHandler = (
         secure: config.cookieSecure,
       });
     }
+    // (Metrics instrumentation for AuthError lives in the class
+    // constructor — see auth.service.ts — so the counter fires
+    // whether a route handler re-throws or catches the error
+    // locally. #139.)
     return c.json({ errors: { [err.field]: [err.detail] } }, err.status);
   }
 

--- a/apps/api/src/middleware/metrics.ts
+++ b/apps/api/src/middleware/metrics.ts
@@ -1,0 +1,136 @@
+import client from "prom-client";
+import { createMiddleware } from "hono/factory";
+
+// Prometheus metrics (#139). Level-2 observability ladder: SRE
+// dashboards + alerting depend on scraping /metrics. We use the
+// canonical `prom-client` library (Node standard, MIT) and register
+// metrics on a dedicated Registry so tests can flush state deterministically.
+//
+// Cardinality discipline: every label comes from a bounded set (HTTP
+// method, route pattern, status, rate-limit bucket, auth-failure
+// reason). Never label by user id, slug, IP, or any unbounded
+// value — Prometheus storage scales with label cardinality, so a
+// slug-labeled counter is the single most common way to blow up a
+// time-series database.
+
+export const metricsRegistry = new client.Registry();
+
+// Default process metrics (event-loop lag, GC, memory, CPU, file
+// descriptors, etc.). Low-cardinality, cheap, and every Grafana
+// dashboard template expects them. `register` is set so they route
+// into OUR registry, not the global default — keeps test resets
+// from clobbering state outside the API.
+client.collectDefaultMetrics({ register: metricsRegistry });
+
+export const httpRequestsTotal = new client.Counter({
+  name: "http_requests_total",
+  help: "Count of HTTP requests processed, labelled by method, route pattern, and status.",
+  labelNames: ["method", "route", "status"],
+  registers: [metricsRegistry],
+});
+
+export const httpRequestDurationSeconds = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "HTTP request duration in seconds, labelled by method, route pattern, and status.",
+  labelNames: ["method", "route", "status"],
+  // Buckets tuned for a fast JSON API — most requests finish under
+  // 100ms, so the lower buckets give us the detail that matters.
+  // AC enumerates the minimum set; we match exactly.
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [metricsRegistry],
+});
+
+export const httpRequestsInflight = new client.Gauge({
+  name: "http_requests_inflight",
+  help: "Current number of HTTP requests being processed.",
+  registers: [metricsRegistry],
+});
+
+export const rateLimitRejectionsTotal = new client.Counter({
+  name: "rate_limit_rejections_total",
+  help: "Count of 429 rate-limit rejections, labelled by the bucket that tripped.",
+  labelNames: ["endpoint"],
+  registers: [metricsRegistry],
+});
+
+export const authFailuresTotal = new client.Counter({
+  name: "auth_failures_total",
+  help: "Count of authentication failures (register/login 4xx), labelled by reason.",
+  labelNames: ["reason"],
+  registers: [metricsRegistry],
+});
+
+// DB pool gauge — Prisma's adapter doesn't expose live pool counts
+// in a stable API as of 7.x, so we emit 0s as a placeholder. When
+// Prisma ships a usable introspection surface (or we swap to
+// pg-pool directly), swap the value source here.
+//
+// Emitting the metric family with placeholder values keeps the
+// Grafana dashboard contract stable: scrapers see the names they
+// expect and plot "0 active" rather than "metric missing".
+export const dbPoolConnections = new client.Gauge({
+  name: "db_pool_connections",
+  help: "Database connection pool gauge, labelled by state (active/idle). Placeholder until Prisma exposes pool stats.",
+  labelNames: ["state"],
+  registers: [metricsRegistry],
+  collect() {
+    this.set({ state: "active" }, 0);
+    this.set({ state: "idle" }, 0);
+  },
+});
+
+// Per-request instrumentation. Runs after request-id so the route
+// pattern is known (Hono sets `c.req.routePath` when the match
+// resolves), and closes over the timer/in-flight gauge so every
+// path — success, zod-422, rate-limit-429, thrown-500 — gets
+// counted exactly once.
+export const metricsMiddleware = () =>
+  createMiddleware(async (c, next) => {
+    // Never instrument /metrics itself — a scraper hitting every 15s
+    // would dominate the counters and bias the route histogram.
+    if (c.req.path === "/metrics") {
+      await next();
+      return;
+    }
+    const method = c.req.method;
+    httpRequestsInflight.inc();
+    const endTimer = httpRequestDurationSeconds.startTimer();
+    try {
+      await next();
+    } finally {
+      // `routePath` is populated once the router matches; falls back
+      // to the literal path for unmatched 404s. Unmatched paths
+      // share a single "not-found" bucket so we don't balloon
+      // cardinality on random probe URLs.
+      const route = c.req.routePath || "not-found";
+      const status = String(c.res.status);
+      const labels = { method, route, status };
+      httpRequestsTotal.inc(labels);
+      endTimer(labels);
+      httpRequestsInflight.dec();
+    }
+  });
+
+// Prometheus text exposition with an optional token gate. The env
+// is read lazily (per request) so tests can flip NODE_ENV and
+// METRICS_TOKEN at will without re-importing the module.
+export const metricsHandler = async (): Promise<{
+  body: string;
+  contentType: string;
+}> => {
+  const body = await metricsRegistry.metrics();
+  return { body, contentType: metricsRegistry.contentType };
+};
+
+export const isMetricsAuthorized = (token: string | undefined): boolean => {
+  // Non-prod: no gate. Local compose, CI, and dev environments
+  // don't wire a secret; the convenience matters more than the
+  // negligible local leak risk (issue AC scenario 4).
+  if (process.env.NODE_ENV !== "production") return true;
+  const expected = process.env.METRICS_TOKEN;
+  if (!expected) {
+    // Misconfigured prod (no token set). Fail closed.
+    return false;
+  }
+  return token === expected;
+};

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -2,6 +2,7 @@ import { createMiddleware } from "hono/factory";
 import type { Context } from "hono";
 import { prisma } from "../prisma/client.js";
 import type { UserVars } from "./jwt-cookie.js";
+import { rateLimitRejectionsTotal } from "./metrics.js";
 
 // Per-bucket rate limiter backed by the RateLimit table (#116).
 //
@@ -126,6 +127,7 @@ export const rateLimit = (opts: RateLimitOptions) =>
 
     if (row.hits > opts.limit) {
       c.header("Retry-After", String(retryAfter));
+      rateLimitRejectionsTotal.inc({ endpoint: opts.bucket });
       return c.json(
         jsonError("too many requests, please try again later"),
         429,

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import jwt, { type SignOptions } from "jsonwebtoken";
 import type { User } from "@prisma/client";
 import { config } from "../config.js";
+import { authFailuresTotal } from "../middleware/metrics.js";
 import { prisma } from "../prisma/client.js";
 
 // RealWorld user envelope — what the spec returns in the `user` key for
@@ -29,8 +30,25 @@ export class AuthError extends Error {
   ) {
     super(`${field}: ${detail}`);
     this.name = "AuthError";
+    // Observability: every AuthError creation is an auth failure,
+    // regardless of whether the route handler re-throws or catches
+    // it locally. Incrementing in the constructor guarantees the
+    // metric counts actual incidents, not rethrow decisions. (#139)
+    authFailuresTotal.inc({ reason: authFailureReasonOf(field) });
   }
 }
+
+// Bound set of reason labels for auth_failures_total (#139). The
+// raw `field+detail` pair is too fine-grained for a Prom label
+// (risk: high cardinality if detail strings diverge). We map the
+// field → a stable reason token the dashboard can pivot on.
+const authFailureReasonOf = (field: string): string => {
+  if (field === "credentials") return "invalid_credentials";
+  if (field === "token") return "missing_or_expired_token";
+  if (field === "email") return "email_conflict";
+  if (field === "username") return "username_conflict";
+  return "other";
+};
 
 const signToken = (user: Pick<User, "id" | "email" | "username">): string => {
   const payload: JwtPayload = {

--- a/docs/adr/001-initial-architecture.md
+++ b/docs/adr/001-initial-architecture.md
@@ -159,3 +159,12 @@ process env; nothing hardcoded in `src/`. Portability checklist
 - **Build-time bake**: CSP + HSTS are resolved at `next build` time and written into `routes-manifest.json`; `NEXT_PUBLIC_API_URL` and `ENFORCE_HSTS` must therefore flow through as Docker build args per deploy target. `infra/docker-compose.yml` passes both from `.env`.
 - **HSTS in local dev**: forbidden. A 2-year preload pin on `localhost` locks the browser into HTTPS-only for every other dev server on the host. All local envs keep `ENFORCE_HSTS` unset.
 - **Reference**: `docs/security-headers.md` — full table, tuning guide, verification commands.
+
+## Addendum — Metrics + observability (2026-04-29, #139)
+
+- **Library**: `prom-client` (Node canonical, MIT). A dedicated `metricsRegistry` holds our metrics so tests can flush state without clobbering the global default.
+- **Families**: `http_requests_total` (counter), `http_request_duration_seconds` (histogram), `http_requests_inflight` (gauge), `rate_limit_rejections_total` (counter), `auth_failures_total` (counter), `db_pool_connections` (gauge, placeholder until Prisma exposes pool stats). Plus `prom-client`'s default process/node collectors.
+- **Cardinality**: the `route` label is Hono's `c.req.routePath` (matched pattern), never the interpolated URL. All other labels come from a bounded enum set (method, status, bucket name, failure reason).
+- **Placement**: `metricsMiddleware` runs after request-id + logger so the router has resolved the route pattern before we label. Skips `/metrics` itself to avoid scraper-feedback noise.
+- **Auth**: dev/test = open; production requires `X-Metrics-Token: $METRICS_TOKEN` header. Empty `METRICS_TOKEN` in production fails closed.
+- **Reference**: `docs/observability.md` — family table, Grafana panel shapes, alerting suggestions.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,106 @@
+# Observability (#25, #139)
+
+Three surfaces make the API observable in production:
+
+| Surface | Purpose | Introduced |
+|---|---|---|
+| Structured pino JSON logs (stdout) | Per-request line with `requestId`, path, status, duration | #25 |
+| `/healthz` | Liveness probe + DB round-trip check | #25 |
+| `/metrics` | Prometheus-format metrics for SRE dashboards + alerting | #139 |
+
+This doc covers `/metrics`. Logging + healthz are described inline in their own middleware modules.
+
+## Metric families
+
+Scrape `GET http://<api-host>/metrics`. Response is
+`text/plain; version=0.0.4; charset=utf-8` — the canonical
+Prometheus exposition format.
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `http_requests_total` | counter | `method`, `route`, `status` | Total requests served, per HTTP method + route pattern + status. |
+| `http_request_duration_seconds` | histogram | `method`, `route`, `status` | Request duration in seconds. Buckets: 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10. |
+| `http_requests_inflight` | gauge | — | Requests currently being processed. |
+| `db_pool_connections` | gauge | `state` (`active`/`idle`) | Database connection pool stats. **Placeholder 0s** until Prisma 7.x exposes pool introspection. |
+| `rate_limit_rejections_total` | counter | `endpoint` | Count of 429s emitted by the rate-limit middleware, by bucket name (`users:register`, `articles:write`, etc.). |
+| `auth_failures_total` | counter | `reason` | Auth failures by stable reason: `invalid_credentials`, `missing_or_expired_token`, `email_conflict`, `username_conflict`, `other`. |
+
+Plus the standard `process_*` and `nodejs_*` families from
+`prom-client`'s default collector (CPU, RSS, GC, event-loop lag,
+heap, file descriptors).
+
+## Cardinality discipline
+
+**The `route` label is the matched pattern, not the interpolated
+URL.** Hono's `c.req.routePath` returns `/api/articles/:slug` — we
+label with that, not `/api/articles/my-great-post`. The latter
+would blow up Prometheus storage proportionally to the number of
+distinct slugs ever fetched, which is unbounded.
+
+Same discipline on the other labels:
+
+- `status` — one of ~10 HTTP codes we emit; bounded.
+- `method` — seven HTTP verbs; bounded.
+- `endpoint` on `rate_limit_rejections_total` — the `bucket` name
+  set at middleware configuration time; bounded by the number of
+  distinct rate-limit buckets we define (currently 7).
+- `reason` on `auth_failures_total` — five stable tokens, not the
+  raw `AuthError` detail string.
+
+If you add a new labelled metric, think "could a user action
+create a new label value?" — if yes, stop and redesign. This is
+the single most common mistake with Prometheus metrics.
+
+## Local scraping
+
+```sh
+curl -s http://localhost:3101/metrics | head -40
+```
+
+Dev mode (`NODE_ENV=development` or `test`) is token-less — the
+convenience matters more than the negligible local-leak risk. Any
+scraper on the compose network can fetch.
+
+## Production scraping
+
+Production (`NODE_ENV=production`) requires an `X-Metrics-Token`
+header. The server compares against `METRICS_TOKEN` env; if the
+env is unset, `/metrics` is closed (fail-closed on
+misconfiguration, not open).
+
+```sh
+curl -H "X-Metrics-Token: $METRICS_TOKEN" https://api.example/metrics
+```
+
+Set `METRICS_TOKEN` to a long random value per env (32+ chars);
+rotate with the same cadence you rotate other ops secrets. The
+token is scraper-facing, not user-facing — a breach leaks metric
+shape, not data.
+
+## Grafana dashboard shape
+
+Not shipped here — file a follow-up once ops defines the alerting
+thresholds. Minimum useful panels:
+
+1. **Request rate**: `sum(rate(http_requests_total[1m])) by (route, status)`.
+2. **p95 latency per route**: `histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))`.
+3. **Error ratio**: `sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))`.
+4. **Rate-limit rejections**: `sum(rate(rate_limit_rejections_total[5m])) by (endpoint)`.
+5. **Auth failure rate**: `sum(rate(auth_failures_total[5m])) by (reason)` — alert on `invalid_credentials` burst.
+6. **In-flight gauge**: `http_requests_inflight` — back-pressure signal.
+
+Alerting suggestions:
+
+- Page when p95 latency on `/api/articles/:slug` exceeds 500ms for 5 minutes.
+- Page when 5xx ratio on any route exceeds 0.01 for 3 minutes.
+- Page when `invalid_credentials` > 20/min for 5 minutes (credential-stuffing signal).
+
+## Future work
+
+- Swap the `db_pool_connections` placeholder for real Prisma pool
+  stats when the Prisma team ships an introspection surface.
+  Tracked as a code comment in `middleware/metrics.ts`.
+- OpenTelemetry tracing is a different axis — see a separate issue
+  if distributed-tracing becomes a requirement.
+- A Grafana dashboard JSON + Prometheus scrape-config example
+  belongs in a dedicated ops repo when one exists.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -68,6 +68,10 @@ services:
       # headers (nosniff / DENY / Referrer-Policy / Permissions-
       # Policy) ship unconditionally.
       ENFORCE_HSTS: ${ENFORCE_HSTS:-}
+      # /metrics auth (#139). Empty in dev so local scraping works
+      # without a secret; production compose MUST set METRICS_TOKEN
+      # to a long random value or /metrics returns 401.
+      METRICS_TOKEN: ${METRICS_TOKEN:-}
     ports:
       - "${API_HOST_PORT:-3001}:3001"
     healthcheck:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       prisma:
         specifier: 7.8.0
         version: 7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -107,7 +110,7 @@ importers:
         version: 1.19.1(zod@4.3.6)
       next:
         specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -1108,6 +1111,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paulirish/trace_engine@0.0.53':
     resolution: {integrity: sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==}
@@ -2328,6 +2335,9 @@ packages:
 
   better-result@2.8.2:
     resolution: {integrity: sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bluebird@2.11.0:
     resolution: {integrity: sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==}
@@ -4757,6 +4767,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -5302,6 +5316,9 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -7063,6 +7080,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@paulirish/trace_engine@0.0.53':
     dependencies:
       legacy-javascript: 0.0.1
@@ -8422,6 +8441,8 @@ snapshots:
   bcryptjs@3.0.2: {}
 
   better-result@2.8.2: {}
+
+  bintrees@1.0.2: {}
 
   bluebird@2.11.0: {}
 
@@ -10867,7 +10888,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -10886,6 +10907,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -11357,6 +11379,11 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
 
   prop-types@15.8.1:
     dependencies:
@@ -12088,6 +12115,10 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teex@1.0.1:
     dependencies:

--- a/tests/e2e/specs/139-api-metrics.spec.ts
+++ b/tests/e2e/specs/139-api-metrics.spec.ts
@@ -1,0 +1,117 @@
+import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #139 — Prometheus /metrics endpoint.
+// Dev mode is token-less; prod requires X-Metrics-Token. Tests
+// exercise the dev path because compose ships NODE_ENV=development.
+
+const API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3101";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const fetchMetrics = async (): Promise<string> => {
+  const ctx = await request.newContext();
+  const res = await ctx.get(`${API_URL}/metrics`);
+  expect(res.status()).toBe(200);
+  expect(res.headers()["content-type"] ?? "").toMatch(/text\/plain/);
+  return res.text();
+};
+
+// Count a labelled counter value by summing all matching series in
+// the Prometheus exposition text. Simple regex — AC cares about
+// movement, not absolute numbers (baseline varies per run).
+const counterSum = (body: string, metricName: string): number => {
+  const pattern = new RegExp(`^${metricName}(\\{[^}]*\\})? (\\d+(?:\\.\\d+)?)`, "gm");
+  let total = 0;
+  for (const m of body.matchAll(pattern)) total += Number(m[2]);
+  return total;
+};
+
+test.describe("issue #139 — /metrics Prometheus endpoint", () => {
+  test("Scenario 1: /metrics returns Prometheus text with every required family", async () => {
+    // Seed a little traffic first so counters + histograms aren't
+    // empty for this fresh process.
+    const ctx = await request.newContext();
+    await ctx.get(`${API_URL}/api/tags`);
+    await ctx.get(`${API_URL}/api/articles?limit=1`);
+
+    const body = await fetchMetrics();
+
+    // Six required families (AC scenario 1 + planner's list).
+    expect(body).toMatch(/# TYPE http_requests_total counter/);
+    expect(body).toMatch(/# TYPE http_request_duration_seconds histogram/);
+    expect(body).toMatch(/# TYPE http_requests_inflight gauge/);
+    expect(body).toMatch(/# TYPE db_pool_connections gauge/);
+    expect(body).toMatch(/# TYPE rate_limit_rejections_total counter/);
+    expect(body).toMatch(/# TYPE auth_failures_total counter/);
+
+    // Histogram must cover the AC-enumerated buckets.
+    for (const le of ["0.01", "0.05", "0.1", "0.25", "0.5", "1", "2.5", "5", "10"]) {
+      expect(body).toContain(`le="${le}"`);
+    }
+  });
+
+  test("Scenario 2: route label uses the pattern, not the interpolated slug", async () => {
+    // Hit a slug-bearing route so we'd see a leak if the label
+    // interpolated.
+    const id = uniq();
+    const jake = `m-r-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `route-${id}` });
+
+    const ctx = await request.newContext();
+    await ctx.get(`${API_URL}/api/articles/${slug}`);
+
+    const body = await fetchMetrics();
+    // The pattern (Hono-style ":slug") must appear.
+    expect(body).toMatch(/route="\/api\/articles\/:slug"/);
+    // The interpolated slug must NEVER appear as a label value.
+    expect(body).not.toContain(`route="/api/articles/${slug}"`);
+  });
+
+  test("Scenario 3: http_requests_total increments per served request", async () => {
+    const before = counterSum(await fetchMetrics(), "http_requests_total");
+
+    const ctx = await request.newContext();
+    // A handful of deterministic hits.
+    for (let i = 0; i < 5; i++) {
+      await ctx.get(`${API_URL}/api/tags`);
+    }
+
+    const after = counterSum(await fetchMetrics(), "http_requests_total");
+    expect(after - before).toBeGreaterThanOrEqual(5);
+  });
+
+  test("Scenario 4: auth_failures_total increments on invalid login", async () => {
+    const before = counterSum(await fetchMetrics(), "auth_failures_total");
+
+    // Invalid credentials → AuthError("credentials", "invalid", 401).
+    const ctx = await request.newContext();
+    await ctx.post(`${API_URL}/api/users/login`, {
+      data: {
+        user: { email: "nobody-present@jake.jake", password: "jakejake" },
+      },
+    });
+
+    const after = counterSum(await fetchMetrics(), "auth_failures_total");
+    expect(after - before).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Scenario 5: histogram duration buckets populate", async () => {
+    // Any request will populate at least one bucket; confirm the
+    // counts are moving for the sum-column.
+    const ctx = await request.newContext();
+    await ctx.get(`${API_URL}/api/articles?limit=1`);
+    await ctx.get(`${API_URL}/api/tags`);
+
+    const body = await fetchMetrics();
+    const sumMatch = body.match(/http_request_duration_seconds_sum\{[^}]*\} (\d+(?:\.\d+)?)/);
+    expect(sumMatch).toBeTruthy();
+    const sum = Number(sumMatch![1]);
+    expect(sum).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #139

## User Intent

The API now exposes `/metrics` in Prometheus text format with per-route request histograms, in-flight gauge, rate-limit rejection counters, and auth-failure counters. SRE dashboards + alerting get the visibility they need — a 5xx spike or credential-stuffing burst is detectable without grepping logs. Level-2 observability ladder advancement.

## Summary

- **Library**: `prom-client` 15.x (Node canonical, MIT). New dep in `apps/api/package.json`.
- **Middleware**: `apps/api/src/middleware/metrics.ts` — dedicated `metricsRegistry`, default process/node collectors, six custom families: `http_requests_total` (counter), `http_request_duration_seconds` (histogram, AC-enumerated buckets 0.01–10s), `http_requests_inflight` (gauge), `rate_limit_rejections_total` (counter, `endpoint` label = bucket name), `auth_failures_total` (counter, `reason` label = stable enum), `db_pool_connections` (gauge, placeholder until Prisma exposes pool stats).
- **Route-pattern labels**: `metricsMiddleware` reads `c.req.routePath` (matched pattern) rather than the interpolated URL. `/api/articles/:slug` — never `/api/articles/my-great-post`. Verified by spec 139 Scenario 2.
- **Auth instrumentation** lives in `AuthError`'s constructor so the counter fires regardless of whether the route handler re-throws or catches locally. Reason labels are a bounded enum (`invalid_credentials`, `missing_or_expired_token`, `email_conflict`, `username_conflict`, `other`) — raw `field+detail` would leak cardinality.
- **Rate-limit instrumentation** sits in the rate-limit middleware on the 429 path, labelled by `bucket`.
- **/metrics route**: `GET /metrics` in `app.ts`. Dev/test = open. Production requires `X-Metrics-Token: $METRICS_TOKEN`; fail-closed when `METRICS_TOKEN` is unset.
- **Skip self**: `metricsMiddleware` bypasses `/metrics` itself so scraper traffic doesn't dominate the histograms.
- **docs/observability.md** — family table, cardinality discipline, local-scrape command, Grafana panel shapes, alerting suggestions.
- **ADR 001 addendum** — §"Metrics + observability" naming the library, cardinality stance, placement, and auth shape.

## Evidence

**Spec 139 (Playwright):**
```
✓ Scenario 1: /metrics returns Prometheus text with every required family (70ms)
✓ Scenario 2: route label uses the pattern, not the interpolated slug (218ms)
✓ Scenario 3: http_requests_total increments per served request (49ms)
✓ Scenario 4: auth_failures_total increments on invalid login (25ms)
✓ Scenario 5: histogram duration buckets populate (23ms)
5 passed (1.1s)
```

**Full Playwright suite:** 173 passed, 6 skipped. 3 intermittent — all pre-existing parallel-seed class, verified green in isolation (#15 axe, #25b healthz-503 side-stack, #127 empty-states timing). Not caused by this PR.

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions.

**Typecheck + lint** clean.

**OpenAPI drift** — `/metrics` is mounted outside the OpenAPI router so it stays off the public API surface; snapshot unchanged.

**Manual verification:**
```
$ curl -s http://localhost:3101/metrics | grep -E '^(http_requests_total|rate_limit|auth_failures|db_pool|http_requests_inflight)'
http_requests_total{method="GET",route="/api/tags",status="200"} 3
http_request_duration_seconds_bucket{le="0.01",method="GET",route="/api/articles",status="200"} 3
...
auth_failures_total{reason="invalid_credentials"} 1
db_pool_connections{state="active"} 0
db_pool_connections{state="idle"} 0
http_requests_inflight 0
```

## Notes for review

- **`db_pool_connections` ships as placeholder 0s.** Prisma 7.x doesn't yet expose pool introspection in a stable API; emitting the family with placeholder values keeps the Grafana dashboard contract stable ("0 active" is a valid chart, "metric missing" is a broken chart). Comment in `middleware/metrics.ts` flags the follow-up when Prisma exposes it.
- **AuthError constructor-side instrumentation** is the non-obvious design choice. Alternative was to instrument every `if (err instanceof AuthError)` catch site in the routes (~5 spots), or rely on the global `error.ts` handler (doesn't fire when routes catch locally). Constructor-side is the one place that catches every auth failure exactly once.
- **Prod auth fails closed** when `METRICS_TOKEN` is unset — deliberate. A misconfigured prod stack should not leak metrics publicly just because the ops team forgot to set the secret.
- `/metrics` is outside the OpenAPI surface. Metrics are ops-facing, not product-API; they shouldn't show up in the Scalar reference UI.
