### PR TITLE
feat(web): RSS feeds — global + per-tag + per-author (#150)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,6 +21,15 @@ export const metadata: Metadata = {
       { url: "/icons/apple-touch-icon.png", sizes: "180x180" },
     ],
   },
+  // Global RSS feed discovery (#150). Feed readers scan <head>
+  // for <link rel="alternate"> with an Atom/RSS type and
+  // auto-subscribe. Per-author + per-tag feeds override on their
+  // own pages below.
+  alternates: {
+    types: {
+      "application/atom+xml": "/rss.xml",
+    },
+  },
 };
 
 // theme-color (#149) with separate light + dark entries so the

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { ArticleList } from "@/components/article/ArticleList";
 import { SearchBar } from "@/components/article/SearchBar";
@@ -19,6 +20,30 @@ import { buildWebSiteJsonLd } from "@/lib/jsonld";
 // list), and renders the RealWorld banner + feed tabs + article list +
 // tag sidebar in one server render. No client components — the
 // interactive favorite button lands in follow-up issue #56.
+
+// Per-tag RSS feed discovery (#150). When the user is on
+// `/?tag=<tag>`, override the layout's global-feed alternate with
+// the tag-specific feed so a reader auto-subscribes to just that
+// tag. Falls through to the layout's default for other modes.
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}): Promise<Metadata> {
+  const sp = await searchParams;
+  const raw = sp.tag;
+  const tag = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof tag === "string" && tag.length > 0) {
+    return {
+      alternates: {
+        types: {
+          "application/atom+xml": `/rss/tag/${encodeURIComponent(tag)}`,
+        },
+      },
+    };
+  }
+  return {};
+}
 
 const PAGE_SIZE = 20;
 

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -56,6 +56,15 @@ export async function generateMetadata({
       description,
       ...(profile.image ? { images: [profile.image] } : {}),
     },
+    // Per-author RSS feed discovery (#150). The global feed link
+    // lives on the root layout; this override adds the author-
+    // specific feed so a reader on /profile/<user> can one-click
+    // subscribe to just that user's articles.
+    alternates: {
+      types: {
+        "application/atom+xml": `/rss/author/${encodeURIComponent(profile.username)}`,
+      },
+    },
   };
 }
 

--- a/apps/web/src/app/rss.xml/route.ts
+++ b/apps/web/src/app/rss.xml/route.ts
@@ -1,0 +1,31 @@
+import { listArticles } from "@/features/articles/queries";
+import {
+  buildAtomFeed,
+  FEED_CACHE_CONTROL,
+  FEED_CONTENT_TYPE,
+  FEED_LIMIT,
+} from "@/lib/rss";
+import { siteUrl } from "@/lib/site";
+
+// Global feed (#150). Newest 20 articles across the whole site.
+// Used by feed readers as the default "follow the whole
+// publication" subscription.
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const origin = siteUrl();
+  const payload = await listArticles({ limit: FEED_LIMIT });
+  const xml = buildAtomFeed(payload.articles, {
+    title: "Conduit — Latest articles",
+    webUrl: `${origin}/`,
+    feedUrl: `${origin}/rss.xml`,
+  });
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      "Content-Type": FEED_CONTENT_TYPE,
+      "Cache-Control": FEED_CACHE_CONTROL,
+    },
+  });
+}

--- a/apps/web/src/app/rss/author/[username]/route.ts
+++ b/apps/web/src/app/rss/author/[username]/route.ts
@@ -1,0 +1,33 @@
+import { listArticles } from "@/features/articles/queries";
+import {
+  buildAtomFeed,
+  FEED_CACHE_CONTROL,
+  FEED_CONTENT_TYPE,
+  FEED_LIMIT,
+} from "@/lib/rss";
+import { siteUrl } from "@/lib/site";
+
+// Per-author feed (#150). Newest 20 articles by `<username>`.
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ username: string }> },
+) {
+  const { username } = await params;
+  const origin = siteUrl();
+  const payload = await listArticles({ author: username, limit: FEED_LIMIT });
+  const xml = buildAtomFeed(payload.articles, {
+    title: `Conduit — Articles by ${username}`,
+    webUrl: `${origin}/profile/${encodeURIComponent(username)}`,
+    feedUrl: `${origin}/rss/author/${encodeURIComponent(username)}`,
+  });
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      "Content-Type": FEED_CONTENT_TYPE,
+      "Cache-Control": FEED_CACHE_CONTROL,
+    },
+  });
+}

--- a/apps/web/src/app/rss/tag/[tag]/route.ts
+++ b/apps/web/src/app/rss/tag/[tag]/route.ts
@@ -1,0 +1,33 @@
+import { listArticles } from "@/features/articles/queries";
+import {
+  buildAtomFeed,
+  FEED_CACHE_CONTROL,
+  FEED_CONTENT_TYPE,
+  FEED_LIMIT,
+} from "@/lib/rss";
+import { siteUrl } from "@/lib/site";
+
+// Per-tag feed (#150). Newest 20 articles tagged `<tag>`.
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ tag: string }> },
+) {
+  const { tag } = await params;
+  const origin = siteUrl();
+  const payload = await listArticles({ tag, limit: FEED_LIMIT });
+  const xml = buildAtomFeed(payload.articles, {
+    title: `Conduit — Articles tagged #${tag}`,
+    webUrl: `${origin}/?tag=${encodeURIComponent(tag)}`,
+    feedUrl: `${origin}/rss/tag/${encodeURIComponent(tag)}`,
+  });
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      "Content-Type": FEED_CONTENT_TYPE,
+      "Cache-Control": FEED_CACHE_CONTROL,
+    },
+  });
+}

--- a/apps/web/src/lib/rss.ts
+++ b/apps/web/src/lib/rss.ts
@@ -1,0 +1,105 @@
+import type { ArticleListItem } from "@/features/articles/queries";
+import { siteUrl } from "./site";
+
+// Atom 1.0 feed builder (#150). Handwritten — the surface is tiny
+// (root <feed> + N <entry>s), the escape rules are straightforward,
+// and pulling in `feed` or `xmlbuilder2` would add ~30KB for no
+// functionality our users' readers need.
+//
+// Escape strategy: pass every author-supplied string (title,
+// description, username) through `escapeXml` before embedding.
+// Character references for `&`, `<`, `>`, `"`, `'` are the full
+// set Atom requires; no other transformation is needed because
+// Atom entries use plain text (no HTML), not embedded markup.
+
+type FeedMeta = {
+  // Feed-level title: "Conduit — Latest articles", "... tagged #react", etc.
+  title: string;
+  // Canonical URL the feed surfaces — homepage for the global
+  // feed, profile URL for author feeds, filtered homepage for
+  // tag feeds.
+  webUrl: string;
+  // Self URL — the feed URL itself. Helps aggregators cache and
+  // detect redirects.
+  feedUrl: string;
+};
+
+const escapeXml = (raw: string): string =>
+  raw
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+// Stable URN for each entry. Using `tag:<host>,<date>:article/<slug>`
+// is the canonical pattern for content feeds (RFC 4151). Readers
+// dedupe on `<id>`, so using the slug keeps dedup working even
+// when we regenerate the feed.
+const entryId = (origin: string, slug: string): string => {
+  const host = origin.replace(/^https?:\/\//, "").replace(/:\d+$/, "");
+  // Use the article's publish year for the date component; we
+  // don't have that pre-parsed here, but "first-write" stability
+  // isn't needed — the slug alone is unique. Hardcode 2026 as
+  // the registration year for this tag URI scheme.
+  return `tag:${host},2026:article/${slug}`;
+};
+
+export const buildAtomFeed = (
+  articles: ArticleListItem[],
+  meta: FeedMeta,
+): string => {
+  const origin = siteUrl();
+  const updated =
+    articles.length > 0
+      ? articles[0]!.updatedAt
+      : new Date().toISOString();
+
+  const entries = articles
+    .map((article) => {
+      const url = `${origin}/article/${article.slug}`;
+      return [
+        "  <entry>",
+        `    <title>${escapeXml(article.title)}</title>`,
+        `    <link href="${escapeXml(url)}" rel="alternate" />`,
+        `    <id>${entryId(origin, article.slug)}</id>`,
+        `    <updated>${article.updatedAt}</updated>`,
+        `    <published>${article.createdAt}</published>`,
+        `    <summary>${escapeXml(article.description)}</summary>`,
+        "    <author>",
+        `      <name>${escapeXml(article.author.username)}</name>`,
+        `      <uri>${escapeXml(`${origin}/profile/${article.author.username}`)}</uri>`,
+        "    </author>",
+        ...article.tagList.map(
+          (t) => `    <category term="${escapeXml(t)}" />`,
+        ),
+        "  </entry>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <title>${escapeXml(meta.title)}</title>`,
+    `  <link href="${escapeXml(meta.webUrl)}" rel="alternate" />`,
+    `  <link href="${escapeXml(meta.feedUrl)}" rel="self" />`,
+    `  <id>${meta.webUrl}</id>`,
+    `  <updated>${updated}</updated>`,
+    entries,
+    "</feed>",
+    "",
+  ].join("\n");
+};
+
+// Standard Cache-Control for every feed endpoint. Readers poll
+// every 30-60 minutes; max-age=5min + swr=1h keeps the DB load
+// low and readers fresh.
+export const FEED_CACHE_CONTROL =
+  "public, max-age=300, stale-while-revalidate=3600";
+
+// Atom MIME type.
+export const FEED_CONTENT_TYPE = "application/atom+xml; charset=utf-8";
+
+// Feed item cap per the AC — 20 newest per feed.
+export const FEED_LIMIT = 20;

--- a/tests/e2e/specs/150-web-rss-feeds.spec.ts
+++ b/tests/e2e/specs/150-web-rss-feeds.spec.ts
@@ -1,0 +1,200 @@
+import { expect, request, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+
+// BDD coverage for issue #150 — Atom feeds for the global feed,
+// per-tag feeds, and per-author feeds. Asserts well-formed XML,
+// the required Atom envelope + entry shape, correct caching
+// headers, and the `<link rel="alternate">` discoverability tags
+// on home / profile / tag-filtered pages.
+//
+// Note on paths: Next.js 16's file-router treats `[slug].xml` as
+// the segment name "slug].xml" rather than a slug with an
+// extension, so the RSS dynamic routes live at `/rss/tag/<tag>`
+// and `/rss/author/<username>` (no .xml suffix). Feed readers
+// key on the Content-Type header, not the URL suffix — this is
+// standards-compliant.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+// Minimal XML well-formedness probe: split into opening tags and
+// closing tags and make sure they balance. A real XML parser is
+// overkill for the shape we emit; this catches missing closes or
+// mismatched nesting.
+const tagBalance = (
+  xml: string,
+  name: string,
+): { opens: number; closes: number } => {
+  const opens = (
+    xml.match(new RegExp(`<${name}(?:\\s[^>]*)?>`, "g")) ?? []
+  ).length;
+  const closes = (xml.match(new RegExp(`</${name}>`, "g")) ?? []).length;
+  return { opens, closes };
+};
+
+const extractTextAll = (xml: string, tag: string): string[] => {
+  const out: string[] = [];
+  const re = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, "g");
+  for (const m of xml.matchAll(re)) out.push(m[1]);
+  return out;
+};
+
+test.describe("issue #150 — RSS / Atom feeds", () => {
+  test("Scenario 1: /rss.xml is a well-formed Atom feed with correct headers", async () => {
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/rss.xml`);
+    expect(res.status()).toBe(200);
+
+    const contentType = res.headers()["content-type"] ?? "";
+    expect(contentType).toMatch(/atom\+xml/);
+
+    const cache = res.headers()["cache-control"] ?? "";
+    expect(cache).toMatch(/public/);
+    expect(cache).toMatch(/max-age=300/);
+    expect(cache).toMatch(/stale-while-revalidate=3600/);
+
+    const xml = await res.text();
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    // Root <feed> matches close tag.
+    const { opens, closes } = tagBalance(xml, "feed");
+    expect(opens).toBe(1);
+    expect(closes).toBe(1);
+    // Exactly one <title> at the root (entry titles are nested
+    // under <entry> but our extractTextAll grabs only direct tag
+    // matches — multiple is OK on a seeded DB).
+    expect(xml).toMatch(
+      /<title>Conduit — Latest articles<\/title>/,
+    );
+    // Self-reference link.
+    expect(xml).toMatch(/rel="self"/);
+  });
+
+  test("Scenario 2: /rss/author/<username> filters to that author's articles", async () => {
+    const id = uniq();
+    const jake = `rss-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    await api.createArticle({ title: `rss-a-${id}` });
+
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/rss/author/${jake}`);
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+
+    expect(xml).toMatch(new RegExp(`Articles by ${jake}`));
+    const titles = extractTextAll(xml, "title");
+    // First <title> is the feed title; subsequent are entries.
+    // At least one entry title should match our seed.
+    const match = titles.some((t) => t.includes(`rss-a-${id}`));
+    expect(match).toBe(true);
+    // Every <author><name>...</name></author> inside an <entry>
+    // must be our author — ensure no cross-author leak.
+    const names = extractTextAll(xml, "name");
+    expect(names.every((n) => n === jake)).toBe(true);
+  });
+
+  test("Scenario 3: /rss/tag/<tag> filters to that tag's articles", async () => {
+    const id = uniq();
+    const tag = `t${id.replace(/\D/g, "").slice(0, 10)}`;
+    const jake = `rsst-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    await api.createArticle({
+      title: `rss-t-${id}`,
+      tagList: [tag],
+    });
+
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/rss/tag/${tag}`);
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+
+    expect(xml).toMatch(new RegExp(`Articles tagged #${tag}`));
+    // Our seeded entry's tag category should appear.
+    expect(xml).toMatch(new RegExp(`category term="${tag}"`));
+  });
+
+  test("Scenario 4: feed URLs are absolute, use canonical origin", async () => {
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/rss.xml`);
+    const xml = await res.text();
+    // Self + alternate links at the root carry absolute URLs.
+    const hrefs = [...xml.matchAll(/<link href="([^"]+)"/g)].map((m) => m[1]);
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      expect(href).toMatch(/^https?:\/\//);
+    }
+  });
+
+  test("Scenario 5: home page renders <link rel=alternate> pointing at /rss.xml", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    const links = page.locator(
+      'link[rel="alternate"][type*="atom"], link[rel="alternate"][type*="rss"]',
+    );
+    await expect(links.first()).toHaveAttribute("href", /\/rss\.xml$/);
+  });
+
+  test("Scenario 6: profile page alternate-link points to per-author feed", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rss-p-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+    const links = page.locator(
+      'link[rel="alternate"][type*="atom"], link[rel="alternate"][type*="rss"]',
+    );
+    const href = await links.first().getAttribute("href");
+    expect(href).toBeTruthy();
+    expect(href).toMatch(new RegExp(`/rss/author/${jake}$`));
+  });
+
+  test("Scenario 7: tag-filtered home page alternate-link points to per-tag feed", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const tag = `tg${id.replace(/\D/g, "").slice(0, 8)}`;
+    await page.goto(`${WEB_URL}/?tag=${tag}`);
+    const links = page.locator(
+      'link[rel="alternate"][type*="atom"], link[rel="alternate"][type*="rss"]',
+    );
+    const href = await links.first().getAttribute("href");
+    expect(href).toBeTruthy();
+    expect(href).toMatch(new RegExp(`/rss/tag/${tag}$`));
+  });
+
+  test("Scenario 8: XML escapes author-supplied strings (no script injection via title)", async () => {
+    const id = uniq();
+    const jake = `rss-xss-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    // Title with characters XML must escape.
+    await api.createArticle({
+      title: `rss-xml "<>&'-${id}`,
+    });
+
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${WEB_URL}/rss/author/${jake}`);
+    const xml = await res.text();
+
+    // The literal `<` from the title MUST NOT appear — it must be
+    // &lt;. Same for the other metacharacters.
+    expect(xml).not.toMatch(/rss-xml "<>/);
+    expect(xml).toMatch(/&lt;/);
+    expect(xml).toMatch(/&gt;/);
+    expect(xml).toMatch(/&quot;/);
+    expect(xml).toMatch(/&amp;/);
+    expect(xml).toMatch(/&apos;/);
+
+    // No double-escape (&amp;amp;).
+    expect(xml).not.toMatch(/&amp;amp;/);
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #150

## User Intent

Readers who prefer feed aggregators (Reeder, NetNewsWire, Feedly, Thunderbird) can subscribe to Conduit via Atom 1.0. Three feeds: global (newest 20 site-wide), per-tag, per-author. Feed readers auto-discover via `<link rel="alternate">` on the matching HTML page — landing on `/profile/jake` and clicking the RSS icon in the browser bar subscribes to just jake's articles.

## Summary

- **`apps/web/src/lib/rss.ts`** — handwritten Atom 1.0 builder (~80 LOC). Skips the `feed` dep since the surface is tiny + escape rules are simple. `escapeXml` handles all 5 metacharacters; stable URN `<id>` per-entry via RFC 4151 tag URI.
- **Three route handlers** at `apps/web/src/app/rss.xml/route.ts`, `rss/tag/[tag]/route.ts`, `rss/author/[username]/route.ts`. Each calls `listArticles` with the appropriate filter (limit 20, newest-first) and returns Atom XML with `Cache-Control: public, max-age=300, stale-while-revalidate=3600`.
- **Discoverability**:
  - Layout metadata adds `<link rel="alternate" type="application/atom+xml" href="/rss.xml">` globally.
  - Profile page's `generateMetadata` overrides with `/rss/author/<username>`.
  - Home page's `generateMetadata` overrides with `/rss/tag/<tag>` when `?tag=` is present.

## Evidence

**Spec 150 (Playwright) — 8/8:**
```
✓ Scenario 1: /rss.xml is a well-formed Atom feed with correct headers (52ms)
✓ Scenario 2: /rss/author/<username> filters to that author's articles (225ms)
✓ Scenario 3: /rss/tag/<tag> filters to that tag's articles (160ms)
✓ Scenario 4: feed URLs are absolute, use canonical origin (22ms)
✓ Scenario 5: home page renders <link rel=alternate> pointing at /rss.xml (316ms)
✓ Scenario 6: profile page alternate-link points to per-author feed (393ms)
✓ Scenario 7: tag-filtered home page alternate-link points to per-tag feed (208ms)
✓ Scenario 8: XML escapes author-supplied strings (no script injection via title) (144ms)
8 passed (2.5s)
```

**Full Playwright suite:** **213 passed, 0 failed, 15 skipped** — full-suite green again.

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions.

**Typecheck + lint** clean.

**Manual verification:**
```
$ curl -sI http://localhost:3100/rss.xml | grep -iE 'content-type|cache-control'
content-type: application/atom+xml; charset=utf-8
cache-control: public, max-age=300, stale-while-revalidate=3600

$ curl -s http://localhost:3100/rss.xml | head -6
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>Conduit — Latest articles</title>
  <link href="http://localhost:3100/" rel="alternate" />
  <link href="http://localhost:3100/rss.xml" rel="self" />
  <id>http://localhost:3100/</id>
```

## Notes for review

- **URL shape deviates from AC.** The issue specifies `/rss/tag/<tag>.xml` and `/rss/author/<username>.xml`, but Next.js 16's file-router treats `[slug].xml` as the literal segment name `slug].xml` rather than a dynamic slug with an extension. Workaround: drop the `.xml` suffix — routes live at `/rss/tag/<tag>` and `/rss/author/<username>`. Feed readers key on the `Content-Type` header (`application/atom+xml`), not the URL suffix; this is standards-compliant. If the `.xml` suffix is load-bearing for some reader tools, a `next.config.ts` `rewrites()` rule could map `/rss/tag/<tag>.xml` → `/rss/tag/<tag>`, but no reader I'm aware of requires it.
- **Handwritten over `feed` dep.** The Atom envelope is ~15 LOC of skeleton + ~15 per entry; the escape pass is 5 lines. `feed`, `xmlbuilder2`, or `react-rss` would add 20-80 KB for no functionality readers actually need. Handwritten keeps the bundle tight and the escape contract auditable in one file.
- **XML escape is the load-bearing safety.** Scenario 8 seeds a title with `<`, `>`, `&`, `"`, `'` and asserts none leak into the XML tree unescaped AND no double-escape (`&amp;amp;`) occurs. If a future refactor swaps the escape for an incomplete one, that scenario fails immediately.
- **`tag:<host>,2026:article/<slug>` is the `<id>` scheme.** RFC 4151 tag URIs are the canonical feed-item identifier when you don't have UUIDs — readers dedupe on `<id>`, so the slug-based stable form keeps dedup working across regenerations.
- Full-text content (`content:encoded`) is out of scope per the AC. Summary only.
