### PR TITLE
fix(web): apply .article-meta .author underline in both themes (#143)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -515,7 +515,17 @@ footer {
   color: var(--conduit-text-muted);
 }
 
-[data-theme="dark"] .article-meta .author {
+/* .author link in the article-meta strip sits adjacent to the
+ * date/read-time spans. WCAG 1.4.1 requires ≥3:1 contrast between
+ * the link color and surrounding text to rely on color alone;
+ * our palette is below that in both light AND dark modes:
+ *   light: #2c7a2c link vs #373a3c text → ~1.3:1 (regression #143)
+ *   dark:  #4cc04c link vs #e8e9ea text → ~2.1:1
+ * Underline the link in both modes so the affordance is
+ * distinguishable without relying on color — matches the
+ * prose-link pattern from #93.
+ */
+.article-meta .author {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #143

## User Intent

Nothing user-visible changes semantically — the `.author` link on every article-preview card now carries an underline in both light and dark modes (it used to be dark-only). Closes a priority/1 axe regression from PR #142 that was failing the a11y gate on `/` and the layout-shell anon routes deterministically.

## Summary

- One-line CSS change: dropped the `[data-theme="dark"]` scope so `.article-meta .author` gets `text-decoration: underline` regardless of palette.
- Updated the inline comment so it reflects the actual WCAG math (light + dark both below 3:1 non-color-distinguishability) rather than my earlier incorrect claim that light mode had enough contrast.

## Evidence

**Two regressing specs — both green post-fix:**

```
  ✓ axe a11y gate on layout-shell anon routes (#87)  (#15)
  ✓ axe a11y gate on homepage with articles (#87)    (#56)
```

**Dark-mode spec unaffected:**

```
  ✓ Scenario 5: axe a11y gate on dark-palette homepage
  ✓ Scenario 6: axe a11y gate on dark-palette article detail
```

**17 specs (the regressing pair + spec 56 full + spec 136 full) green after rebuild.**

## Notes for review

- PR #142 comment claimed "Light mode keeps the canonical look (no underline) since the darker green has enough contrast." That was wrong; axe's `link-in-text-block` rule was already flagging this before dark mode — the two intermittent #15 + #56 failures we'd been seeing on full-suite runs and classifying as "parallel-seed flake" were in fact this regression manifesting non-deterministically because the axe run hits different article counts across runs. This fix makes the gate deterministic green.
- Could alternatively have darkened the link color to clear 3:1 vs body text, but that would mean diverging further from the canonical RealWorld brand green (`--conduit-green`). Underline is the lighter-touch fix.
