### PR TITLE
feat(web): relative time labels (3h ago, yesterday) with formal date on hover (#158)

### DIFF
--- a/apps/web/src/components/RelativeTime.tsx
+++ b/apps/web/src/components/RelativeTime.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  formatFormalDate,
+  formatRelativeTime,
+} from "@/lib/relativeTime";
+
+// Renders a <time> element whose visible text is the relative
+// age ("3h ago", "yesterday", "2 weeks ago") and whose `title`
+// attribute carries the formal date for hover reveal. (#158)
+//
+// The label auto-refreshes every 60s via a single shared
+// external store so all RelativeTime instances on the page
+// re-render in lockstep (cheaper than a per-component interval).
+//
+// SSR/CSR shape: the server renders the formal date so the
+// initial HTML looks stable to crawlers + first-paint users.
+// `useSyncExternalStore` then flips `mounted` → true on the
+// client and the visible label becomes the relative form after
+// hydration. `suppressHydrationWarning` quiets React's
+// mismatch log because the initial post-mount text is expected
+// to differ from the SSR text.
+
+// Shared 60s tick — all RelativeTime instances share one
+// timer. Subscribing bumps the count; unsubscribing drops it.
+let tickValue = 0;
+const tickSubscribers = new Set<() => void>();
+let tickerStarted = false;
+
+const startTicker = () => {
+  if (tickerStarted || typeof window === "undefined") return;
+  tickerStarted = true;
+  window.setInterval(() => {
+    tickValue += 1;
+    for (const fn of tickSubscribers) fn();
+  }, 60_000);
+};
+
+const subscribeTick = (onStoreChange: () => void): (() => void) => {
+  tickSubscribers.add(onStoreChange);
+  startTicker();
+  return () => {
+    tickSubscribers.delete(onStoreChange);
+  };
+};
+const getTickClient = (): number => tickValue;
+const getTickServer = (): number => -1;
+
+// Separate mount flag, same useSyncExternalStore pattern as
+// next-themes / ThemeToggle — returns `true` on client and
+// `false` on SSR + first-client render. React 19's "no setState
+// in effect" rule forbids the older mount-via-useEffect trick.
+const mountedSubscribe = (): (() => void) => () => {};
+const mountedClient = (): boolean => true;
+const mountedServer = (): boolean => false;
+
+type Props = {
+  iso: string;
+  // Optional locale override; defaults to the browser's. Tests
+  // use `locale="en-US"` for deterministic formatting.
+  locale?: string;
+  // Optional className for meta-strip styling consistency with
+  // the old formal-date span.
+  className?: string;
+};
+
+export const RelativeTime = ({ iso, locale, className }: Props) => {
+  const mounted = useSyncExternalStore(
+    mountedSubscribe,
+    mountedClient,
+    mountedServer,
+  );
+  // Subscribing to the tick is what makes the label refresh; we
+  // don't read the value, just the side-effect of re-rendering.
+  useSyncExternalStore(subscribeTick, getTickClient, getTickServer);
+
+  const visible = mounted
+    ? formatRelativeTime(iso, new Date(), locale)
+    : formatFormalDate(iso, locale);
+  const hoverTitle = formatFormalDate(iso, locale);
+  return (
+    <time
+      dateTime={iso}
+      title={hoverTitle}
+      className={className}
+      suppressHydrationWarning
+      data-testid="relative-time"
+    >
+      {visible}
+    </time>
+  );
+};

--- a/apps/web/src/components/article/ArticleMeta.tsx
+++ b/apps/web/src/components/article/ArticleMeta.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { RelativeTime } from "@/components/RelativeTime";
 import type { Article } from "@/features/articles/queries";
 import { FollowButton } from "./FollowButton";
 import { FavoriteButton } from "./FavoriteButton";
@@ -8,17 +9,6 @@ type Props = {
   article: Article;
   viewerUsername: string | null;
   authed: boolean;
-};
-
-const formatDate = (iso: string): string => {
-  const d = new Date(iso);
-  return Number.isNaN(d.getTime())
-    ? iso
-    : d.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
 };
 
 // Article author line + action buttons. Reused by both the banner
@@ -46,7 +36,7 @@ export const ArticleMeta = ({ article, viewerUsername, authed }: Props) => {
         <Link href={profileHref} className="author">
           {article.author.username}
         </Link>
-        <span className="date">{formatDate(article.createdAt)}</span>
+        <RelativeTime iso={article.createdAt} className="date" />
         <span className="read-time" data-testid="read-time">
           {article.readingTimeMinutes} min read
         </span>

--- a/apps/web/src/components/article/ArticlePreview.tsx
+++ b/apps/web/src/components/article/ArticlePreview.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { RelativeTime } from "@/components/RelativeTime";
 import type { ArticleListItem } from "@/features/articles/queries";
 import { ArticlePreviewLink } from "./ArticlePreviewLink";
 import { FavoriteButton } from "./FavoriteButton";
@@ -15,13 +16,6 @@ type Props = {
   // so the favorite button knows whether to POST or redirect to /login.
   authed: boolean;
 };
-
-const formatDate = (iso: string): string =>
-  new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
 
 export const ArticlePreview = ({ article, authed }: Props) => {
   return (
@@ -49,7 +43,7 @@ export const ArticlePreview = ({ article, authed }: Props) => {
           >
             {article.author.username}
           </Link>
-          <span className="date">{formatDate(article.createdAt)}</span>
+          <RelativeTime iso={article.createdAt} className="date" />
           <span className="read-time" data-testid="read-time">
             {article.readingTimeMinutes} min read
           </span>

--- a/apps/web/src/components/comment/CommentItem.tsx
+++ b/apps/web/src/components/comment/CommentItem.tsx
@@ -1,3 +1,4 @@
+import { RelativeTime } from "@/components/RelativeTime";
 import type { Comment } from "@/features/articles/queries";
 import { DeleteCommentButton } from "./DeleteCommentButton";
 
@@ -5,17 +6,6 @@ type Props = {
   slug: string;
   comment: Comment;
   viewerUsername: string | null;
-};
-
-const formatDate = (iso: string): string => {
-  const d = new Date(iso);
-  return Number.isNaN(d.getTime())
-    ? iso
-    : d.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
 };
 
 export const CommentItem = ({ slug, comment, viewerUsername }: Props) => {
@@ -49,7 +39,7 @@ export const CommentItem = ({ slug, comment, viewerUsername }: Props) => {
         >
           {comment.author.username}
         </a>
-        <span className="date-posted">{formatDate(comment.createdAt)}</span>
+        <RelativeTime iso={comment.createdAt} className="date-posted" />
         {isOwn ? (
           <DeleteCommentButton slug={slug} commentId={comment.id} />
         ) : null}

--- a/apps/web/src/lib/relativeTime.ts
+++ b/apps/web/src/lib/relativeTime.ts
@@ -1,0 +1,85 @@
+// Relative-time formatter (#158). Returns locale-aware short
+// labels like "3h ago" / "yesterday" / "2 weeks ago" — what
+// every modern feed surface displays instead of formal dates.
+// Formal dates are still available via the `formatFormalDate`
+// helper for the <time title> hover reveal.
+//
+// Uses browser-native `Intl.RelativeTimeFormat` so every locale
+// the user's browser reports is supported out of the box; no
+// library needed. When the delta exceeds ~1 year the formatter
+// falls back to a short formal date (e.g. "Jan 2025") because
+// "23 months ago" is less useful than the year.
+
+const MS_PER_MIN = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MIN;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+const MS_PER_MONTH = 30 * MS_PER_DAY; // calendar-month approximation
+const MS_PER_YEAR = 365 * MS_PER_DAY;
+
+export const formatRelativeTime = (
+  iso: string,
+  now: Date = new Date(),
+  locale: string | undefined = undefined,
+): string => {
+  const parsed = new Date(iso);
+  const parsedTime = parsed.getTime();
+  if (!Number.isFinite(parsedTime)) return iso;
+
+  const deltaMs = now.getTime() - parsedTime;
+  // Treat near-zero + mild future drift (clock skew) as "just now"
+  // rather than "in 0s"; "in 3m" for a 3-minute future delta is
+  // confusing and usually a clock-skew artifact.
+  if (deltaMs < MS_PER_MIN) return "just now";
+
+  // Past-direction formatter. Intl returns e.g. "3 minutes ago",
+  // "yesterday", "2 weeks ago" in the user's locale.
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (deltaMs < MS_PER_HOUR) {
+    const mins = Math.floor(deltaMs / MS_PER_MIN);
+    return rtf.format(-mins, "minute");
+  }
+  if (deltaMs < MS_PER_DAY) {
+    const hours = Math.floor(deltaMs / MS_PER_HOUR);
+    return rtf.format(-hours, "hour");
+  }
+  if (deltaMs < 2 * MS_PER_DAY) {
+    return rtf.format(-1, "day");
+  }
+  if (deltaMs < MS_PER_WEEK) {
+    const days = Math.floor(deltaMs / MS_PER_DAY);
+    return rtf.format(-days, "day");
+  }
+  if (deltaMs < 4 * MS_PER_WEEK) {
+    const weeks = Math.floor(deltaMs / MS_PER_WEEK);
+    return rtf.format(-weeks, "week");
+  }
+  if (deltaMs < MS_PER_YEAR) {
+    const months = Math.floor(deltaMs / MS_PER_MONTH);
+    return rtf.format(-months, "month");
+  }
+  // Over one year — short formal date beats "14 months ago".
+  return formatShortYearMonth(parsed, locale);
+};
+
+// Short formal date for long-past entries. "Jan 2025" rather
+// than "January 2025" to keep card meta strips compact.
+const formatShortYearMonth = (d: Date, locale: string | undefined): string =>
+  d.toLocaleDateString(locale, { month: "short", year: "numeric" });
+
+// Formal date for <time title> hover. Full locale-aware form.
+export const formatFormalDate = (
+  iso: string,
+  locale: string | undefined = undefined,
+): string => {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return iso;
+  return d.toLocaleString(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};

--- a/tests/e2e/specs/158-web-relative-time.spec.ts
+++ b/tests/e2e/specs/158-web-relative-time.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+import { ArticlesApi } from "../page-objects/articles";
+import { runAxe } from "../axe-config";
+
+// BDD coverage for issue #158 — relative time labels with formal
+// date on hover. The RelativeTime client component renders the
+// formal date on SSR + first client render (for SEO + hydration
+// parity), then swaps to the relative label after hydration
+// + refreshes every 60s via a shared tick store.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+const uniq = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+test.describe("issue #158 — relative time labels", () => {
+  test("Scenario 1: preview card renders relative time after hydration", async ({
+    page,
+  }) => {
+    // Seed a fresh article — "just now" is the expected label.
+    const id = uniq();
+    const jake = `rt-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `rt-${id}` });
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+    const preview = page.locator(
+      `.article-preview:has(a[href="/article/${slug}"])`,
+    );
+    await expect(preview).toBeVisible();
+
+    // Post-hydration, the RelativeTime label flips to the
+    // relative form. "just now" is deterministic for a
+    // fresh-seeded article.
+    const time = preview.getByTestId("relative-time").first();
+    await expect(time).toContainText(/just now|seconds ago|minute/);
+  });
+
+  test("Scenario 2: <time> carries datetime + title attributes", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rtm-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `rtm-${id}` });
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+    const time = page.getByTestId("relative-time").first();
+    await expect(time).toBeVisible();
+
+    // Machine-readable ISO in datetime — crawlers + screen
+    // readers consume this.
+    const dt = await time.getAttribute("datetime");
+    expect(dt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Formal date in title — hover reveal for the human who
+    // wants unambiguous time info.
+    const title = await time.getAttribute("title");
+    expect(title).toBeTruthy();
+    expect(title).toMatch(/\d{4}/); // year is always present
+    expect(title).toMatch(/\w+ \d+/); // month + day words
+  });
+
+  test("Scenario 3: article detail shows relative time in both meta strips", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rtd-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `rtd-${id}` });
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+    const times = page.getByTestId("relative-time");
+    // Banner meta + footer meta both render ArticleMeta, so we
+    // expect at least 2 <time> elements on the detail page.
+    const count = await times.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("Scenario 4: comments show relative time per item", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rtc-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    const slug = await api.createArticleReturnSlug({ title: `rtc-${id}` });
+    await api.api.post(`/api/articles/${slug}/comments`, {
+      data: { comment: { body: `rt-comment-${id}` } },
+    });
+
+    await page.goto(`${WEB_URL}/article/${slug}`);
+    const comment = page.locator('[data-testid="comment-list"] > *').first();
+    await expect(comment).toBeVisible();
+    const time = comment.getByTestId("relative-time");
+    await expect(time).toHaveAttribute("datetime", /\d{4}-\d{2}-\d{2}T/);
+    await expect(time).toContainText(/just now|seconds ago|minute/);
+  });
+
+  test("Scenario 5: axe a11y gate on page with relative times", async ({
+    page,
+  }) => {
+    const id = uniq();
+    const jake = `rta-${id}`;
+    const api = await ArticlesApi.newContext();
+    await api.registerUser(jake);
+    await api.createArticleReturnSlug({ title: `rta-${id}` });
+
+    await page.goto(`${WEB_URL}/profile/${jake}`);
+    await expect(
+      page.getByTestId("relative-time").first(),
+    ).toBeVisible();
+    await runAxe(page);
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #158

## User Intent

Article cards, article banner meta, and comments now show "just now" / "3h ago" / "yesterday" / "2 weeks ago" — what every modern feed surface displays instead of formal dates like "April 29, 2026". Formal dates stay available via hover on the `<time title="...">`. Crawlers and screen readers get the machine-readable ISO via `<time datetime="...">`.

## Summary

- **`apps/web/src/lib/relativeTime.ts`** — pure formatter wrapping `Intl.RelativeTimeFormat` with a 10-bucket ladder: `just now` → `Nm ago` → `Nh ago` → `yesterday` → `N days ago` → `N weeks ago` → `N months ago` → `Jan 2025` (short formal date for >1 year). Uses the browser's detected locale by default; Korean / Japanese / etc. work out of the box.
- **`apps/web/src/components/RelativeTime.tsx`** — tiny client component. SSR + first client render emit the **formal date** (so the server HTML is crawler-friendly and hydration has a stable shape); after hydration, `useSyncExternalStore` flips the mounted flag and the visible text becomes the relative label. A single shared 60s tick store drives all `<RelativeTime>` instances on the page — one `setInterval` per page, not per-component.
- **Swapped `formatDate`** calls in `ArticlePreview.tsx`, `ArticleMeta.tsx`, `CommentItem.tsx` for `<RelativeTime iso={...} className="…" />`.
- **`suppressHydrationWarning`** on `<time>` quiets the expected SSR/CSR text mismatch (the rest of the element hydrates strictly).

## Evidence

**Spec 158 (Playwright) — 5/5:**
```
✓ Scenario 1: preview card renders relative time after hydration (765ms)
✓ Scenario 2: <time> carries datetime + title attributes (494ms)
✓ Scenario 3: article detail shows relative time in both meta strips (370ms)
✓ Scenario 4: comments show relative time per item (380ms)
✓ Scenario 5: axe a11y gate on page with relative times (651ms)
5 passed (3.7s)
```

**Full Playwright suite:** 229 passed, 15 skipped, 1 intermittent (#56 favorite optimistic — pre-existing parallel-seed flake, solo-green). 

**Bruno conformance:** 149/149 assertions, baseline 0/0 regressions.

**Typecheck + lint** clean.

**Manual verification:**
```
$ curl -s http://localhost:3100/ | grep -oE '<time[^>]*>[^<]*</time>' | head -1
<time dateTime="2026-04-29T22:23:37.843Z" title="April 29, 2026 at 10:23 PM" class="date" data-testid="relative-time">April 29, 2026 at 10:23 PM</time>
```
SSR shows the formal date (above). Open in a browser → after hydration, the visible text becomes "just now". The `datetime` and `title` attrs stay put.

## Notes for review

- **SSR + CSR render the same shape but different text.** The `<time>` element is identical server vs client except for the text content — `datetime` and `title` are stable. `suppressHydrationWarning` is scoped to the `<time>` element only; the rest hydrates strictly.
- **Shared tick store.** Per the AC: "a useEffect interval that ticks every 60s". One interval for the whole page via `useSyncExternalStore` is cheaper + keeps instances in sync. React 19's "no setState in effect" rule means the canonical `useEffect + setInterval + setState` pattern is unavailable; the external store is the right pattern.
- **Unit tests deferred.** The web workspace doesn't yet have vitest wired (api does). The boundary tests live in the Playwright spec — a fresh article tests "just now" / "seconds ago" / "1 minute ago"; the rest of the ladder is exercised manually + would move into a vitest suite the moment web gains one. Flagged for follow-up.
- **Over-1-year fallback** returns a short formal date ("Jan 2025") because "23 months ago" is less useful than the year. AC documents this explicitly.
- **`<time>` with both `datetime` + `title` is the canonical a11y shape** — screen readers read the visible text OR the datetime depending on the engine; crawlers index on datetime; hover reveals title. No JS-only secret channel.
