### PR TITLE
feat(web): structured data (JSON-LD) on article + profile + homepage (#148)

### DIFF
--- a/apps/web/src/app/article/[slug]/page.tsx
+++ b/apps/web/src/app/article/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ArticleBody } from "@/components/article/ArticleBody";
 import { ArticleMeta } from "@/components/article/ArticleMeta";
 import { CommentList } from "@/components/comment/CommentList";
 import { CommentForm } from "@/components/comment/CommentForm";
+import { JsonLd } from "@/components/JsonLd";
 import { CommentsSkeleton } from "@/components/skeletons/CommentsSkeleton";
 import {
   getArticle,
@@ -16,6 +17,7 @@ import {
   isAuthenticated,
   readCurrentUsername,
 } from "@/features/auth/session";
+import { buildArticleJsonLd } from "@/lib/jsonld";
 import { siteUrl } from "@/lib/site";
 
 // Dynamic share-preview metadata (#113). When a link previewer
@@ -108,6 +110,8 @@ export default async function ArticlePage({
 
   return (
     <div className="article-page">
+      {/* Article JSON-LD (#148). Rich-results eligibility in SERPs. */}
+      <JsonLd payload={buildArticleJsonLd(article)} id="jsonld-article" />
       <div className="banner">
         <div className="container">
           <h1>{article.title}</h1>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { ArticleList } from "@/components/article/ArticleList";
 import { SearchBar } from "@/components/article/SearchBar";
 import { FeedTabs, type FeedMode } from "@/components/FeedTabs";
+import { JsonLd } from "@/components/JsonLd";
 import { TagCloud } from "@/components/TagCloud";
 import { TagCloudSkeleton } from "@/components/skeletons/TagCloudSkeleton";
 import {
@@ -11,6 +12,7 @@ import {
   type ArticleListPayload,
 } from "@/features/articles/queries";
 import { isAuthenticated } from "@/features/auth/session";
+import { buildWebSiteJsonLd } from "@/lib/jsonld";
 
 // Home page. RSC; reads search params + session cookie, picks the
 // article source (global list vs personalised feed vs tag-filtered
@@ -107,6 +109,11 @@ export default async function Home({
 
   return (
     <div className="home-page">
+      {/* WebSite + SearchAction JSON-LD (#148). Search engines
+          render an in-SERP search box for the site when this is
+          present. The action template points at /?q={search} —
+          same URL SearchBar (#117) emits. */}
+      <JsonLd payload={buildWebSiteJsonLd()} id="jsonld-website" />
       <div className="banner">
         <div className="container">
           <h1 className="logo-font">conduit</h1>

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArticleList } from "@/components/article/ArticleList";
+import { JsonLd } from "@/components/JsonLd";
 import { ProfileBanner } from "@/components/profile/ProfileBanner";
 import { ArticleListSkeleton } from "@/components/skeletons/ArticleListSkeleton";
 import {
@@ -14,6 +15,7 @@ import {
   readCurrentUsername,
 } from "@/features/auth/session";
 import { getProfile } from "@/features/profiles/queries";
+import { buildPersonJsonLd } from "@/lib/jsonld";
 import { siteUrl } from "@/lib/site";
 
 // Dynamic share-preview metadata (#113). See the article page's
@@ -118,6 +120,9 @@ export default async function ProfilePage({
 
   return (
     <div className="profile-page">
+      {/* Person JSON-LD (#148). Profile pages opt into Person
+          rich-results. */}
+      <JsonLd payload={buildPersonJsonLd(profile)} id="jsonld-person" />
       <ProfileBanner
         profile={profile}
         viewerUsername={viewerUsername}

--- a/apps/web/src/components/JsonLd.tsx
+++ b/apps/web/src/components/JsonLd.tsx
@@ -1,0 +1,46 @@
+// JSON-LD script tag renderer (#148). Takes a serializable
+// schema.org payload and emits a `<script type="application/ld+json">`
+// with the JSON stringified in a way that can't be prematurely
+// closed by a literal `</script>` inside a title / description /
+// bio. The escape strategy: replace `</` with `<\/` in the
+// serialized output. Parsers accept the escaped form as
+// equivalent; a literal `</script>` inside a title no longer
+// terminates the enclosing script tag.
+//
+// We use React's `dangerouslySetInnerHTML` because it's the only
+// way to inject raw text inside a `<script>` element — React's
+// normal children rendering would escape the JSON's quotes. The
+// sanitize() step below is what makes the raw text safe: input
+// from `JSON.stringify` has no interpretable HTML except for
+// sequences containing `</`, which we rewrite to the escaped
+// form before the string ever reaches the DOM. This is the
+// canonical pattern documented by OWASP for embedding JSON in
+// HTML (see "Embedding JSON directly in HTML" in the XSS Prevention
+// Cheat Sheet).
+
+type Props = {
+  payload: Record<string, unknown>;
+  // Distinct id helps the Playwright spec query multiple JsonLd
+  // emissions on the same page (e.g. homepage WebSite + a stats
+  // object). Defaults to type-derived so callers rarely pass it.
+  id?: string;
+};
+
+// Replace every `</` occurrence with `<\/` in the serialized JSON.
+// `</script>` inside a user-supplied title would otherwise close
+// the enclosing <script> tag and inject attacker-controlled HTML.
+const sanitizeForScriptTag = (json: string): string =>
+  json.replace(/<\//g, "<\\/");
+
+export const JsonLd = ({ payload, id }: Props) => {
+  const scriptId = id ?? `jsonld-${payload["@type"] ?? "data"}`;
+  const safe = sanitizeForScriptTag(JSON.stringify(payload));
+  return (
+    <script
+      id={scriptId}
+      type="application/ld+json"
+      data-testid="jsonld"
+      dangerouslySetInnerHTML={{ __html: safe }}
+    />
+  );
+};

--- a/apps/web/src/lib/jsonld.ts
+++ b/apps/web/src/lib/jsonld.ts
@@ -1,0 +1,96 @@
+import type { Article } from "@/features/articles/queries";
+import { siteUrl } from "./site";
+
+// Builders for schema.org JSON-LD payloads (#148). Returns plain
+// serializable objects; the <JsonLd> component handles the
+// `<script>` wrapping + the `</` escape that prevents a literal
+// `</script>` inside a title from closing the script tag early.
+//
+// Hand-typed rather than pulling in `schema-dts` — the subset we
+// emit is tiny (Article, Person, WebSite + SearchAction) and the
+// dependency would be 5x the size of the payload it types.
+
+// Minimum shape of our JSON-LD payloads. Schema.org permits many
+// more properties; we emit only the ones crawlers weight highly.
+type JsonLdObject = Record<string, unknown>;
+
+const ORG_NAME = "Conduit";
+
+// Trim the origin once per build; siteUrl already handles this,
+// but we surface it here so callers can concatenate without
+// thinking about trailing slashes.
+const origin = (): string => siteUrl();
+
+// Omit null / empty values from the final payload so crawlers
+// don't see `"description": null` — that fails some validators
+// and adds noise in Search Console's rich-result report.
+const compact = <T extends JsonLdObject>(obj: T): T => {
+  const out: JsonLdObject = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined || value === "") continue;
+    out[key] = value;
+  }
+  return out as T;
+};
+
+export const buildArticleJsonLd = (article: Article): JsonLdObject => {
+  const authorUrl = `${origin()}/profile/${article.author.username}`;
+  const author = compact({
+    "@type": "Person",
+    name: article.author.username,
+    url: authorUrl,
+    image: article.author.image,
+  });
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: article.title,
+    description: article.description,
+    datePublished: article.createdAt,
+    dateModified: article.updatedAt,
+    mainEntityOfPage: `${origin()}/article/${article.slug}`,
+    author,
+    publisher: {
+      "@type": "Organization",
+      name: ORG_NAME,
+      url: origin(),
+    },
+    image: article.author.image ?? undefined,
+  });
+};
+
+export type PersonJsonLdInput = {
+  username: string;
+  bio: string | null;
+  image: string | null;
+};
+
+export const buildPersonJsonLd = (user: PersonJsonLdInput): JsonLdObject =>
+  compact({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: user.username,
+    description: user.bio,
+    image: user.image,
+    url: `${origin()}/profile/${user.username}`,
+  });
+
+export const buildWebSiteJsonLd = (): JsonLdObject => ({
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: ORG_NAME,
+  url: origin(),
+  // SearchAction points at the homepage's `?q=` query — the
+  // same search parameter the SearchBar from #117 reads. Google
+  // uses this to render an in-SERP search box for the site.
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${origin()}/?q={search_term_string}`,
+    },
+    // `query-input` naming is a schema.org quirk — it's a string,
+    // not an object, and search engines expect exactly this form.
+    "query-input": "required name=search_term_string",
+  },
+});

--- a/tests/e2e/specs/148-web-jsonld-structured-data.spec.ts
+++ b/tests/e2e/specs/148-web-jsonld-structured-data.spec.ts
@@ -1,0 +1,202 @@
+import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+import { runAxe } from "../axe-config";
+
+// BDD coverage for issue #148 — schema.org JSON-LD structured
+// data on article / profile / homepage. Parses each page's
+// `<script type="application/ld+json">` blocks, asserts the
+// required shape, plus the XSS-injection resilience check.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Parse every JSON-LD script blob on the page. Returns an array of
+// parsed objects; most pages have a single blob but the homepage
+// could add more in the future.
+const readJsonLd = async (
+  page: import("@playwright/test").Page,
+): Promise<unknown[]> => {
+  const raw = await page
+    .locator('script[type="application/ld+json"]')
+    .allTextContents();
+  return raw.map((s) => JSON.parse(s));
+};
+
+test.describe("issue #148 — JSON-LD structured data", () => {
+  test("Scenario 1: article page emits Article JSON-LD with required properties", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `ld-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const article = await api.createArticle({
+      title: `JSON-LD article ${id}`,
+      description: "Structured data coverage article",
+    });
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+    const blobs = await readJsonLd(page);
+    expect(blobs.length).toBeGreaterThan(0);
+
+    const articleBlob = blobs.find(
+      (b) => (b as Record<string, unknown>)["@type"] === "Article",
+    ) as Record<string, unknown> | undefined;
+    expect(articleBlob).toBeTruthy();
+    expect(articleBlob?.["@context"]).toBe("https://schema.org");
+    expect(articleBlob?.headline).toBe(`JSON-LD article ${id}`);
+    expect(articleBlob?.description).toBe("Structured data coverage article");
+    expect(typeof articleBlob?.datePublished).toBe("string");
+    expect(typeof articleBlob?.dateModified).toBe("string");
+    // author is a nested Person
+    const author = articleBlob?.author as Record<string, unknown> | undefined;
+    expect(author?.["@type"]).toBe("Person");
+    expect(author?.name).toBe(jake);
+    expect(String(author?.url ?? "")).toMatch(/\/profile\/ld-/);
+    // publisher is an Organization
+    const publisher = articleBlob?.publisher as
+      | Record<string, unknown>
+      | undefined;
+    expect(publisher?.["@type"]).toBe("Organization");
+    expect(publisher?.name).toBe("Conduit");
+  });
+
+  test("Scenario 2: profile page emits Person JSON-LD", async ({ page }) => {
+    const id = uniq();
+    const jake = `ld-p-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+    const blobs = await readJsonLd(page);
+    const personBlob = blobs.find(
+      (b) => (b as Record<string, unknown>)["@type"] === "Person",
+    ) as Record<string, unknown> | undefined;
+    expect(personBlob).toBeTruthy();
+    expect(personBlob?.name).toBe(jake);
+    expect(String(personBlob?.url ?? "")).toMatch(/\/profile\/ld-p-/);
+  });
+
+  test("Scenario 3: homepage emits WebSite + SearchAction JSON-LD", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    const blobs = await readJsonLd(page);
+    const siteBlob = blobs.find(
+      (b) => (b as Record<string, unknown>)["@type"] === "WebSite",
+    ) as Record<string, unknown> | undefined;
+    expect(siteBlob).toBeTruthy();
+    expect(siteBlob?.name).toBe("Conduit");
+    const action = siteBlob?.potentialAction as
+      | Record<string, unknown>
+      | undefined;
+    expect(action?.["@type"]).toBe("SearchAction");
+    const target = action?.target as Record<string, unknown> | undefined;
+    expect(String(target?.urlTemplate ?? "")).toMatch(
+      /\?q=\{search_term_string\}$/,
+    );
+  });
+
+  test("Scenario 4: </script> inside a title is escaped — no script-tag breakout", async ({
+    page,
+  }) => {
+    // Seed an article whose title contains a literal `</script>`
+    // followed by attacker-controlled script payload. If the
+    // JsonLd sanitize step works, the rendered HTML contains the
+    // escaped form `<\/script>` and no extra script element gets
+    // injected into the DOM.
+    const id = uniq();
+    const jake = `ld-xss-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const malicious = `</script><script data-testid="xss-attempt">window.__xss=true;</script>pwned-${id}`;
+    const article = await api.createArticle({
+      title: malicious,
+      description: "safe desc",
+    });
+
+    // Surface any JS console errors that might accompany a
+    // breakout so we'd notice if the page did something odd.
+    const consoleErrors: string[] = [];
+    page.on("pageerror", (err) => consoleErrors.push(err.message));
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+
+    // The injected <script> element must NOT have run. If it had,
+    // `window.__xss` would be set to true.
+    const xssRan = await page.evaluate(
+      () => (window as unknown as { __xss?: boolean }).__xss === true,
+    );
+    expect(xssRan).toBe(false);
+
+    // The data-testid the attacker picked must NOT appear as a
+    // real DOM element (the literal string may appear inside the
+    // JSON-LD script's text content, but no live script element
+    // should match).
+    const xssScriptCount = await page
+      .locator('script[data-testid="xss-attempt"]')
+      .count();
+    expect(xssScriptCount).toBe(0);
+
+    // The JSON-LD blob's headline should round-trip the malicious
+    // title back through JSON.parse — no double-encoding, no data
+    // loss, no breakout.
+    const blobs = await readJsonLd(page);
+    const articleBlob = blobs.find(
+      (b) => (b as Record<string, unknown>)["@type"] === "Article",
+    ) as Record<string, unknown> | undefined;
+    expect(articleBlob?.headline).toBe(malicious);
+
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("Scenario 5: JSON-LD uses absolute canonical URLs", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `ld-url-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const article = await api.createArticle({ title: `url-${id}` });
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+    const blobs = await readJsonLd(page);
+    const articleBlob = blobs.find(
+      (b) => (b as Record<string, unknown>)["@type"] === "Article",
+    ) as Record<string, unknown> | undefined;
+    expect(articleBlob).toBeTruthy();
+
+    // Every URL property we emit must start with http — no bare
+    // paths, no protocol-relative.
+    const author = articleBlob?.author as Record<string, unknown> | undefined;
+    expect(String(author?.url ?? "")).toMatch(/^https?:\/\//);
+    expect(String(articleBlob?.mainEntityOfPage ?? "")).toMatch(
+      /^https?:\/\//,
+    );
+  });
+
+  test("Scenario 6: axe a11y gate on pages with JSON-LD", async ({ page }) => {
+    // JSON-LD has no visible surface; confirm we didn't regress
+    // the page-level axe score on the article-detail surface that
+    // gained the new script element.
+    const id = uniq();
+    const jake = `ld-a-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const article = await api.createArticle({ title: `axe-${id}` });
+
+    await page.goto(`${WEB_URL}/article/${article.slug}`);
+    await expect(page.locator(".article-page")).toBeVisible();
+    // Also probe via request to verify the ld+json script is
+    // content-type text (axe shouldn't look at non-visible
+    // content). This is belt-and-braces.
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/article/${article.slug}`);
+    expect(res.status()).toBe(200);
+    await runAxe(page);
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #148

## User Intent

Search engines and rich-result renderers now see `schema.org` JSON-LD on every indexable page — `Article` on `/article/<slug>`, `Person` on `/profile/<username>`, `WebSite + SearchAction` on `/`. This unlocks article-card rendering in Google SERPs (headshot + byline + publish date) and an in-SERP site search box. Implementation is a script tag emitted by each page + a safety net that prevents user-supplied content (`</script>` inside a title) from breaking out.

## Summary

- **`apps/web/src/lib/jsonld.ts`** — builders: `buildArticleJsonLd(article)`, `buildPersonJsonLd(user)`, `buildWebSiteJsonLd()`. Hand-typed rather than pulling in `schema-dts` — the subset we emit is tiny and the dependency would be 5× the payload it types. All URLs come from `siteUrl()` (#113) so the canonical origin matches OG + sitemap.
- **`apps/web/src/components/JsonLd.tsx`** — renders `<script type="application/ld+json">` with the stringified payload. Every `</` in the serialized output is replaced with `<\/` before injection. That's the OWASP-recommended escape for JSON embedded in HTML; it prevents a literal `</script>` inside user-supplied text from closing the script tag early.
- **Wired** into `apps/web/src/app/article/[slug]/page.tsx`, `apps/web/src/app/profile/[username]/page.tsx`, `apps/web/src/app/page.tsx`. Each page emits one JSON-LD blob; IDs (`jsonld-article` / `jsonld-person` / `jsonld-website`) let specs scope without ambiguity.

## Evidence

**Spec 148 (Playwright) — 6/6 including the XSS scenario:**

```
✓ Scenario 1: article page emits Article JSON-LD with required properties
✓ Scenario 2: profile page emits Person JSON-LD
✓ Scenario 3: homepage emits WebSite + SearchAction JSON-LD
✓ Scenario 4: </script> inside a title is escaped — no script-tag breakout
✓ Scenario 5: JSON-LD uses absolute canonical URLs
✓ Scenario 6: axe a11y gate on pages with JSON-LD
6 passed (3.9s)
```

**XSS scenario (Scenario 4)**: seeds an article with title containing a literal `</script><script data-testid="xss-attempt">window.__xss=true;</script>` prefix. Asserts `window.__xss` is NOT set (the injected script did not execute), no `script[data-testid="xss-attempt"]` element appears in the DOM, and the JSON-LD `headline` round-trips the raw string verbatim when parsed back through `JSON.parse`.

**Full Playwright suite:** 200 passed, 6 skipped, 1 intermittent (`#18 Scenario 7 comment delete`) — pre-existing parallel-seed flake.

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions.

**Typecheck + lint** clean.

**Manual verification:**

```
$ curl -s http://localhost:3100/ | grep -oE 'application/ld\+json|@type[^,]*' | head
application/ld+json
@type":"WebSite"
@type":"SearchAction"
@type":"EntryPoint"

$ curl -s http://localhost:3100/article/<slug> | grep -oE '@type":"Article"|headline'
@type":"Article"
headline
```

## Notes for review

- **Raw-HTML injection is unavoidable** for putting text inside a `<script>` element — React's normal child rendering would HTML-escape the JSON's quotes and break the payload. The sanitize step (`</` → `<\/`) is what makes the raw text safe: the serialized JSON has no interpretable HTML except for sequences starting `</`, which we rewrite before they reach the DOM. Comment in `JsonLd.tsx` flags the OWASP reference so a future security review can see the justification.
- **Scenario 4 is the load-bearing spec.** If a future refactor ever swaps the raw insertion for a non-sanitized variant, scenario 4 fails immediately. The XSS payload is deliberately concrete (sets `window.__xss=true`) rather than a vague "no extra scripts" check — it tests exactly the class of attack the escape exists to block.
- **Homepage SearchAction** points at `/?q={search_term_string}`, matching what #117's `SearchBar` emits. Google uses this to draw an in-SERP search box under the Conduit site entry.
- **`compact()` helper** drops `null` / empty keys from every payload so crawlers don't see `"description": null` (some rich-result validators flag that).
