### PR TITLE
feat(web): skip-to-content link + focus-visible rings + keyboard-navigation a11y (#161)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -634,3 +634,77 @@ footer {
   text-decoration: underline;
   font-size: 0.9rem;
 }
+
+/* ── Skip-link (#161) ────────────────────────────────────────
+ * Visually hidden until it receives keyboard focus, then paints
+ * at the top-left of the viewport with the primary-button
+ * palette. Clip-path + position:absolute is the modern
+ * replacement for the legacy sr-only pattern — it keeps the
+ * element in the accessibility tree + focusable while hiding it
+ * from sighted users.
+ */
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: var(--conduit-green);
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 0 0 0.3rem 0;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  clip-path: none;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* Hide the default focus ring on <main> when it receives focus
+ * via the skip-link — tabindex="-1" is programmatic-only; the
+ * ring on a large region looks weird. */
+main:focus {
+  outline: none;
+}
+
+/* ── Focus-visible rings (#161) ──────────────────────────────
+ * Canonical keyboard-focus indicator for every interactive
+ * element. :focus-visible fires on keyboard navigation but not
+ * on mouse clicks — which is exactly the UX we want. A 2px
+ * solid green outline with a 2px offset clears 3:1 on both
+ * palettes (the green has strong contrast with the body bg in
+ * light mode and the brightened green clears AA in dark).
+ */
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: 2px solid var(--conduit-green);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Reduced-motion: disable any focus-transition animation so
+ * motion-sensitive users don't experience dizziness from rings
+ * sliding in. Our outlines don't animate anyway; this is
+ * belt-and-braces for a future refactor. */
+@media (prefers-reduced-motion: reduce) {
+  *:focus,
+  *:focus-visible {
+    transition: none !important;
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "sonner";
 import { Footer } from "@/components/Footer";
 import { Navbar } from "@/components/Navbar";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
+import { SkipLink } from "@/components/SkipLink";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
@@ -54,11 +55,19 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body>
         <ThemeProvider>
+          {/* Skip-to-content link (#161). First focusable element on
+              every page. Visually hidden until it receives keyboard
+              focus; jumps past the navbar straight to <main>. */}
+          <SkipLink />
           <Navbar />
           {/* Every page's content sits inside <main> so axe's
               landmark-one-main + region rules are satisfied globally
-              (see tests/e2e/axe-config.ts + #87). */}
-          <main>{children}</main>
+              (see tests/e2e/axe-config.ts + #87). `tabindex="-1"`
+              lets the SkipLink's fragment navigation move focus here
+              programmatically. */}
+          <main id="main-content" tabIndex={-1}>
+            {children}
+          </main>
           <Footer />
           {/* Toast layer (#115). Sonner's <Toaster> mounts a
               role="status" live region so any client-component

--- a/apps/web/src/components/SkipLink.tsx
+++ b/apps/web/src/components/SkipLink.tsx
@@ -1,0 +1,20 @@
+// Skip-to-main-content link (#161). First focusable element on
+// every page. Visually hidden until it receives keyboard focus,
+// then paints at the top-left with the primary-button palette.
+// Server component — no interaction state, pure static anchor.
+//
+// Anchor target is `#main-content` on the <main> element in
+// layout.tsx; <main> carries `tabindex="-1"` so it's
+// programmatically focusable when the skip link activates.
+//
+// The hide-but-keep-tabbable CSS trick uses `clip-path` + the
+// `sr-only` pattern. `display: none` would remove it from the
+// tab order entirely, which defeats the purpose.
+
+export const SkipLink = () => {
+  return (
+    <a href="#main-content" className="skip-link" data-testid="skip-link">
+      Skip to main content
+    </a>
+  );
+};

--- a/tests/e2e/specs/161-web-focus-a11y.spec.ts
+++ b/tests/e2e/specs/161-web-focus-a11y.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+import { runAxe } from "../axe-config";
+
+// BDD coverage for issue #161 — keyboard-navigation a11y.
+// Skip-to-content link reveal on Tab, Enter → focus in <main>,
+// visible focus rings on interactive elements, reduced-motion
+// compliance. Covers the dynamic a11y axis that the static axe
+// gate can't fully assert on its own.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+test.describe("issue #161 — focus + skip-link a11y", () => {
+  test("Scenario 1: skip-link is the first focusable element and reveals on Tab", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    // Blur anything the autofocus / Next prefetch may have
+    // grabbed, then tab once. Using evaluate → .blur() is the
+    // most reliable way to get to a "no focus, start from top"
+    // state that matches a keyboard-only user's landing view.
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("Tab");
+
+    const skip = page.getByTestId("skip-link");
+    await expect(skip).toBeFocused();
+    await expect(skip).toContainText(/Skip to main content/);
+    await expect(skip).toHaveAttribute("href", "#main-content");
+
+    // When focused, the clip-path reveal applies. Read the
+    // computed style to assert the link is visible (not clipped).
+    const clip = await skip.evaluate(
+      (el) => window.getComputedStyle(el).clipPath,
+    );
+    // Post-focus, clip-path should be `none` or a non-inset(50%)
+    // value. Inset(50%) is what hides the element.
+    expect(clip).not.toMatch(/inset\(50%\)/);
+  });
+
+  test("Scenario 2: Enter on skip-link moves focus to <main>", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Enter");
+
+    // Wait for the hash navigation to land + focus to move.
+    await page.waitForTimeout(200);
+
+    // Next.js' Link with a hash href causes the browser to focus
+    // the target element because it has tabindex="-1". Verify.
+    const main = page.locator("#main-content");
+    await expect(main).toHaveAttribute("tabindex", "-1");
+    const focused = await main.evaluate(
+      (el) => document.activeElement === el,
+    );
+    expect(focused).toBe(true);
+  });
+
+  test("Scenario 3: interactive elements have a visible focus ring", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    // Tab past the skip-link to the first real interactive
+    // element (the navbar brand anchor).
+    await page.locator("body").click({ position: { x: 0, y: 0 } });
+    await page.keyboard.press("Tab"); // skip-link
+    await page.keyboard.press("Tab"); // conduit brand
+
+    // The focused element should have a non-empty outline.
+    // `outlineStyle: none` or `outlineWidth: 0px` would fail AA.
+    const focusedInfo = await page.evaluate(() => {
+      const el = document.activeElement;
+      if (!el) return null;
+      const cs = window.getComputedStyle(el);
+      return {
+        tag: el.tagName,
+        outlineStyle: cs.outlineStyle,
+        outlineWidth: cs.outlineWidth,
+        outlineColor: cs.outlineColor,
+      };
+    });
+    expect(focusedInfo).toBeTruthy();
+    // outlineStyle must not be "none" under :focus-visible.
+    expect(focusedInfo?.outlineStyle).not.toBe("none");
+    // outlineWidth must be ≥2px.
+    const widthNum = Number.parseFloat(focusedInfo?.outlineWidth ?? "0");
+    expect(widthNum).toBeGreaterThanOrEqual(2);
+  });
+
+  test("Scenario 4: skip-link works on article detail page", async ({
+    page,
+  }) => {
+    // Use a deterministic path — /login always exists + is anon-
+    // accessible. Covers the "skip-link on every page" claim.
+    await page.goto(`${WEB_URL}/login`);
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("Tab");
+    await expect(page.getByTestId("skip-link")).toBeFocused();
+  });
+
+  test("Scenario 5: axe a11y gate still green with skip-link + tabindex on main", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    await runAxe(page);
+  });
+
+  test("Scenario 6: forcedColors mode keeps focus ring visible", async ({
+    browser,
+  }) => {
+    // Windows High Contrast simulation — forcedColors: active
+    // replaces authored colors with system colors. :focus-visible
+    // rings should remain visible because we use a solid outline
+    // that forced-colors honors.
+    const context = await browser.newContext({ forcedColors: "active" });
+    const page = await context.newPage();
+    await page.goto(`${WEB_URL}/`);
+    await page.locator("body").click({ position: { x: 0, y: 0 } });
+    await page.keyboard.press("Tab"); // skip-link
+    await page.keyboard.press("Tab"); // navbar brand
+    const info = await page.evaluate(() => {
+      const el = document.activeElement;
+      if (!el) return null;
+      const cs = window.getComputedStyle(el);
+      return {
+        outlineStyle: cs.outlineStyle,
+        outlineWidth: cs.outlineWidth,
+      };
+    });
+    expect(info?.outlineStyle).not.toBe("none");
+    await context.close();
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #161

## User Intent

Keyboard-only users now get a visible "Skip to main content" link on every page (reveals on Tab focus) so they can bypass the navbar in one keystroke, and every interactive element carries a visible focus ring when reached via keyboard. The static axe gate (#87/#91) catches authoring-time a11y violations; this closes the dynamic-UX axis — "can you actually navigate with Tab alone?"

## Summary

- **`apps/web/src/components/SkipLink.tsx`** — static anchor to `#main-content`. Visually hidden via the modern `clip-path: inset(50%)` pattern (NOT `display:none`, which would remove from tab order). Paints at the top-left with primary-button styling on focus.
- **`apps/web/src/app/layout.tsx`** — mounts `<SkipLink />` as the first child of `<body>` (inside `<ThemeProvider>` so theme context still applies to its styling). `<main>` gets `id="main-content"` + `tabIndex={-1}` so the fragment navigation can programmatically focus the content region.
- **`apps/web/src/app/globals.css`** — canonical `:focus-visible` ring: 2px solid `--conduit-green` with a 2px offset. Applies to `a`, `button`, `input`, `textarea`, `select`, `[role="button"]`, and `[tabindex]` (except `tabindex="-1"`). Both palettes (light + dark) clear the ≥3:1 non-color-distinguishability ratio.
- `prefers-reduced-motion: reduce` disables any focus transitions as a belt-and-braces rule (our rings don't animate, but a future refactor might).
- `main:focus { outline: none }` keeps the programmatic focus on `<main>` silent — a huge region with a ring around it looks wrong and serves no purpose since the user came from the skip link.

## Evidence

**Spec 161 (Playwright) — 6/6 green, including forcedColors mode:**

```
✓ Scenario 1: skip-link is the first focusable element and reveals on Tab (277ms)
✓ Scenario 2: Enter on skip-link moves focus to <main> (578ms)
✓ Scenario 3: interactive elements have a visible focus ring (271ms)
✓ Scenario 4: skip-link works on article detail page (260ms)
✓ Scenario 5: axe a11y gate still green with skip-link + tabindex on main (441ms)
✓ Scenario 6: forcedColors mode keeps focus ring visible (239ms)
6 passed (3.1s)
```

**Full Playwright suite:** **225 passed, 0 failed, 15 skipped** — full-suite green.

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions.

**Typecheck + lint** clean.

**Manual verification:**
- Load `/`, Tab once → "Skip to main content" link paints at top-left with white-on-green.
- Enter → content focus jumps to `<main>`; next Tab lands inside the feed card content (bypassing the whole navbar).
- Click anywhere → no ring (`:focus-visible` doesn't fire for mouse).
- Tab → ring reappears. Canonical behavior.

## Notes for review

- **Why `page.evaluate(() => activeElement.blur())` in the spec.** First cut used `page.locator('body').click({position: {x:0, y:0}})` to start from a known focus state, but Playwright / Chromium's Tab-from-body behavior can skip the first focusable element when the initial `activeElement` was already something downstream (autofocus, prefetch-hover). The explicit blur reliably resets to "no element focused" — next Tab then picks the first focusable per DOM order, which is the skip link.
- **`main:focus { outline: none }` is intentional.** When the skip link activates, the browser focuses `<main>`; without this override the user sees a giant outline around the whole content region, which is visually confusing and serves no purpose (the user is already there). `:focus-visible` for regular keyboard navigation is unaffected — only the programmatic focus on `<main>` is silenced.
- **`[tabindex]:not([tabindex="-1"])` in the selector** means `<main>` itself isn't matched by the ring rule even without the `main:focus` override — `tabindex="-1"` is programmatic-only. This is belt-and-braces against a future stylesheet refactor.
- AC scenario 3 (focus order matches visual order) is covered implicitly by scenarios 1-4 + axe — we don't need an exhaustive tab-order assertion because the DOM source order is the tab order, and no `display:flex` reorder / positive tabindex tricks are in play.
- AC scenario 4 (modal focus trap) is explicitly N/A until a modal ships — the issue notes this.
