### PR TITLE
feat(web): keyboard shortcuts — ?/help, /search, g h/p nav, n editor, Esc (#160)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -708,3 +708,91 @@ select:focus-visible,
     transition: none !important;
   }
 }
+
+/* ── Keyboard-shortcut help modal (#160) ─────────────────────
+ * Backdrop + centered dialog. role="dialog" aria-modal, with a
+ * palette-aware surface. Close button styling reuses .btn-primary
+ * so it inherits the focus ring + palette from the rest of the
+ * app.
+ */
+.shortcut-help-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 1rem;
+}
+
+.shortcut-help-dialog {
+  background: var(--conduit-surface, #ffffff);
+  color: var(--conduit-text, #373a3c);
+  border-radius: 0.5rem;
+  padding: 1.5rem 1.75rem;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+}
+
+.shortcut-help-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.shortcut-help-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.25rem;
+}
+
+.shortcut-help-table td {
+  padding: 0.45rem 0.25rem;
+  font-size: 0.9rem;
+}
+
+.shortcut-help-keys {
+  white-space: nowrap;
+  width: 1%;
+  padding-right: 1rem !important;
+}
+
+.shortcut-help-keys kbd {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  background: rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--conduit-border, rgba(0, 0, 0, 0.15));
+  border-radius: 0.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+[data-theme="dark"] .shortcut-help-keys kbd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.shortcut-help-desc {
+  color: var(--conduit-text-muted, #55595c);
+}
+
+.shortcut-help-actions {
+  text-align: right;
+}
+
+.shortcut-help-footer-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--conduit-green);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+}
+
+.shortcut-help-footer-link:hover,
+.shortcut-help-footer-link:focus {
+  color: var(--conduit-green-dark);
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Toaster } from "sonner";
 import { Footer } from "@/components/Footer";
+import { KeyboardShortcutHelp } from "@/components/KeyboardShortcutHelp";
+import { KeyboardShortcutProvider } from "@/components/KeyboardShortcutProvider";
 import { Navbar } from "@/components/Navbar";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
 import { SkipLink } from "@/components/SkipLink";
@@ -55,11 +57,18 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body>
         <ThemeProvider>
-          {/* Skip-to-content link (#161). First focusable element on
-              every page. Visually hidden until it receives keyboard
-              focus; jumps past the navbar straight to <main>. */}
-          <SkipLink />
-          <Navbar />
+          {/* Keyboard shortcuts (#160). The provider owns the global
+              keydown listener + sequence state machine; the Help
+              modal mounts here (rendered conditionally by the
+              provider context's helpOpen flag). Wraps everything
+              below so any component can open/close the help dialog
+              through useShortcutContext. */}
+          <KeyboardShortcutProvider>
+            {/* Skip-to-content link (#161). First focusable element on
+                every page. Visually hidden until it receives keyboard
+                focus; jumps past the navbar straight to <main>. */}
+            <SkipLink />
+            <Navbar />
           {/* Every page's content sits inside <main> so axe's
               landmark-one-main + region rules are satisfied globally
               (see tests/e2e/axe-config.ts + #87). `tabindex="-1"`
@@ -80,6 +89,10 @@ export default function RootLayout({
           {/* PWA service worker registration (#149). Lazy on
               `load` so it never competes with first-paint. */}
           <ServiceWorkerRegistration />
+          {/* Keyboard-shortcut help modal (#160). Renders null
+              unless helpOpen=true in the provider. */}
+          <KeyboardShortcutHelp />
+          </KeyboardShortcutProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { KeyboardShortcutFooterLink } from "./KeyboardShortcutFooterLink";
 
 export const Footer = () => (
   <footer>
@@ -15,6 +16,10 @@ export const Footer = () => (
         {" "}
         See the{" "}
         <a href="https://realworld-docs.netlify.app/">RealWorld spec</a>.
+      </span>
+      <span className="attribution">
+        {" "}
+        <KeyboardShortcutFooterLink />
       </span>
     </div>
   </footer>

--- a/apps/web/src/components/KeyboardShortcutFooterLink.tsx
+++ b/apps/web/src/components/KeyboardShortcutFooterLink.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useShortcutContext } from "./KeyboardShortcutProvider";
+
+// Footer trigger for the keyboard-shortcuts help modal (#160).
+// Styled as a bare button that looks like a link — screen
+// readers treat it as a button (correct, since it opens a
+// dialog rather than navigating), but visually it sits inside
+// the footer alongside the Thinkster + RealWorld-spec links.
+
+export const KeyboardShortcutFooterLink = () => {
+  const { openHelp } = useShortcutContext();
+  return (
+    <button
+      type="button"
+      className="shortcut-help-footer-link"
+      onClick={openHelp}
+      data-testid="shortcut-help-trigger"
+    >
+      Keyboard shortcuts (?)
+    </button>
+  );
+};

--- a/apps/web/src/components/KeyboardShortcutHelp.tsx
+++ b/apps/web/src/components/KeyboardShortcutHelp.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useShortcutContext } from "./KeyboardShortcutProvider";
+
+// Help modal (#160). Lists every keyboard shortcut the app
+// supports. Rendered at the app root (inside
+// KeyboardShortcutProvider) so it's available from every page.
+//
+// Accessibility contract:
+//   - role="dialog" + aria-modal="true" + aria-labelledby on
+//     the title element.
+//   - Initial focus lands on the Close button so Esc + Space/
+//     Enter dismiss immediately.
+//   - Tab cycles within the modal (focus trap); Shift+Tab
+//     wraps from the first focusable back to the last.
+//   - Esc closes (handled in the provider, so even a swallowed
+//     Tab doesn't lose the Esc path).
+//   - Clicking outside the dialog (backdrop) also closes.
+
+const SHORTCUTS = [
+  { keys: ["?"], description: "Open this help modal" },
+  { keys: ["/"], description: "Focus the search bar (homepage only)" },
+  { keys: ["g", "h"], description: "Go to the homepage" },
+  { keys: ["g", "p"], description: "Go to your profile" },
+  { keys: ["n"], description: "Start a new article (opens the editor)" },
+  { keys: ["Esc"], description: "Close this modal / dismiss dialogs" },
+];
+
+export const KeyboardShortcutHelp = () => {
+  const { helpOpen, closeHelp } = useShortcutContext();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus-trap: keep Tab navigation inside the dialog while
+  // it's open. Implementation queries focusables fresh on each
+  // Tab press so dynamic content (future inputs, etc.) is
+  // handled automatically.
+  const onKeyDownTrap = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusables = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [],
+  );
+
+  // Move focus into the modal when it opens. Scoped to the
+  // helpOpen transition so focus isn't yanked on every render.
+  useEffect(() => {
+    if (!helpOpen) return;
+    // requestAnimationFrame to defer focus until the DOM has
+    // painted — otherwise the Close button might not exist yet.
+    const raf = requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [helpOpen]);
+
+  if (!helpOpen) return null;
+
+  return (
+    <div
+      className="shortcut-help-backdrop"
+      onClick={(e) => {
+        // Only close on outer backdrop click, not on clicks
+        // inside the dialog body.
+        if (e.target === e.currentTarget) closeHelp();
+      }}
+      data-testid="shortcut-help-backdrop"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcut-help-title"
+        className="shortcut-help-dialog"
+        onKeyDown={onKeyDownTrap}
+        data-testid="shortcut-help"
+      >
+        <h2 id="shortcut-help-title" className="shortcut-help-title">
+          Keyboard shortcuts
+        </h2>
+        <table className="shortcut-help-table">
+          <tbody>
+            {SHORTCUTS.map(({ keys, description }) => (
+              <tr key={keys.join("+")}>
+                <td className="shortcut-help-keys">
+                  {keys.map((k, idx) => (
+                    <span key={idx}>
+                      <kbd>{k}</kbd>
+                      {idx < keys.length - 1 ? <span> then </span> : null}
+                    </span>
+                  ))}
+                </td>
+                <td className="shortcut-help-desc">{description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="shortcut-help-actions">
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="btn btn-primary"
+            onClick={closeHelp}
+            data-testid="shortcut-help-close"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/KeyboardShortcutProvider.tsx
+++ b/apps/web/src/components/KeyboardShortcutProvider.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+// Global keyboard-shortcut runtime (#160). Owns:
+//   - `?` opens the help modal
+//   - `/` focuses the SearchBar
+//   - `g h` navigates to /
+//   - `g p` navigates to /profile/<viewer>  (falls back to /login if anon)
+//   - `n` opens the editor (falls back to /login if anon)
+//   - `Esc` closes any open modal
+//
+// Sequence shortcuts (`g h`, `g p`) use a simple timeout-based
+// state machine: the first key enters "g-prefix" state; a second
+// key within 1s triggers the action; otherwise the prefix
+// expires.
+//
+// Guard: every shortcut checks whether focus is inside a text
+// input / textarea / contenteditable, and skips if so. Otherwise
+// typing a `?` in an article body would open the modal.
+
+type ShortcutContextValue = {
+  // Dispatched by KeyboardShortcutHelp's Close button + by any
+  // other caller that wants to open / close the help modal.
+  openHelp: () => void;
+  closeHelp: () => void;
+  helpOpen: boolean;
+};
+
+const ShortcutContext = createContext<ShortcutContextValue | null>(null);
+
+export const useShortcutContext = (): ShortcutContextValue => {
+  const ctx = useContext(ShortcutContext);
+  if (!ctx) {
+    throw new Error(
+      "useShortcutContext must be used inside <KeyboardShortcutProvider>",
+    );
+  }
+  return ctx;
+};
+
+// True when focus is on an element that should swallow the
+// keystroke as text input (input, textarea, contenteditable,
+// select). Modal dialog controls (role=dialog children) also
+// need to preserve Esc + Tab, but those are handled by the
+// modal's own handlers.
+const isTextInputFocused = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+};
+
+// Read the current viewer's username from the `conduit-user`
+// cookie, same convention Navbar uses. Returns null for anon.
+const readViewerUsername = (): string | null => {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(/(?:^|; )conduit-user=([^;]+)/);
+  if (!match) return null;
+  try {
+    const decoded = decodeURIComponent(match[1]!);
+    // Cookie may be a bare username or JSON. Handle both.
+    if (decoded.startsWith("{")) {
+      const parsed = JSON.parse(decoded) as { username?: string };
+      return parsed.username ?? null;
+    }
+    return decoded;
+  } catch {
+    return null;
+  }
+};
+
+const SEQUENCE_TIMEOUT_MS = 1000;
+
+type Props = { children: ReactNode };
+
+export const KeyboardShortcutProvider = ({ children }: Props) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [helpOpen, setHelpOpen] = useState(false);
+  // Pre-open-modal focused element so we can restore focus on
+  // close (accessibility requirement — the user's tab position
+  // shouldn't get lost when they dismiss a modal).
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  // Sequence state: tracks whether we just saw the prefix key
+  // (`g`) and expects a second press within SEQUENCE_TIMEOUT_MS.
+  const seqPrefixRef = useRef<string | null>(null);
+  const seqTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openHelp = useCallback(() => {
+    if (helpOpen) return;
+    if (typeof document !== "undefined") {
+      prevFocusRef.current = document.activeElement as HTMLElement | null;
+    }
+    setHelpOpen(true);
+  }, [helpOpen]);
+
+  const closeHelp = useCallback(() => {
+    setHelpOpen(false);
+    // Restore focus to whatever had it before the modal opened.
+    // Defer to next frame so the modal's unmount completes
+    // before we try to focus the old element (otherwise focus
+    // lands on body).
+    const prev = prevFocusRef.current;
+    if (prev && typeof prev.focus === "function") {
+      requestAnimationFrame(() => prev.focus());
+    }
+  }, []);
+
+  const navigate = useCallback(
+    (path: string, requireAuth = false) => {
+      if (requireAuth && readViewerUsername() === null) {
+        router.push(`/login?redirect=${encodeURIComponent(path)}`);
+        return;
+      }
+      router.push(path);
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Shortcuts inside the help modal: only Esc is honored
+      // (close). Tab cycling is handled by the modal's own trap.
+      if (helpOpen) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeHelp();
+        }
+        return;
+      }
+
+      // Text-input guard: shortcuts don't fire while the user
+      // is typing. Applies even to modifier-free keys like `?`
+      // because typing `?` in an article body is the common
+      // case; opening the help modal mid-paragraph would be
+      // a UX regression.
+      if (isTextInputFocused(event.target)) return;
+
+      // `?` (Shift+/ or bare `?`) opens the help modal.
+      if (event.key === "?") {
+        event.preventDefault();
+        openHelp();
+        return;
+      }
+
+      // Modifier keys (Ctrl/Cmd/Alt/Meta) are reserved for
+      // browser + OS shortcuts. Never hijack.
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+      // `/` focuses the search bar — homepage only. On other
+      // pages it's a no-op (typing `/` does nothing because
+      // there's no input to focus).
+      if (event.key === "/") {
+        const searchInput = document.querySelector<HTMLInputElement>(
+          'input[type="search"], [role="searchbox"], input[name="q"]',
+        );
+        if (searchInput) {
+          event.preventDefault();
+          searchInput.focus();
+          searchInput.setSelectionRange(
+            searchInput.value.length,
+            searchInput.value.length,
+          );
+        }
+        return;
+      }
+
+      // `g` enters sequence-prefix state, waiting for the
+      // second key (h / p).
+      if (event.key === "g") {
+        event.preventDefault();
+        seqPrefixRef.current = "g";
+        if (seqTimerRef.current !== null) clearTimeout(seqTimerRef.current);
+        seqTimerRef.current = setTimeout(() => {
+          seqPrefixRef.current = null;
+        }, SEQUENCE_TIMEOUT_MS);
+        return;
+      }
+
+      // Sequence follow-up keys: `g h` → home, `g p` → profile.
+      if (seqPrefixRef.current === "g") {
+        seqPrefixRef.current = null;
+        if (seqTimerRef.current !== null) clearTimeout(seqTimerRef.current);
+        if (event.key === "h") {
+          event.preventDefault();
+          navigate("/");
+          return;
+        }
+        if (event.key === "p") {
+          event.preventDefault();
+          const viewer = readViewerUsername();
+          if (viewer) {
+            navigate(`/profile/${encodeURIComponent(viewer)}`);
+          } else {
+            navigate("/profile", true);
+          }
+          return;
+        }
+        // Unknown follow-up key — drop through; the sequence is
+        // cancelled either way.
+      }
+
+      // `n` opens the editor (authed) or routes to /login.
+      if (event.key === "n") {
+        event.preventDefault();
+        navigate("/editor", true);
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    // Ready marker for e2e: set once the keydown listener is
+    // actually attached. Without this, Playwright races the
+    // listener — a `page.keyboard.press("n")` fired before
+    // hydration finishes is silently dropped.
+    document.body.dataset.shortcutsReady = "1";
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      if (seqTimerRef.current !== null) clearTimeout(seqTimerRef.current);
+      delete document.body.dataset.shortcutsReady;
+    };
+  }, [helpOpen, openHelp, closeHelp, navigate]);
+
+  // Deliberate non-feature: the modal does NOT auto-close on
+  // pathname change. Users dismiss it themselves with Esc or
+  // the Close button. React 19's combined "no setState in
+  // effect" + "no ref access during render" rules make the
+  // auto-close awkward to express without violating one or the
+  // other; since the modal's content is navigation-invariant
+  // (the shortcut list is the same on every page), leaving it
+  // open across a transition is a reasonable default.
+  void pathname;
+
+  return (
+    <ShortcutContext.Provider value={{ openHelp, closeHelp, helpOpen }}>
+      {children}
+    </ShortcutContext.Provider>
+  );
+};

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,93 @@
+# Keyboard shortcuts (#160)
+
+Global keyboard shortcuts give power users a "stay in the flow" navigation loop. Every modern content platform (GitHub, Linear, Notion, Hacker News) has one; Conduit's is small, documented, and fully screen-reader accessible.
+
+## The shortcut table
+
+| Key | Action |
+|-----|--------|
+| `?` | Open the help modal |
+| `/` | Focus the SearchBar (homepage) |
+| `g h` | Navigate to `/` |
+| `g p` | Navigate to `/profile/<your-username>` (→ `/login?redirect=/profile` when anon) |
+| `n` | Open the editor (→ `/login?redirect=/editor` when anon) |
+| `Esc` | Close the help modal + restore focus |
+
+Multi-key sequences (`g h`, `g p`) have a 1-second timeout: press `g`, then the follow-up within 1s. Miss the window and the prefix is discarded silently (no error, no toast).
+
+## Architecture
+
+Two components, both in `apps/web/src/components/`:
+
+- **`KeyboardShortcutProvider.tsx`** — mounts in `layout.tsx` once, owns the `window.addEventListener("keydown", ...)` handler and the `helpOpen` state. Exposes `useShortcutContext()` for children that want to open / close the modal programmatically (e.g. the footer link).
+- **`KeyboardShortcutHelp.tsx`** — the modal. Renders `null` when `helpOpen === false`. When open: `role="dialog"`, `aria-modal="true"`, `aria-labelledby="shortcut-help-title"`, an internal focus trap (Tab / Shift+Tab cycle within the dialog), and `requestAnimationFrame`-deferred focus to the Close button so initial-focus works across all paint timings.
+
+The provider wraps everything inside `<body>` so every route has shortcuts, including `/login` and 404s.
+
+## Input-field guard
+
+Every keystroke the provider handles first runs through `isTextInputFocused(event.target)`. If the focused element is an `<input>`, `<textarea>`, `<select>`, or `contenteditable`, shortcuts do NOT fire. That means:
+
+- Typing `?` in an article body types a `?` into the textarea. It does NOT open the help modal mid-paragraph.
+- Typing `/` in the search bar types a `/`. It does NOT re-focus the search bar.
+- Typing `n` in a profile-edit input types `n`. It does NOT navigate away.
+
+The guard is the single most important UX rule in this feature. Without it the shortcuts would be actively hostile.
+
+## Modifier reservation
+
+`Ctrl` / `Cmd` / `Alt` / `Meta` + any key is always passed through to the browser / OS. This keeps `Cmd+L` (address bar), `Ctrl+F` (find), `Cmd+R` (reload), etc. working as expected.
+
+## Focus restoration on modal close
+
+Before opening the help modal, the provider captures `document.activeElement` into `prevFocusRef`. On close, it calls `requestAnimationFrame(() => prev.focus())` — the RAF defer lets the modal's unmount complete first, otherwise focus lands on `<body>` instead of the element that opened the modal.
+
+This is an a11y requirement: a screen-reader user's tab position must not disappear when they dismiss a modal.
+
+## Modal auto-close on navigation — deliberately NOT implemented
+
+The naive "close the modal when `pathname` changes" effect runs into React 19's combined rules:
+
+1. `react-hooks/set-state-in-effect` forbids `setHelpOpen(false)` inside a `useEffect`.
+2. `react-hooks/refs` forbids reading a ref during render (so the "track previous pathname" trick doesn't help).
+3. Passing a ref into `clearTimeout` during render also counts as "ref read during render".
+
+All three fighters blocked every variant I tried. Since the help modal's contents are navigation-invariant (the shortcut list is the same on every page), leaving it open across a route transition is a reasonable default. The user dismisses it with `Esc` or the Close button. This is documented as a non-feature in the provider source.
+
+If a future shortcut opens a navigation-relevant modal (e.g. a confirm dialog for destructive actions), that modal owns its own close-on-navigate logic — not the global provider.
+
+## Discoverability
+
+The footer carries a small `⌨ Keyboard shortcuts (?)` link (`KeyboardShortcutFooterLink.tsx`). Clicking it opens the same modal — users who don't know about `?` still find the feature.
+
+## Viewer detection
+
+`g p` (and `n`) need to know whether the viewer is authenticated. The provider reads the `conduit-user` cookie directly via `document.cookie.match(/(?:^|; )conduit-user=([^;]+)/)`. Two shapes are supported:
+
+- Bare username: `conduit-user=alice`.
+- JSON: `conduit-user={"username":"alice",...}`.
+
+Both appear in the codebase — server actions write bare usernames, client-only code sometimes persists the full user object. The `try { JSON.parse(...) } catch` lets the provider accept whichever form is current. If the cookie is missing, `readViewerUsername()` returns `null` and the shortcut falls through to the `/login?redirect=...` branch.
+
+## Adding a new shortcut
+
+1. Extend the `onKeyDown` handler in `KeyboardShortcutProvider.tsx` with a new branch. Always `event.preventDefault()` before triggering navigation / focus, and always check the text-input guard first.
+2. Add a row to the `SHORTCUTS` array in `KeyboardShortcutHelp.tsx` so it appears in the help modal.
+3. Add a row to the table at the top of this document.
+4. Add a scenario to `tests/e2e/specs/160-web-keyboard-shortcuts.spec.ts` verifying the new shortcut via `page.keyboard.press(...)`.
+
+If the new shortcut is a multi-key sequence other than `g`-prefix, add a second prefix ref (don't overload `seqPrefixRef`) so the two sequences don't interfere.
+
+## Out of scope
+
+- **User-customizable shortcuts** — too much UI for one refinement issue. Users get the published set.
+- **`j` / `k` vertical navigation in feeds** — separate polish issue if demanded.
+- **Command palette (`Cmd+K`)** — future Level-3 feature, filed separately.
+
+## Verification
+
+```sh
+pnpm test:e2e tests/e2e/specs/160-web-keyboard-shortcuts.spec.ts
+```
+
+9 scenarios: `?` opens modal, `Esc` closes, `/` focuses search, `g h` navigates home, `n` routes to `/login?redirect=/editor` when anon, input-field guard (typing `?` in a form types the character), footer trigger opens modal, axe a11y gate on the open modal, Tab cycles within the modal.

--- a/tests/e2e/specs/160-web-keyboard-shortcuts.spec.ts
+++ b/tests/e2e/specs/160-web-keyboard-shortcuts.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "@playwright/test";
+import { runAxe } from "../axe-config";
+
+// BDD coverage for issue #160 — keyboard shortcuts:
+//   ?   open help modal
+//   /   focus search bar
+//   g h → home
+//   g p → profile (or /login?redirect=/profile when anon)
+//   n   → editor (or /login?redirect=/editor when anon)
+//   Esc close modal
+//
+// Each scenario uses page.keyboard.press to exercise the global
+// keydown handler installed by KeyboardShortcutProvider. The
+// input-field guard is verified by typing "?" inside a textarea
+// and asserting the modal does NOT open.
+
+const WEB_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.WEB_URL ??
+  "http://localhost:3100";
+
+// Wait for the KeyboardShortcutProvider to finish its useEffect
+// pass — the provider attaches the global keydown listener in
+// an effect, so a keypress fired before React hydration is
+// silently dropped. Polling for the provider's ready marker is
+// faster + more deterministic than networkidle (which waits for
+// every image + font on a Suspense-streaming homepage). The
+// provider writes a data attribute on <body> once the effect has
+// mounted; the spec just polls for it.
+const waitForShortcutsReady = async (page: import("@playwright/test").Page) => {
+  await page.waitForFunction(
+    () => document.body.dataset.shortcutsReady === "1",
+    null,
+    { timeout: 5000 },
+  );
+};
+
+test.describe("issue #160 — keyboard shortcuts", () => {
+  test("Scenario 1: `?` opens the help modal", async ({ page }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.keyboard.press("Shift+?");
+    const dialog = page.getByTestId("shortcut-help");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("role", "dialog");
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    // Close button has initial focus per the AC.
+    await expect(page.getByTestId("shortcut-help-close")).toBeFocused();
+  });
+
+  test("Scenario 2: Esc closes the modal", async ({ page }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.keyboard.press("Shift+?");
+    await expect(page.getByTestId("shortcut-help")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("shortcut-help")).toHaveCount(0);
+  });
+
+  test("Scenario 3: `/` focuses the search bar on the homepage", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    // Blur any auto-focus target so the / keystroke doesn't
+    // race an existing text field.
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("/");
+    // The SearchBar from #117 renders an input[name=q] /
+    // type=search. Either selector should match.
+    const search = page.locator(
+      'input[type="search"], [role="searchbox"], input[name="q"]',
+    );
+    await expect(search.first()).toBeFocused();
+  });
+
+  test("Scenario 4: `g h` navigates to home", async ({ page }) => {
+    await page.goto(`${WEB_URL}/login`);
+    await waitForShortcutsReady(page);
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("g");
+    await page.keyboard.press("h");
+    await page.waitForURL(`${WEB_URL}/`);
+    expect(page.url()).toBe(`${WEB_URL}/`);
+  });
+
+  test("Scenario 5: `n` opens the editor when anon — routes to /login?redirect", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && typeof el.blur === "function") el.blur();
+    });
+    await page.keyboard.press("n");
+    await page.waitForURL(/\/login\?redirect=/);
+    expect(page.url()).toContain("login");
+    expect(page.url()).toContain("redirect");
+  });
+
+  test("Scenario 6: shortcuts don't fire inside form fields", async ({
+    page,
+  }) => {
+    await page.goto(`${WEB_URL}/login`);
+    await waitForShortcutsReady(page);
+    // Focus the email input so typing `?` is text, not
+    // the modal trigger.
+    const emailInput = page.locator('input[type="email"]');
+    await emailInput.focus();
+    await page.keyboard.type("hi?");
+    // Help modal must NOT be open.
+    await expect(page.getByTestId("shortcut-help")).toHaveCount(0);
+    // The `?` made it into the field.
+    await expect(emailInput).toHaveValue("hi?");
+  });
+
+  test("Scenario 7: footer link opens the modal", async ({ page }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.getByTestId("shortcut-help-trigger").click();
+    await expect(page.getByTestId("shortcut-help")).toBeVisible();
+  });
+
+  test("Scenario 8: axe a11y gate on the help modal", async ({ page }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.keyboard.press("Shift+?");
+    await expect(page.getByTestId("shortcut-help")).toBeVisible();
+    await runAxe(page);
+  });
+
+  test("Scenario 9: Tab cycles within the modal", async ({ page }) => {
+    await page.goto(`${WEB_URL}/`);
+    await waitForShortcutsReady(page);
+    await page.keyboard.press("Shift+?");
+    const dialog = page.getByTestId("shortcut-help");
+    await expect(dialog).toBeVisible();
+    // Initial focus is on Close. Tab once — with only the Close
+    // button inside, Tab should wrap back to itself. Press Tab
+    // then confirm focus is still on Close.
+    await page.keyboard.press("Tab");
+    await expect(page.getByTestId("shortcut-help-close")).toBeFocused();
+  });
+});


### PR DESCRIPTION
[generator @ gen-69f238ac]

Closes #160

## User Intent

Power users now drive Conduit from the keyboard: `?` opens a help modal listing every shortcut, `/` focuses the SearchBar, `g h` / `g p` navigate to home / profile, `n` opens the editor, `Esc` closes the modal. Every productivity-oriented platform (GitHub, Linear, Notion, Hacker News) ships this — Conduit now does too, fully screen-reader accessible with a documented modal + focus trap.

## Summary

- **`apps/web/src/components/KeyboardShortcutProvider.tsx`** — mounts once in `layout.tsx`, owns the global `keydown` listener + sequence-state machine. Multi-key sequences use a 1s timeout ref. Exposes `useShortcutContext()` for children that want programmatic open / close (the footer link). Reads `conduit-user` cookie for viewer detection; accepts both bare-username and JSON-shape cookies. A ready-marker (`document.body.dataset.shortcutsReady`) lets e2e tests await listener attachment instead of racing hydration.
- **`apps/web/src/components/KeyboardShortcutHelp.tsx`** — the modal. `role="dialog"`, `aria-modal="true"`, `aria-labelledby`. Internal focus trap (Tab/Shift+Tab cycle within dialog). `requestAnimationFrame`-deferred initial focus on Close. Backdrop click + Esc + Close button all dismiss.
- **`apps/web/src/components/KeyboardShortcutFooterLink.tsx`** — bare-button trigger in the footer for mouse-first discovery.
- **`apps/web/src/app/layout.tsx`** — wraps children in the provider, mounts the help modal at the body level.
- **`apps/web/src/app/globals.css`** — modal + trigger styles (scrim, dialog card, `<kbd>` chips, footer button).
- **`tests/e2e/specs/160-web-keyboard-shortcuts.spec.ts`** — 9 BDD scenarios.
- **`docs/keyboard-shortcuts.md`** — contributor reference for adding new shortcuts.

## Input-field guard

The single most important UX rule: every shortcut first checks `isTextInputFocused(event.target)`. If the focused element is an `<input>`, `<textarea>`, `<select>`, or `[contenteditable]`, the shortcut does NOT fire. Typing `?` in an article body types a `?`. Typing `/` in the search bar types a `/`. Typing `n` in a profile-edit field types `n`. Verified by Scenario 6.

## Modifier reservation

`Ctrl` / `Cmd` / `Alt` / `Meta` + any key is passed through untouched. `Cmd+L`, `Ctrl+F`, `Cmd+R` etc. keep working.

## Evidence

**Spec 160 (Playwright) — 9/9 solo:**
```
✓ Scenario 1: `?` opens the help modal (404ms)
✓ Scenario 2: Esc closes the modal (388ms)
✓ Scenario 3: `/` focuses the search bar on the homepage (311ms)
✓ Scenario 4: `g h` navigates to home (368ms)
✓ Scenario 5: `n` opens the editor when anon — routes to /login?redirect (405ms)
✓ Scenario 6: shortcuts don't fire inside form fields (273ms)
✓ Scenario 7: footer link opens the modal (326ms)
✓ Scenario 8: axe a11y gate on the help modal (1.1s)
✓ Scenario 9: Tab cycles within the modal (319ms)
9 passed (5.1s)
```

**Full Playwright suite:** 236 passed, 15 skipped, 5 solo-green (158/150/138/16 all green when re-run solo; #56 favorite-optimistic is the pre-existing parallel-seed flake documented across prior PRs).

**Typecheck + lint** clean.

**Manual verification:**
```
$ curl -s http://localhost:3100/ | grep -c shortcut-help
1
```
Open in browser → press `?` → help modal opens → press `Esc` → closes → focus returns to prior element. Press `/` → SearchBar focuses. Press `g` then `h` within 1s → navigates to `/`. Press `?` inside a textarea → the character types, modal does NOT open.

## Notes for review

- **Modal auto-close on navigation is deliberately NOT implemented.** React 19's combined `no-setState-in-effect` + `no-ref-access-during-render` rules made every naive variant fight two lints at once. Since the modal's content is navigation-invariant (same shortcuts on every page), leaving it open across transitions is a reasonable default. The user dismisses with Esc or Close. Documented in the provider source + in `docs/keyboard-shortcuts.md`.
- **Ready marker via `document.body.dataset`.** The provider sets `shortcutsReady="1"` in the same `useEffect` that attaches the listener, and the spec polls for it. Without this marker, `page.keyboard.press()` raced hydration — sometimes the listener wasn't bound yet, keystroke silently dropped. Same pattern we could apply to any future global-keydown-provider test.
- **Cookie shape polymorphism.** `readViewerUsername()` accepts both bare-username cookies (written by server actions) and JSON cookies (sometimes set client-side). The `try { JSON.parse(...) } catch` lets whichever shape is current just work.
- **Footer link is a `<button>` not an `<a>`.** It opens a dialog, not a navigation. Semantically correct; screen-readers announce "button" not "link".
- **Shortcuts are documented in `docs/keyboard-shortcuts.md`** with the full add-a-shortcut recipe (extend provider, add row to modal, add row to docs, add spec scenario).
